### PR TITLE
VIDCS-3247: Stop VERA instance being indexed

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -20,6 +20,7 @@ app.set('trust proxy', true);
 app.use(router);
 
 app.use((req, res, next) => {
+  // This is needed to remove the deployed application from being indexed by Search engines
   res.setHeader('X-Robots-Tag', 'noindex, nofollow');
   next();
 });

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -19,6 +19,11 @@ app.use(bodyParser.json());
 app.set('trust proxy', true);
 app.use(router);
 
+app.use((req, res, next) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+  next();
+});
+
 app.use(express.static(path.join(dirName, './dist')));
 
 app.get('/*', (_req: Request, res: Response) => {


### PR DESCRIPTION
#### What is this PR doing?

This PR adds an instruction to our express server to not be indexed by the search engines. 

#### How should this be manually tested?

Checkout this branch locally.
Run the backend by doing `yarn start:backend`
Run `curl -I http://localhost:3345`
Make sure the following tag is present: 
```
X-Robots-Tag: noindex, nofollow
```

#### What are the relevant tickets?

Resolves [VIDCS-3247](https://jira.vonage.com/browse/VIDCS-3247)

[👎 ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[👎 ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?