### PR TITLE
VIDCS-3140: Resolve GitHub Mend warnings for VERA

### DIFF
--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [edited, opened]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: [self-hosted]
@@ -13,7 +16,7 @@ jobs:
           set -e
 
           pr_name="${{ github.event.pull_request.title }}"
-          echo "PR Title: '$pr_name'"
+          echo "PR Title: '${pr_name}'"
 
           # Regex to check following:
           # Starts with "VIDCS-" followed by digits


### PR DESCRIPTION
#### What is this PR doing?

This PR resolves the 2 issues mentioned in the `Issues` tab:

https://github.com/Vonage/vonage-video-react-app/issues/11

https://github.com/Vonage/vonage-video-react-app/issues/10

#### How should this be manually tested?

We need to make sure that with these changes the `check-pull-request-title.yml` job still runs; therefore, please follow the steps [described here](https://github.com/Vonage/vonage-video-react-app/pull/8) to make sure it still works. 

#### What are the relevant tickets?

Resolves [VIDCS-3140](https://jira.vonage.com/browse/VIDCS-3140)

[👎 ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[👍 ] Resolves an item reported in `Issues`.
If yes, which issue? 
* [Issue Number 11](https://github.com/Vonage/vonage-video-react-app/issues/11)
* [Issue Number 10](https://github.com/Vonage/vonage-video-react-app/issues/10)
[👍 ] If yes, did you close the item in `Issues`?