### PR TITLE
VIDCS-3248: Updating title does not re-run the CI job

### DIFF
--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -2,7 +2,7 @@ name: check-pull-request-title
 
 on:
   pull_request:
-    types: [assigned, edited, opened, synchronize, reopened]
+    types: [edited]
 
 jobs:
   run:

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -1,0 +1,38 @@
+name: check-pull-request-title
+
+on:
+  pull_request:
+    types: [assigned, edited, opened, synchronize, reopened]
+
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: [self-hosted]
+    steps:
+      - name: Validate PR title
+        run: |
+          set -e
+
+          pr_name="${{ github.event.pull_request.title }}"
+          echo "PR Title: '$pr_name'"
+
+          # Regex to check following:
+          # Starts with "VIDCS-" followed by digits
+          # A colon (:) followed by exactly one space
+          # followed by the actual PR title text
+          regex="^VIDCS-[0-9]+: [^ ].*$"
+
+          if [[ "$pr_name" =~ $regex ]]; then
+            echo "Acceptable title"
+            exit 0
+          else
+            echo "Rejected title"
+            echo "Reason: The PR title must start with 'VIDCS-' followed by digits, a colon (:), and exactly one space, with the rest of the title immediately after the space."
+            exit 1
+          fi
+        shell: bash

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -2,7 +2,7 @@ name: check-pull-request-title
 
 on:
   pull_request:
-    types: [edited]
+    types: [edited, opened]
 
 jobs:
   run:

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -4,12 +4,6 @@ on:
   pull_request:
     types: [assigned, edited, opened, synchronize, reopened]
 
-permissions:
-  contents: read
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   run:
     runs-on: [self-hosted]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,29 +41,6 @@ jobs:
         run: |
           yarn lint:filenames
 
-      - name: Validate PR title
-        run: |
-          set -e
-
-          pr_name="${{ github.event.pull_request.title }}"
-          echo "PR Title: '$pr_name'"
-
-          # Regex to check following:
-          # Starts with "VIDCS-" followed by digits
-          # A colon (:) followed by exactly one space
-          # followed by the actual PR title text
-          regex="^VIDCS-[0-9]+: [^ ].*$"
-
-          if [[ "$pr_name" =~ $regex ]]; then
-            echo "Acceptable title"
-            exit 0
-          else
-            echo "Rejected title"
-            echo "Reason: The PR title must start with 'VIDCS-' followed by digits, a colon (:), and exactly one space, with the rest of the title immediately after the space."
-            exit 1
-          fi
-        shell: bash
-
       - name: Run license check
         run: |
           npx license-checker --json > scripts/allLicenseResults.json


### PR DESCRIPTION
#### What is this PR doing?

This PR fixes the issue where updating the incorrect title does not re-trigger the job unless a new commit is pushed up or the PR is closed/reopened.

I moved out the job to check the PR title out of lint job to its own job since we do not want to trigger all of the lint to re-run if the PR title is changed.

#### How should this be manually tested?

Checkout this branch.
Create a new branch from this branch and make a small change to, for example, README.md.
Make a new pull request with your newly created branch with a PR title that would not satisfy the conditions. 
Notice that `check-pull-request-title` job fails.
Change the PR title to the correct format such as `VIDCS-3248: testing the pull request`
Notice that after some seconds the `check-pull-request-title` job runs and passes.

#### What are the relevant tickets?

Resolves [VIDCS-3248](https://jira.vonage.com/browse/VIDCS-3248)

[👎 ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[👎 ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?