### PR TITLE
VIDCS-3223: Fix audio option crash in android chrome - disable speaker test on android

### DIFF
--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
@@ -81,4 +81,40 @@ describe('AudioInputOutputDevice Component', () => {
     const outputDevicesElement = screen.queryByTestId('output-devices');
     expect(outputDevicesElement).not.toBeInTheDocument();
   });
+
+  it('renders the speaker test if the browser supports audio output device selection', () => {
+    (util.isGetActiveAudioOutputDeviceSupported as Mock).mockReturnValue(true);
+
+    render(
+      <AudioOutputProvider>
+        <AudioInputOutputDevices
+          handleToggle={mockHandleToggle}
+          isOpen
+          anchorRef={mockAnchorRef}
+          handleClose={mockHandleClose}
+        />
+      </AudioOutputProvider>
+    );
+
+    const outputDevicesElement = screen.getByTestId('output-devices');
+    expect(outputDevicesElement).toBeInTheDocument();
+  });
+
+  it('does not render the speaker test devices if the browser does not support audio output device selection', () => {
+    (util.isGetActiveAudioOutputDeviceSupported as Mock).mockReturnValue(false);
+
+    render(
+      <AudioOutputProvider>
+        <AudioInputOutputDevices
+          handleToggle={mockHandleToggle}
+          isOpen
+          anchorRef={mockAnchorRef}
+          handleClose={mockHandleClose}
+        />
+      </AudioOutputProvider>
+    );
+
+    const soundTest = screen.queryByTestId('soundTest');
+    expect(soundTest).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
@@ -9,6 +9,7 @@ import ToggleOnIcon from '@mui/icons-material/ToggleOn';
 import usePublisherContext from '../../../../hooks/usePublisherContext';
 import DropdownSeparator from '../../DropdownSeparator';
 import SoundTest from '../../../SoundTest';
+import { isGetActiveAudioOutputDeviceSupported } from '../../../../utils/util';
 
 export type ReduceNoiseTestSpeakersProps = {
   customLightBlueColor: string;
@@ -84,9 +85,11 @@ const ReduceNoiseTestSpeakers = ({
             </IconButton>
           </MenuItem>
         )}
-        <SoundTest>
-          <VolumeUpIcon sx={{ fontSize: 24, mr: 2 }} />
-        </SoundTest>
+        {isGetActiveAudioOutputDeviceSupported() && (
+          <SoundTest>
+            <VolumeUpIcon sx={{ fontSize: 24, mr: 2 }} />
+          </SoundTest>
+        )}
       </MenuList>
     </>
   );

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -45,7 +45,9 @@ export const isGetActiveAudioOutputDeviceSupported = () => {
 
   const isFirefox = userAgent.includes('firefox');
 
-  return !isFirefox && !isWebKit();
+  const isAndroid = userAgent.includes('android');
+
+  return !isFirefox && !isWebKit() && !isAndroid;
 };
 
 /**


### PR DESCRIPTION
#### What is this PR doing?

- Removes sound test / speaker test option on android
- This fixes a bug where opening mic audio device settings crashed the app because it tried to use `setSinkId` which is not supported
```
index-s-hJiPSy.js:40 TypeError: i.setSinkId is not a function
index-s-hJiPSy.js:1954 Uncaught TypeError: i.setSinkId is not a function
index-s-hJiPSy.js:620 OpenTok:NativeVideoElementWrapper:2:warn Video element paused, auto-resuming. If you intended to do this, use publishVideo(false) or subscribeToVideo(false) instead. +0ms
index-s-hJiPSy.js:1954 Uncaught (in promise) 
p {code: undefined, message: 'setAudioOutputDevice is not supported in your browser.', name: 'OT_UNSUPPORTED_BROWSER', stack: 'Error: setAudioOutputDevice is not supported in yo…/localhost:3345/assets/index-s-hJiPSy.js:81:7215)'}
```

#### How should this be manually tested?
STR and STVerify fix
- open the app on android chrome
- join a room
- click the mic options button
- observe crash

#### What are the relevant tickets?

Resolves [VIDCS-3223](https://jira.vonage.com/browse/VIDCS-3223)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?