### PR TITLE
VIDCS-3273: Fix audio output selection crash in android Waiting Room

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.17.1",
-    "@types/react": "^18.0.28",
+    "@types/react": "^18.3.3",
     "@types/react-dom": "^18.2.1",
     "@types/react-router-dom": "^5.3.3",
     "@types/uuid": "^9.0.8",

--- a/frontend/src/Context/AudioOutputProvider/useAudioOutput/useAudioOutput.spec.tsx
+++ b/frontend/src/Context/AudioOutputProvider/useAudioOutput/useAudioOutput.spec.tsx
@@ -3,16 +3,30 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { AudioOutputDevice } from '@vonage/client-sdk-video';
 import * as OT from '@vonage/client-sdk-video';
 import useAudioOutput from './useAudioOutput';
+import { nativeDevices } from '../../../utils/mockData/device';
 
 vi.mock('@vonage/client-sdk-video');
 
 describe('useAudioOutput', () => {
+  const nativeMediaDevices = global.navigator.mediaDevices;
   let mockGetActiveAudioOutputDevice: MockInstance<[], Promise<AudioOutputDevice>>;
   let mockSetAudioOutputDevice: MockInstance<[deviceId: string], Promise<void>>;
 
   beforeEach(() => {
     vi.resetAllMocks();
-
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      writable: true,
+      value: {
+        enumerateDevices: vi.fn(
+          () =>
+            new Promise<MediaDeviceInfo[]>((res) => {
+              res(nativeDevices as MediaDeviceInfo[]);
+            })
+        ),
+        addEventListener: vi.fn(() => []),
+        removeEventListener: vi.fn(() => []),
+      },
+    });
     mockGetActiveAudioOutputDevice = vi.spyOn(OT, 'getActiveAudioOutputDevice').mockImplementation(
       () =>
         new Promise<AudioOutputDevice>((res) => {
@@ -32,42 +46,46 @@ describe('useAudioOutput', () => {
 
   afterAll(() => {
     vi.restoreAllMocks();
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      writable: true,
+      value: nativeMediaDevices,
+    });
   });
 
   it('should provide initial state', () => {
     const { result } = renderHook(() => useAudioOutput());
 
-    expect(result.current.audioOutput).toBeUndefined();
-    expect(result.current.setAudioOutput).toBeDefined();
+    expect(result.current.currentAudioOutputDevice).toBeUndefined();
+    expect(result.current.setAudioOutputDevice).toBeDefined();
   });
 
   it('should call getActiveAudioOutputDevice when initialized', async () => {
     const { result } = renderHook(() => useAudioOutput());
 
-    await waitFor(() => expect(result.current.audioOutput).toBe('some-device-id'));
+    await waitFor(() => expect(result.current.currentAudioOutputDevice).toBe('some-device-id'));
 
     expect(mockGetActiveAudioOutputDevice).toHaveBeenCalledOnce();
   });
 
-  it('should update audioOutput when setAudioOutput is called', async () => {
+  it('should update currentAudioOutputDevice when setAudioOutputDevice is called', async () => {
     const newAudioOutput = 'new-audio-output-device';
     const { result, rerender } = renderHook(() => useAudioOutput());
 
     await act(async () => {
-      await result.current.setAudioOutput(newAudioOutput);
+      await result.current.setAudioOutputDevice(newAudioOutput);
     });
 
     rerender();
 
-    expect(result.current.audioOutput).toBe(newAudioOutput);
+    expect(result.current.currentAudioOutputDevice).toBe(newAudioOutput);
   });
 
-  it('should call setAudioOutputDevice when audioOutput is called', async () => {
+  it('should call setAudioOutputDevice when currentAudioOutputDevice is called', async () => {
     const newAudioOutput = 'new-audio-output-device';
     const { result } = renderHook(() => useAudioOutput());
 
     await act(async () => {
-      await result.current.setAudioOutput(newAudioOutput);
+      await result.current.setAudioOutputDevice(newAudioOutput);
     });
 
     expect(mockSetAudioOutputDevice).toHaveBeenCalledOnce();

--- a/frontend/src/Context/AudioOutputProvider/useAudioOutput/useAudioOutput.tsx
+++ b/frontend/src/Context/AudioOutputProvider/useAudioOutput/useAudioOutput.tsx
@@ -1,11 +1,14 @@
-import { getActiveAudioOutputDevice, setAudioOutputDevice } from '@vonage/client-sdk-video';
+import {
+  getActiveAudioOutputDevice as getVonageActiveAudioOutputDevice,
+  setAudioOutputDevice as setVonageAudioOutputDevice,
+} from '@vonage/client-sdk-video';
 import { useCallback, useEffect, useState } from 'react';
 
 export type AudioDeviceId = string | null | undefined;
 
 export type AudioOutputContextType = {
-  audioOutput: string | undefined | null;
-  setAudioOutput: (deviceId: AudioDeviceId) => Promise<void>;
+  currentAudioOutputDevice: string | undefined | null;
+  setAudioOutputDevice: (deviceId: AudioDeviceId) => Promise<void>;
 };
 
 /**
@@ -15,26 +18,41 @@ export type AudioOutputContextType = {
  * @returns {AudioOutputContextType} audioOutput context
  */
 const useAudioOutput = (): AudioOutputContextType => {
-  const [audioOutput, setAudioOutput] = useState<AudioDeviceId>();
+  const [currentAudioOutputDevice, setCurrentAudioOutputDevice] = useState<AudioDeviceId>();
+  const { mediaDevices } = window.navigator;
 
-  useEffect(() => {
-    getActiveAudioOutputDevice().then((audioOutputDevice) => {
+  const updateCurrentAudioOutputDevice = useCallback(() => {
+    getVonageActiveAudioOutputDevice().then((audioOutputDevice) => {
       if (audioOutputDevice.deviceId) {
-        setAudioOutput(audioOutputDevice.deviceId);
+        setCurrentAudioOutputDevice(audioOutputDevice.deviceId);
       }
     });
   }, []);
 
-  const updateAudioOutput = useCallback(async (deviceId: AudioDeviceId) => {
+  useEffect(() => {
+    updateCurrentAudioOutputDevice();
+  }, [updateCurrentAudioOutputDevice]);
+
+  useEffect(() => {
+    // Add an event listener to update device list when the list changes (such as plugging or unplugging a device)
+    mediaDevices.addEventListener('devicechange', updateCurrentAudioOutputDevice);
+
+    return () => {
+      // Remove the event listener when component unmounts
+      mediaDevices.removeEventListener('devicechange', updateCurrentAudioOutputDevice);
+    };
+  }, [mediaDevices, updateCurrentAudioOutputDevice]);
+
+  const setAudioOutputDevice = useCallback(async (deviceId: AudioDeviceId) => {
     if (deviceId) {
-      await setAudioOutputDevice(deviceId);
-      setAudioOutput(deviceId);
+      await setVonageAudioOutputDevice(deviceId);
+      setCurrentAudioOutputDevice(deviceId);
     }
   }, []);
 
   return {
-    audioOutput,
-    setAudioOutput: updateAudioOutput,
+    currentAudioOutputDevice,
+    setAudioOutputDevice,
   };
 };
 

--- a/frontend/src/Context/AudioOutputProvider/useAudioOutput/useAudioOutput.tsx
+++ b/frontend/src/Context/AudioOutputProvider/useAudioOutput/useAudioOutput.tsx
@@ -18,7 +18,9 @@ const useAudioOutput = (): AudioOutputContextType => {
   const [audioOutput, setAudioOutput] = useState<AudioDeviceId>();
 
   useEffect(() => {
+    debugger;
     getActiveAudioOutputDevice().then((audioOutputDevice) => {
+      debugger;
       if (audioOutputDevice.deviceId) {
         setAudioOutput(audioOutputDevice.deviceId);
       }

--- a/frontend/src/Context/AudioOutputProvider/useAudioOutput/useAudioOutput.tsx
+++ b/frontend/src/Context/AudioOutputProvider/useAudioOutput/useAudioOutput.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
 import { getActiveAudioOutputDevice, setAudioOutputDevice } from '@vonage/client-sdk-video';
+import { useCallback, useEffect, useState } from 'react';
 
 export type AudioDeviceId = string | null | undefined;
 
@@ -18,9 +18,7 @@ const useAudioOutput = (): AudioOutputContextType => {
   const [audioOutput, setAudioOutput] = useState<AudioDeviceId>();
 
   useEffect(() => {
-    debugger;
     getActiveAudioOutputDevice().then((audioOutputDevice) => {
-      debugger;
       if (audioOutputDevice.deviceId) {
         setAudioOutput(audioOutputDevice.deviceId);
       }

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
@@ -152,7 +152,7 @@ describe('AudioInputOutputDevice Component', () => {
     expect(outputDevicesElement).toBeInTheDocument();
   });
 
-  it('does not render the speaker test devices if the browser does not support audio output device selection', () => {
+  it('renders the speaker test devices if the browser does not support audio output device selection', () => {
     (util.isGetActiveAudioOutputDeviceSupported as Mock).mockReturnValue(false);
 
     render(

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
@@ -101,9 +101,8 @@ describe('AudioInputOutputDevice Component', () => {
 
     const outputDevicesElement = screen.getByTestId('output-devices');
     await waitFor(() => expect(outputDevicesElement.children).to.have.length(3));
-    const firstChild = outputDevicesElement.firstChild as HTMLOptionElement;
     expect(outputDevicesElement.firstChild).toHaveTextContent('System Default');
-    expect(firstChild.selected).toBe(true);
+    expect((outputDevicesElement.firstChild as HTMLOptionElement).selected).toBe(true);
     expect(outputDevicesElement.children[1]).toHaveTextContent('Soundcore Life A2 NC (Bluetooth)');
     expect(outputDevicesElement.children[2]).toHaveTextContent('MacBook Pro Speakers (Built-in)');
 
@@ -197,9 +196,8 @@ describe('AudioInputOutputDevice Component', () => {
 
     // Check initial list is correct
     await waitFor(() => expect(outputDevicesElement.children).to.have.length(3));
-    const firstChild = outputDevicesElement.firstChild as HTMLOptionElement;
     expect(outputDevicesElement.firstChild).toHaveTextContent('System Default');
-    expect(firstChild.selected).toBe(true);
+    expect((outputDevicesElement.firstChild as HTMLOptionElement).selected).toBe(true);
     expect(outputDevicesElement.children[1]).toHaveTextContent('Soundcore Life A2 NC (Bluetooth)');
     expect(outputDevicesElement.children[2]).toHaveTextContent('MacBook Pro Speakers (Built-in)');
 
@@ -215,7 +213,7 @@ describe('AudioInputOutputDevice Component', () => {
     await act(() => deviceChangeListener.emit('devicechange'));
     await waitFor(() => expect(outputDevicesElement.children).to.have.length(2));
     expect(outputDevicesElement.firstChild).toHaveTextContent('System Default');
-    expect(firstChild.selected).toBe(true);
+    expect((outputDevicesElement.firstChild as HTMLOptionElement).selected).toBe(true);
     expect(outputDevicesElement.children[1]).toHaveTextContent('MacBook Pro Speakers (Built-in)');
     const removedDevice = queryByText(outputDevicesElement, 'Soundcore Life A2 NC (Bluetooth)');
     expect(removedDevice).not.toBeInTheDocument();

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
@@ -43,7 +43,7 @@ vi.mock('../../../utils/util', async () => {
 });
 
 // This is returned by Vonage SDK if audioOutput is not supported
-// const vonageDefaultEmptyOutputDevice = { deviceId: null, label: null };
+const vonageDefaultEmptyOutputDevice = { deviceId: null, label: null };
 
 describe('AudioInputOutputDevice Component', () => {
   const nativeMediaDevices = global.navigator.mediaDevices;
@@ -54,6 +54,7 @@ describe('AudioInputOutputDevice Component', () => {
   const mockHandleClose = vi.fn();
 
   beforeEach(() => {
+    vi.resetAllMocks();
     mockGetDevices.mockImplementation((cb) =>
       cb(null, [...audioInputDevices, ...videoInputDevices])
     );
@@ -111,7 +112,7 @@ describe('AudioInputOutputDevice Component', () => {
 
   it('renders the default output device if the browser does not support setting audioOutput device', async () => {
     (util.isGetActiveAudioOutputDeviceSupported as Mock).mockReturnValue(false);
-    mockGetAudioOutputDevices.mockResolvedValue([]);
+    mockGetAudioOutputDevices.mockResolvedValue([vonageDefaultEmptyOutputDevice]);
     render(
       <AudioOutputProvider>
         <AudioInputOutputDevices
@@ -134,39 +135,44 @@ describe('AudioInputOutputDevice Component', () => {
     await expect((outputDevicesElement.firstChild as HTMLOptionElement).selected).toBe(true);
   });
 
-  it('renders the speaker test if the browser supports audio output device selection', () => {
+  it('renders the speaker test if the browser supports audio output device selection', async () => {
     (util.isGetActiveAudioOutputDeviceSupported as Mock).mockReturnValue(true);
 
-    render(
-      <AudioOutputProvider>
-        <AudioInputOutputDevices
-          handleToggle={mockHandleToggle}
-          isOpen
-          anchorRef={mockAnchorRef}
-          handleClose={mockHandleClose}
-        />
-      </AudioOutputProvider>
+    await act(() =>
+      render(
+        <AudioOutputProvider>
+          <AudioInputOutputDevices
+            handleToggle={mockHandleToggle}
+            isOpen
+            anchorRef={mockAnchorRef}
+            handleClose={mockHandleClose}
+          />
+        </AudioOutputProvider>
+      )
     );
 
     const outputDevicesElement = screen.getByTestId('output-devices');
     expect(outputDevicesElement).toBeInTheDocument();
   });
 
-  it('renders the speaker test devices if the browser does not support audio output device selection', () => {
+  it('renders the speaker test devices if the browser does not support audio output device selection', async () => {
     (util.isGetActiveAudioOutputDeviceSupported as Mock).mockReturnValue(false);
+    mockGetAudioOutputDevices.mockResolvedValue([vonageDefaultEmptyOutputDevice]);
 
-    render(
-      <AudioOutputProvider>
-        <AudioInputOutputDevices
-          handleToggle={mockHandleToggle}
-          isOpen
-          anchorRef={mockAnchorRef}
-          handleClose={mockHandleClose}
-        />
-      </AudioOutputProvider>
+    await act(() =>
+      render(
+        <AudioOutputProvider>
+          <AudioInputOutputDevices
+            handleToggle={mockHandleToggle}
+            isOpen
+            anchorRef={mockAnchorRef}
+            handleClose={mockHandleClose}
+          />
+        </AudioOutputProvider>
+      )
     );
 
     const soundTest = screen.queryByTestId('soundTest');
-    expect(soundTest).not.toBeInTheDocument();
+    expect(soundTest).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
@@ -124,10 +124,14 @@ describe('AudioInputOutputDevice Component', () => {
     );
 
     const outputDevicesElement = screen.getByTestId('output-devices');
-    await waitFor(() => expect(outputDevicesElement.children).to.have.length(3));
+    await waitFor(() => expect(outputDevicesElement.children).to.have.length(1));
     expect(outputDevicesElement.firstChild).toHaveTextContent('System Default');
-    expect(outputDevicesElement.children[1]).toHaveTextContent('Soundcore Life A2 NC (Bluetooth)');
-    expect(outputDevicesElement.children[2]).toHaveTextContent('MacBook Pro Speakers (Built-in)');
+    expect((outputDevicesElement.firstChild as HTMLOptionElement).selected).toBe(true);
+
+    await act(() => (outputDevicesElement.firstChild as HTMLOptionElement).click?.());
+
+    expect(mockSetAudioOutputDevice).not.toHaveBeenCalled();
+    await expect((outputDevicesElement.firstChild as HTMLOptionElement).selected).toBe(true);
   });
 
   it('renders the speaker test if the browser supports audio output device selection', () => {

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { describe, beforeEach, it, Mock, vi, expect, afterAll } from 'vitest';
 import { MutableRefObject } from 'react';
 import * as util from '../../../utils/util';
@@ -81,7 +81,7 @@ describe('AudioInputOutputDevice Component', () => {
     });
   });
 
-  it('renders the output devices if the browser supports it', async () => {
+  it('renders the output devices if the browser supports setting audioOutput device', async () => {
     (util.isGetActiveAudioOutputDeviceSupported as Mock).mockReturnValue(true);
 
     render(
@@ -102,9 +102,14 @@ describe('AudioInputOutputDevice Component', () => {
     expect(firstChild.selected).toBe(true);
     expect(outputDevicesElement.children[1]).toHaveTextContent('Soundcore Life A2 NC (Bluetooth)');
     expect(outputDevicesElement.children[2]).toHaveTextContent('MacBook Pro Speakers (Built-in)');
+
+    await act(() => (outputDevicesElement.children[2] as HTMLOptionElement).click?.());
+
+    expect(mockSetAudioOutputDevice).toHaveBeenCalledWith(audioOutputDevices[2].deviceId);
+    await expect((outputDevicesElement.children[2] as HTMLOptionElement).selected).toBe(true);
   });
 
-  it('does not render the output devices if the browser does not support it', async () => {
+  it('renders the default output device if the browser does not support setting audioOutput device', async () => {
     (util.isGetActiveAudioOutputDeviceSupported as Mock).mockReturnValue(false);
     mockGetAudioOutputDevices.mockResolvedValue([]);
     render(

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevice.spec.tsx
@@ -1,6 +1,7 @@
-import { act, fireEvent, queryByText, render, screen, waitFor } from '@testing-library/react';
+import { act, queryByText, render, screen, waitFor } from '@testing-library/react';
 import { describe, beforeEach, it, Mock, vi, expect, afterAll } from 'vitest';
 import { MutableRefObject } from 'react';
+import { EventEmitter } from 'stream';
 import * as util from '../../../utils/util';
 import AudioInputOutputDevices from './AudioInputOutputDevices';
 import { AudioOutputProvider } from '../../../Context/AudioOutputProvider';
@@ -10,7 +11,6 @@ import {
   nativeDevices,
   videoInputDevices,
 } from '../../../utils/mockData/device';
-import { EventEmitter } from 'stream';
 
 const {
   mockHasMediaProcessorSupport,

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevices.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevices.tsx
@@ -78,7 +78,6 @@ const AudioInputOutputDevices = ({
                   customLightBlueColor={customLightBlueColor}
                 />
                 <OutputDevices
-                  data-testid="output-devices"
                   handleToggle={handleToggle}
                   customLightBlueColor={customLightBlueColor}
                 />

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevices.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/AudioInputOutputDevices.tsx
@@ -8,7 +8,6 @@ import { PopperChildrenProps } from '@mui/base';
 import InputDevices from './InputDevices';
 import OutputDevices from './OutputDevices';
 import ReduceNoiseTestSpeakers from './ReduceNoiseTestSpeakers';
-import { isGetActiveAudioOutputDeviceSupported } from '../../../utils/util';
 
 export type AudioInputOutputDevicesProps = {
   handleToggle: () => void;
@@ -78,13 +77,11 @@ const AudioInputOutputDevices = ({
                   handleToggle={handleToggle}
                   customLightBlueColor={customLightBlueColor}
                 />
-                {isGetActiveAudioOutputDeviceSupported() && (
-                  <OutputDevices
-                    data-testid="output-devices"
-                    handleToggle={handleToggle}
-                    customLightBlueColor={customLightBlueColor}
-                  />
-                )}
+                <OutputDevices
+                  data-testid="output-devices"
+                  handleToggle={handleToggle}
+                  customLightBlueColor={customLightBlueColor}
+                />
                 <ReduceNoiseTestSpeakers customLightBlueColor={customLightBlueColor} />
               </Paper>
             </ClickAwayListener>

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/InputDevices/InputDevices.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/InputDevices/InputDevices.tsx
@@ -2,7 +2,7 @@ import { Box, MenuItem, MenuList, Typography } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import { Device } from '@vonage/client-sdk-video';
 import MicNoneIcon from '@mui/icons-material/MicNone';
-import { useState, useEffect, MouseEvent as ReactMouseEvent, ReactElement } from 'react';
+import { MouseEvent as ReactMouseEvent, ReactElement } from 'react';
 import useDevices from '../../../../hooks/useDevices';
 import usePublisherContext from '../../../../hooks/usePublisherContext';
 
@@ -21,35 +21,23 @@ export type InputDevicesProps = {
  * @returns {ReactElement} - The InputDevices component.
  */
 const InputDevices = ({ handleToggle, customLightBlueColor }: InputDevicesProps): ReactElement => {
-  const { publisher, isPublishing } = usePublisherContext();
-  const [devicesAvailable, setDevicesAvailable] = useState<Device[] | null>(null);
-  const { allMediaDevices } = useDevices();
-  const [options, setOptions] = useState<string[]>([]);
+  const { publisher } = usePublisherContext();
+  const {
+    allMediaDevices: { audioInputDevices },
+  } = useDevices();
 
-  useEffect(() => {
-    setDevicesAvailable(allMediaDevices.audioInputDevices);
-  }, [publisher, allMediaDevices, devicesAvailable, isPublishing]);
-  const changeAudioSource = (deviceId: string) => {
-    publisher?.setAudioSource(deviceId);
-  };
-
-  useEffect(() => {
-    if (devicesAvailable) {
-      const audioDevicesAvailable: string[] = devicesAvailable.map((availableDevice: Device) => {
-        return availableDevice.label;
-      });
-      setOptions(audioDevicesAvailable);
-    }
-  }, [devicesAvailable]);
+  const options = audioInputDevices.map((availableDevice: Device) => {
+    return availableDevice.label;
+  });
 
   const handleChangeAudioSource = (event: ReactMouseEvent<HTMLLIElement>) => {
     const menuItem = event.target as HTMLLIElement;
     handleToggle();
-    const audioDeviceId = devicesAvailable?.find((device: Device) => {
+    const audioDeviceId = audioInputDevices?.find((device: Device) => {
       return device.label === menuItem.textContent;
     })?.deviceId;
     if (audioDeviceId) {
-      changeAudioSource(audioDeviceId);
+      publisher?.setAudioSource(audioDeviceId);
     }
   };
   return (

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
@@ -68,7 +68,7 @@ const OutputDevices = ({
       </Box>
       <MenuList data-testid="output-devices">
         {availableDevices?.map((device: AudioOutputDevice) => {
-          // If audio output device selection is not support we show the default device as selected
+          // If audio output device selection is not supported we show the default device as selected
           const isSelected =
             device.deviceId === currentAudioOutputDevice || availableDevices.length === 1;
           return (

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
@@ -41,7 +41,9 @@ const OutputDevices = ({
 
   useEffect(() => {
     const getActiveAudioOutputDeviceLabel = async () => {
+      debugger;
       const activeOutputDevice = await getActiveAudioOutputDevice();
+      debugger;
       setAudioOutput(activeOutputDevice.deviceId);
     };
     getActiveAudioOutputDeviceLabel();
@@ -75,9 +77,9 @@ const OutputDevices = ({
         }}
       >
         <VolumeUpIcon sx={{ fontSize: 24, mr: 2 }} />
-        <Typography data-testid="output-devices">Speakers</Typography>
+        <Typography data-testid="output-device-title">Speakers</Typography>
       </Box>
-      <MenuList>
+      <MenuList data-testid="output-devices">
         {devicesAvailable?.map((device: AudioOutputDevice) => {
           const isSelected = device.deviceId === audioOutput || devicesAvailable.length === 1;
           return (

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
@@ -1,8 +1,8 @@
 import { Box, MenuItem, MenuList, Typography } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
-import { AudioOutputDevice, setAudioOutputDevice } from '@vonage/client-sdk-video';
 import { MouseEvent, ReactElement } from 'react';
+import type { AudioOutputDevice } from '@vonage/client-sdk-video';
 import useDevices from '../../../../hooks/useDevices';
 import DropdownSeparator from '../../DropdownSeparator';
 import useAudioOutputContext from '../../../../hooks/useAudioOutputContext';
@@ -28,7 +28,7 @@ const OutputDevices = ({
   handleToggle,
   customLightBlueColor,
 }: OutputDevicesProps): ReactElement => {
-  const { audioOutput, setAudioOutput } = useAudioOutputContext();
+  const { currentAudioOutputDevice, setAudioOutputDevice } = useAudioOutputContext();
   const {
     allMediaDevices: { audioOutputDevices },
   } = useDevices();
@@ -48,7 +48,6 @@ const OutputDevices = ({
 
       if (deviceId) {
         await setAudioOutputDevice(deviceId);
-        setAudioOutput(deviceId);
       }
     }
   };
@@ -69,7 +68,8 @@ const OutputDevices = ({
       </Box>
       <MenuList data-testid="output-devices">
         {availableDevices?.map((device: AudioOutputDevice) => {
-          const isSelected = device.deviceId === audioOutput || availableDevices.length === 1;
+          const isSelected =
+            device.deviceId === currentAudioOutputDevice || availableDevices.length === 1;
           return (
             <MenuItem
               key={device.deviceId}

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
@@ -68,6 +68,7 @@ const OutputDevices = ({
       </Box>
       <MenuList data-testid="output-devices">
         {availableDevices?.map((device: AudioOutputDevice) => {
+          // If audio output device selection is not support we show the default device as selected
           const isSelected =
             device.deviceId === currentAudioOutputDevice || availableDevices.length === 1;
           return (

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
@@ -1,12 +1,8 @@
 import { Box, MenuItem, MenuList, Typography } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
-import {
-  AudioOutputDevice,
-  setAudioOutputDevice,
-  getActiveAudioOutputDevice,
-} from '@vonage/client-sdk-video';
-import { MouseEvent, ReactElement, useEffect } from 'react';
+import { AudioOutputDevice, setAudioOutputDevice } from '@vonage/client-sdk-video';
+import { MouseEvent, ReactElement } from 'react';
 import useDevices from '../../../../hooks/useDevices';
 import DropdownSeparator from '../../DropdownSeparator';
 import useAudioOutputContext from '../../../../hooks/useAudioOutputContext';
@@ -38,16 +34,6 @@ const OutputDevices = ({
   } = useDevices();
   const devicesAvailable =
     audioOutputDevices.length > 0 ? audioOutputDevices : defaultOutputDevices;
-
-  useEffect(() => {
-    const getActiveAudioOutputDeviceLabel = async () => {
-      debugger;
-      const activeOutputDevice = await getActiveAudioOutputDevice();
-      debugger;
-      setAudioOutput(activeOutputDevice.deviceId);
-    };
-    getActiveAudioOutputDeviceLabel();
-  }, [setAudioOutput]);
 
   const handleChangeAudioOutput = async (event: MouseEvent<HTMLLIElement>) => {
     const menuItem = event.target as HTMLLIElement;

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/OutputDevices/OutputDevices.tsx
@@ -32,15 +32,17 @@ const OutputDevices = ({
   const {
     allMediaDevices: { audioOutputDevices },
   } = useDevices();
-  const devicesAvailable =
-    audioOutputDevices.length > 0 ? audioOutputDevices : defaultOutputDevices;
+
+  const isAudioOutputSupported = isGetActiveAudioOutputDeviceSupported();
+
+  const availableDevices = isAudioOutputSupported ? audioOutputDevices : defaultOutputDevices;
 
   const handleChangeAudioOutput = async (event: MouseEvent<HTMLLIElement>) => {
     const menuItem = event.target as HTMLLIElement;
     handleToggle();
 
-    if (isGetActiveAudioOutputDeviceSupported()) {
-      const deviceId = devicesAvailable?.find((device: AudioOutputDevice) => {
+    if (isAudioOutputSupported) {
+      const deviceId = availableDevices?.find((device: AudioOutputDevice) => {
         return device.label === menuItem.textContent;
       })?.deviceId;
 
@@ -66,8 +68,8 @@ const OutputDevices = ({
         <Typography data-testid="output-device-title">Speakers</Typography>
       </Box>
       <MenuList data-testid="output-devices">
-        {devicesAvailable?.map((device: AudioOutputDevice) => {
-          const isSelected = device.deviceId === audioOutput || devicesAvailable.length === 1;
+        {availableDevices?.map((device: AudioOutputDevice) => {
+          const isSelected = device.deviceId === audioOutput || availableDevices.length === 1;
           return (
             <MenuItem
               key={device.deviceId}

--- a/frontend/src/components/MeetingRoom/AudioInputOutputDevices/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
+++ b/frontend/src/components/MeetingRoom/AudioInputOutputDevices/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
@@ -9,7 +9,6 @@ import ToggleOnIcon from '@mui/icons-material/ToggleOn';
 import usePublisherContext from '../../../../hooks/usePublisherContext';
 import DropdownSeparator from '../../DropdownSeparator';
 import SoundTest from '../../../SoundTest';
-import { isGetActiveAudioOutputDeviceSupported } from '../../../../utils/util';
 
 export type ReduceNoiseTestSpeakersProps = {
   customLightBlueColor: string;
@@ -85,11 +84,9 @@ const ReduceNoiseTestSpeakers = ({
             </IconButton>
           </MenuItem>
         )}
-        {isGetActiveAudioOutputDeviceSupported() && (
-          <SoundTest>
-            <VolumeUpIcon sx={{ fontSize: 24, mr: 2 }} />
-          </SoundTest>
-        )}
+        <SoundTest>
+          <VolumeUpIcon sx={{ fontSize: 24, mr: 2 }} />
+        </SoundTest>
       </MenuList>
     </>
   );

--- a/frontend/src/components/SoundTest/SoundTest.spec.tsx
+++ b/frontend/src/components/SoundTest/SoundTest.spec.tsx
@@ -4,11 +4,13 @@ import SportsFootballIcon from '@mui/icons-material/SportsFootball';
 import SoundTest from './SoundTest';
 import useAudioOutputContext from '../../hooks/useAudioOutputContext';
 import { AudioOutputContextType, AudioOutputProvider } from '../../Context/AudioOutputProvider';
+import { nativeDevices } from '../../utils/mockData/device';
 
 vi.mock('../../hooks/useAudioOutputContext');
 const mockUseAudioOutputContext = useAudioOutputContext as Mock<[], AudioOutputContextType>;
 
 describe('SoundTest', () => {
+  const nativeMediaDevices = global.navigator.mediaDevices;
   const nativeAudio = global.Audio;
   let audioOutputContext: AudioOutputContextType;
   const playMock = vi.fn();
@@ -16,7 +18,19 @@ describe('SoundTest', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      writable: true,
+      value: {
+        enumerateDevices: vi.fn(
+          () =>
+            new Promise<MediaDeviceInfo[]>((res) => {
+              res(nativeDevices as MediaDeviceInfo[]);
+            })
+        ),
+        addEventListener: vi.fn(() => []),
+        removeEventListener: vi.fn(() => []),
+      },
+    });
     global.Audio = vi.fn().mockImplementation(() => ({
       play: playMock,
       pause: pauseMock,
@@ -35,6 +49,10 @@ describe('SoundTest', () => {
 
   afterAll(() => {
     global.Audio = nativeAudio;
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      writable: true,
+      value: nativeMediaDevices,
+    });
   });
 
   it('renders', () => {

--- a/frontend/src/components/SoundTest/SoundTest.spec.tsx
+++ b/frontend/src/components/SoundTest/SoundTest.spec.tsx
@@ -110,4 +110,28 @@ describe('SoundTest', () => {
     const displayedText = screen.getByText('Stop testing');
     expect(displayedText).toBeInTheDocument();
   });
+
+  it('does not throw if setSinkId is undefined', () => {
+    global.Audio = vi.fn().mockImplementation(() => ({
+      play: playMock,
+      pause: pauseMock,
+      currentTime: 9001,
+      setSinkId: vi.fn(),
+    }));
+    render(
+      <AudioOutputProvider>
+        <SoundTest>
+          <SportsFootballIcon />
+        </SoundTest>
+      </AudioOutputProvider>
+    );
+
+    const renderedSoundTest = screen.getByTestId('soundTest');
+    act(() => {
+      renderedSoundTest.click();
+    });
+
+    const displayedText = screen.getByText('Stop testing');
+    expect(displayedText).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/SoundTest/SoundTest.spec.tsx
+++ b/frontend/src/components/SoundTest/SoundTest.spec.tsx
@@ -134,7 +134,7 @@ describe('SoundTest', () => {
       play: playMock,
       pause: pauseMock,
       currentTime: 9001,
-      setSinkId: vi.fn(),
+      setSinkId: undefined,
     }));
     render(
       <AudioOutputProvider>

--- a/frontend/src/components/SoundTest/SoundTest.tsx
+++ b/frontend/src/components/SoundTest/SoundTest.tsx
@@ -16,26 +16,26 @@ export type SoundTestProps = {
  */
 const SoundTest = ({ children }: SoundTestProps): ReactElement => {
   const [audioIsPlaying, setAudioIsPlaying] = useState(false);
-  const audio = useMemo(() => new Audio('/sound.mp3'), []);
-  const { audioOutput } = useAudioOutputContext();
+  const audioElement = useMemo(() => new Audio('/sound.mp3'), []);
+  const { currentAudioOutputDevice } = useAudioOutputContext();
 
   useEffect(() => {
-    if (audioOutput) {
-      audio.setSinkId?.(audioOutput);
+    if (currentAudioOutputDevice) {
+      audioElement.setSinkId?.(currentAudioOutputDevice);
     }
-  }, [audio, audioOutput]);
+  }, [audioElement, currentAudioOutputDevice]);
 
   const handlePlayAudio = useCallback(() => {
     if (!audioIsPlaying) {
-      audio.play();
+      audioElement.play();
       setAudioIsPlaying(true);
     } else {
       // Stop playing the audio and reset the playback to the beginning of the track.
-      audio.pause();
-      audio.currentTime = 0;
+      audioElement.pause();
+      audioElement.currentTime = 0;
       setAudioIsPlaying(false);
     }
-  }, [audio, audioIsPlaying]);
+  }, [audioElement, audioIsPlaying]);
 
   return (
     <MenuItem onClick={handlePlayAudio} data-testid="soundTest">

--- a/frontend/src/components/SoundTest/SoundTest.tsx
+++ b/frontend/src/components/SoundTest/SoundTest.tsx
@@ -21,7 +21,7 @@ const SoundTest = ({ children }: SoundTestProps): ReactElement => {
 
   useEffect(() => {
     if (audioOutput) {
-      audio.setSinkId(audioOutput);
+      audio.setSinkId?.(audioOutput);
     }
   }, [audio, audioOutput]);
 

--- a/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
+++ b/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
@@ -9,6 +9,7 @@ import usePreviewPublisherContext from '../../../hooks/usePreviewPublisherContex
 import useDevices from '../../../hooks/useDevices';
 import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 import useAudioOutputContext from '../../../hooks/useAudioOutputContext';
+import { isGetActiveAudioOutputDeviceSupported } from '../../../utils/util';
 
 export type ControlPanelProps = {
   handleAudioInputOpen: (

--- a/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
+++ b/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
@@ -56,7 +56,7 @@ const ControlPanel = ({
   const { allMediaDevices } = useDevices();
   const { localAudioSource, localVideoSource, changeAudioSource, changeVideoSource } =
     usePreviewPublisherContext();
-  const { audioOutput, setAudioOutput } = useAudioOutputContext();
+  const { currentAudioOutputDevice, setAudioOutputDevice } = useAudioOutputContext();
 
   const buttonSx: SxProps = {
     borderRadius: '10px',
@@ -128,8 +128,8 @@ const ControlPanel = ({
           open={openAudioOutput}
           onClose={handleClose}
           anchorEl={anchorEl}
-          localSource={audioOutput}
-          deviceChangeHandler={setAudioOutput}
+          localSource={currentAudioOutputDevice}
+          deviceChangeHandler={setAudioOutputDevice}
           deviceType="audioOutput"
         />
       </div>

--- a/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
+++ b/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
@@ -9,7 +9,6 @@ import usePreviewPublisherContext from '../../../hooks/usePreviewPublisherContex
 import useDevices from '../../../hooks/useDevices';
 import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 import useAudioOutputContext from '../../../hooks/useAudioOutputContext';
-import { isGetActiveAudioOutputDeviceSupported } from '../../../utils/util';
 
 export type ControlPanelProps = {
   handleAudioInputOpen: (

--- a/frontend/src/hooks/useDevices.tsx
+++ b/frontend/src/hooks/useDevices.tsx
@@ -47,7 +47,6 @@ const useDevices = () => {
 
         // Vonage Video API's getAudioOutputDevices retrieves all audio output devices (speakers)
         let audioOutputDevices: AudioOutputDevice[] = await getAudioOutputDevices();
-
         // Rename the label of the default audio output to "System Default"
         audioOutputDevices = audioOutputDevices.map(renameDefaultAudioOutputDevice);
 

--- a/frontend/src/utils/mockData/device.ts
+++ b/frontend/src/utils/mockData/device.ts
@@ -1,3 +1,4 @@
+import { AudioOutputDevice, Device } from '@vonage/client-sdk-video';
 import { AllMediaDevices } from '../../types';
 
 /**
@@ -12,6 +13,48 @@ export const defaultAudioDevice = {
   kind: 'audioInput',
 };
 
+export const audioInputDevices: Device[] = [
+  {
+    deviceId: 'default',
+    label: 'Default - Soundcore Life A2 NC (Bluetooth)',
+    kind: 'audioInput',
+  },
+  {
+    deviceId: 'd59e9898546591e31374d2eb459566649abe47fd461625da72d0cf75f43dc36f',
+    label: 'Soundcore Life A2 NC (Bluetooth)',
+    kind: 'audioInput',
+  },
+  {
+    deviceId: '68f1d1e6f11c629b1febe51a95f8f740f8ac5cd3d4c91419bd2b52bb1a9a01cd',
+    label: 'MacBook Pro Microphone (Built-in)',
+    kind: 'audioInput',
+  },
+];
+
+export const videoInputDevices: Device[] = [
+  {
+    deviceId: 'a68ec4e4a6bc10dc572bd806414b0da27d0aefb0ad822f7ba4cf9b226bb9b7c2',
+    label: 'FaceTime HD Camera (2C0E:82E3)',
+    kind: 'videoInput',
+  },
+];
+
+export const audioOutputDevices: AudioOutputDevice[] = [
+  {
+    deviceId: 'default',
+    label: 'System Default',
+  },
+  {
+    deviceId: '9a2f0c5c9cf94d8bc34847f13ce863864d18ab9f969a73ffa9d15c8162829d68',
+    label: 'Soundcore Life A2 NC (Bluetooth)',
+  },
+  {
+    deviceId: '86e5a9ea93853f6cf7a39c93a0eb979ea9f9e5c97767268629a9ceafd668cdb7',
+    label: 'MacBook Pro Speakers (Built-in)',
+  },
+];
+
+export const nativeDevices = [...audioInputDevices, ...videoInputDevices, ...audioOutputDevices];
 /**
  * An object containing all available media devices.
  * @property {Array<object>} audioInputDevices - all available audio input devices.
@@ -19,44 +62,9 @@ export const defaultAudioDevice = {
  * @property {Array<object>} audioOutputDevices - all available audio output devices.
  */
 export const allMediaDevices: AllMediaDevices = {
-  audioInputDevices: [
-    {
-      deviceId: 'default',
-      label: 'Default - Soundcore Life A2 NC (Bluetooth)',
-      kind: 'audioInput',
-    },
-    {
-      deviceId: 'd59e9898546591e31374d2eb459566649abe47fd461625da72d0cf75f43dc36f',
-      label: 'Soundcore Life A2 NC (Bluetooth)',
-      kind: 'audioInput',
-    },
-    {
-      deviceId: '68f1d1e6f11c629b1febe51a95f8f740f8ac5cd3d4c91419bd2b52bb1a9a01cd',
-      label: 'MacBook Pro Microphone (Built-in)',
-      kind: 'audioInput',
-    },
-  ],
-  videoInputDevices: [
-    {
-      deviceId: 'a68ec4e4a6bc10dc572bd806414b0da27d0aefb0ad822f7ba4cf9b226bb9b7c2',
-      label: 'FaceTime HD Camera (2C0E:82E3)',
-      kind: 'videoInput',
-    },
-  ],
-  audioOutputDevices: [
-    {
-      deviceId: 'default',
-      label: 'System Default',
-    },
-    {
-      deviceId: '9a2f0c5c9cf94d8bc34847f13ce863864d18ab9f969a73ffa9d15c8162829d68',
-      label: 'Soundcore Life A2 NC (Bluetooth)',
-    },
-    {
-      deviceId: '86e5a9ea93853f6cf7a39c93a0eb979ea9f9e5c97767268629a9ceafd668cdb7',
-      label: 'MacBook Pro Speakers (Built-in)',
-    },
-  ],
+  audioInputDevices,
+  videoInputDevices,
+  audioOutputDevices,
 };
 
 export default allMediaDevices;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,10 +2085,18 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.28":
+"@types/react@*":
   version "18.3.3"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz"
   integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@18":
+  version "18.3.18"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.18.tgz#9b382c4cd32e13e463f97df07c2ee3bbcd26904b"
+  integrity sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -2643,7 +2651,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-styles@^6.0.0, ansi-styles@^6.2.1:
+ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -3413,7 +3421,7 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.5:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -6449,7 +6457,7 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^3.3.7, nanoid@^3.3.8:
+nanoid@^3.3.7:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
   integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
@@ -6837,7 +6845,7 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.12, path-to-regexp@^0.1.12:
+path-to-regexp@0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
@@ -7413,7 +7421,7 @@ roarr@^2.15.3:
     semver-compare "^1.0.0"
     sprintf-js "^1.1.2"
 
-rollup@^4.20.0, rollup@^4.22.4:
+rollup@^4.20.0:
   version "4.28.1"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.28.1.tgz#7718ba34d62b449dfc49adbfd2f312b4fe0df4de"
   integrity sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==
@@ -7831,7 +7839,7 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^5.1.2:
+string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -8532,7 +8540,7 @@ vite-node@1.6.0:
     picocolors "^1.0.0"
     vite "^5.0.0"
 
-vite@^5.0.0, vite@^5.4.12, vite@^5.4.6:
+vite@^5.0.0, vite@^5.4.6:
   version "5.4.14"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.14.tgz#ff8255edb02134df180dcfca1916c37a6abe8408"
   integrity sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==
@@ -8710,7 +8718,7 @@ word-wrap@^1.2.5:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0, wrap-ansi@^9.0.0:
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8718,6 +8726,24 @@ wrap-ansi@7.0.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0, wrap-ansi@^9.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
+
+wrap-ansi@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.0.tgz#1a3dc8b70d85eeb8398ddfb1e4a02cd186e58b3e"
+  integrity sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==
+  dependencies:
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
 
 wrappy@1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1566,100 +1566,100 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rollup/rollup-android-arm-eabi@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz#7f4c4d8cd5ccab6e95d6750dbe00321c1f30791e"
-  integrity sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==
+"@rollup/rollup-android-arm-eabi@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.0.tgz#42a8e897c7b656adb4edebda3a8b83a57526452f"
+  integrity sha512-G2fUQQANtBPsNwiVFg4zKiPQyjVKZCUdQUol53R8E71J7AsheRMV/Yv/nB8giOcOVqP7//eB5xPqieBYZe9bGg==
 
-"@rollup/rollup-android-arm64@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz#17ea71695fb1518c2c324badbe431a0bd1879f2d"
-  integrity sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==
+"@rollup/rollup-android-arm64@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.32.0.tgz#846a73eef25b18ff94bac1e52acab6a7c7ac22fa"
+  integrity sha512-qhFwQ+ljoymC+j5lXRv8DlaJYY/+8vyvYmVx074zrLsu5ZGWYsJNLjPPVJJjhZQpyAKUGPydOq9hRLLNvh1s3A==
 
-"@rollup/rollup-darwin-arm64@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz#dac0f0d0cfa73e7d5225ae6d303c13c8979e7999"
-  integrity sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==
+"@rollup/rollup-darwin-arm64@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.32.0.tgz#014ed37f1f7809fdf3442a6b689d3a074a844058"
+  integrity sha512-44n/X3lAlWsEY6vF8CzgCx+LQaoqWGN7TzUfbJDiTIOjJm4+L2Yq+r5a8ytQRGyPqgJDs3Rgyo8eVL7n9iW6AQ==
 
-"@rollup/rollup-darwin-x64@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz#8f63baa1d31784904a380d2e293fa1ddf53dd4a2"
-  integrity sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==
+"@rollup/rollup-darwin-x64@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.32.0.tgz#dde6ed3e56d0b34477fa56c4a199abe5d4b9846b"
+  integrity sha512-F9ct0+ZX5Np6+ZDztxiGCIvlCaW87HBdHcozUfsHnj1WCUTBUubAoanhHUfnUHZABlElyRikI0mgcw/qdEm2VQ==
 
-"@rollup/rollup-freebsd-arm64@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz#30ed247e0df6e8858cdc6ae4090e12dbeb8ce946"
-  integrity sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==
+"@rollup/rollup-freebsd-arm64@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.32.0.tgz#8ad634f462a6b7e338257cf64c7baff99618a08e"
+  integrity sha512-JpsGxLBB2EFXBsTLHfkZDsXSpSmKD3VxXCgBQtlPcuAqB8TlqtLcbeMhxXQkCDv1avgwNjF8uEIbq5p+Cee0PA==
 
-"@rollup/rollup-freebsd-x64@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz#57846f382fddbb508412ae07855b8a04c8f56282"
-  integrity sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==
+"@rollup/rollup-freebsd-x64@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.32.0.tgz#9d4d1dbbafcb0354d52ba6515a43c7511dba8052"
+  integrity sha512-wegiyBT6rawdpvnD9lmbOpx5Sph+yVZKHbhnSP9MqUEDX08G4UzMU+D87jrazGE7lRSyTRs6NEYHtzfkJ3FjjQ==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz#378ca666c9dae5e6f94d1d351e7497c176e9b6df"
-  integrity sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==
+"@rollup/rollup-linux-arm-gnueabihf@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.32.0.tgz#3bd5fcbab92a66e032faef1078915d1dbf27de7a"
+  integrity sha512-3pA7xecItbgOs1A5H58dDvOUEboG5UfpTq3WzAdF54acBbUM+olDJAPkgj1GRJ4ZqE12DZ9/hNS2QZk166v92A==
 
-"@rollup/rollup-linux-arm-musleabihf@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz#a692eff3bab330d5c33a5d5813a090c15374cddb"
-  integrity sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==
+"@rollup/rollup-linux-arm-musleabihf@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.32.0.tgz#a77838b9779931ce4fa01326b585eee130f51e60"
+  integrity sha512-Y7XUZEVISGyge51QbYyYAEHwpGgmRrAxQXO3siyYo2kmaj72USSG8LtlQQgAtlGfxYiOwu+2BdbPjzEpcOpRmQ==
 
-"@rollup/rollup-linux-arm64-gnu@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz#6b1719b76088da5ac1ae1feccf48c5926b9e3db9"
-  integrity sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==
+"@rollup/rollup-linux-arm64-gnu@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.32.0.tgz#ec1b1901b82d57a20184adb61c725dd8991a0bf0"
+  integrity sha512-r7/OTF5MqeBrZo5omPXcTnjvv1GsrdH8a8RerARvDFiDwFpDVDnJyByYM/nX+mvks8XXsgPUxkwe/ltaX2VH7w==
 
-"@rollup/rollup-linux-arm64-musl@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz#865baf5b6f5ff67acb32e5a359508828e8dc5788"
-  integrity sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==
+"@rollup/rollup-linux-arm64-musl@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.32.0.tgz#7aa23b45bf489b7204b5a542e857e134742141de"
+  integrity sha512-HJbifC9vex9NqnlodV2BHVFNuzKL5OnsV2dvTw6e1dpZKkNjPG6WUq+nhEYV6Hv2Bv++BXkwcyoGlXnPrjAKXw==
 
-"@rollup/rollup-linux-loongarch64-gnu@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz#23c6609ba0f7fa7a7f2038b6b6a08555a5055a87"
-  integrity sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==
+"@rollup/rollup-linux-loongarch64-gnu@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.32.0.tgz#7bf0ebd8c5ad08719c3b4786be561d67f95654a7"
+  integrity sha512-VAEzZTD63YglFlWwRj3taofmkV1V3xhebDXffon7msNz4b14xKsz7utO6F8F4cqt8K/ktTl9rm88yryvDpsfOw==
 
-"@rollup/rollup-linux-powerpc64le-gnu@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz#652ef0d9334a9f25b9daf85731242801cb0fc41c"
-  integrity sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==
+"@rollup/rollup-linux-powerpc64le-gnu@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.32.0.tgz#e687dfcaf08124aafaaebecef0cc3986675cb9b6"
+  integrity sha512-Sts5DST1jXAc9YH/iik1C9QRsLcCoOScf3dfbY5i4kH9RJpKxiTBXqm7qU5O6zTXBTEZry69bGszr3SMgYmMcQ==
 
-"@rollup/rollup-linux-riscv64-gnu@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz#1eb6651839ee6ebca64d6cc64febbd299e95e6bd"
-  integrity sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==
+"@rollup/rollup-linux-riscv64-gnu@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.32.0.tgz#19fce2594f9ce73d1cb0748baf8cd90a7bedc237"
+  integrity sha512-qhlXeV9AqxIyY9/R1h1hBD6eMvQCO34ZmdYvry/K+/MBs6d1nRFLm6BOiITLVI+nFAAB9kUB6sdJRKyVHXnqZw==
 
-"@rollup/rollup-linux-s390x-gnu@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz#015c52293afb3ff2a293cf0936b1d43975c1e9cd"
-  integrity sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==
+"@rollup/rollup-linux-s390x-gnu@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.32.0.tgz#fd99b335bb65c59beb7d15ae82be0aafa9883c19"
+  integrity sha512-8ZGN7ExnV0qjXa155Rsfi6H8M4iBBwNLBM9lcVS+4NcSzOFaNqmt7djlox8pN1lWrRPMRRQ8NeDlozIGx3Omsw==
 
-"@rollup/rollup-linux-x64-gnu@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz#b83001b5abed2bcb5e2dbeec6a7e69b194235c1e"
-  integrity sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==
+"@rollup/rollup-linux-x64-gnu@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.32.0.tgz#4e8c697bbaa2e2d7212bd42086746c8275721166"
+  integrity sha512-VDzNHtLLI5s7xd/VubyS10mq6TxvZBp+4NRWoW+Hi3tgV05RtVm4qK99+dClwTN1McA6PHwob6DEJ6PlXbY83A==
 
-"@rollup/rollup-linux-x64-musl@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz#6cc7c84cd4563737f8593e66f33b57d8e228805b"
-  integrity sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==
+"@rollup/rollup-linux-x64-musl@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.32.0.tgz#0d2f74bd9cfe0553f20f056760a95b293e849ab2"
+  integrity sha512-qcb9qYDlkxz9DxJo7SDhWxTWV1gFuwznjbTiov289pASxlfGbaOD54mgbs9+z94VwrXtKTu+2RqwlSTbiOqxGg==
 
-"@rollup/rollup-win32-arm64-msvc@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz#631ffeee094d71279fcd1fe8072bdcf25311bc11"
-  integrity sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==
+"@rollup/rollup-win32-arm64-msvc@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.32.0.tgz#6534a09fcdd43103645155cedb5bfa65fbf2c23f"
+  integrity sha512-pFDdotFDMXW2AXVbfdUEfidPAk/OtwE/Hd4eYMTNVVaCQ6Yl8et0meDaKNL63L44Haxv4UExpv9ydSf3aSayDg==
 
-"@rollup/rollup-win32-ia32-msvc@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz#06d1d60d5b9f718e8a6c4a43f82e3f9e3254587f"
-  integrity sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==
+"@rollup/rollup-win32-ia32-msvc@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.32.0.tgz#8222ccfecffd63a6b0ddbe417d8d959e4f2b11b3"
+  integrity sha512-/TG7WfrCAjeRNDvI4+0AAMoHxea/USWhAzf9PVDFHbcqrQ7hMMKp4jZIy4VEjk72AAfN5k4TiSMRXRKf/0akSw==
 
-"@rollup/rollup-win32-x64-msvc@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz#4dff5c4259ebe6c5b4a8f2c5bc3829b7a8447ff0"
-  integrity sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==
+"@rollup/rollup-win32-x64-msvc@4.32.0":
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.32.0.tgz#1a40b4792c08094b6479c48c90fe7f4b10ec2f54"
+  integrity sha512-5hqO5S3PTEO2E5VjCePxv40gIgyS2KvO7E7/vvC/NbIW4SIRamkMr1hqj+5Y67fbBWv/bQLB6KelBQmXlyCjWA==
 
 "@shikijs/core@1.22.2":
   version "1.22.2"
@@ -2093,7 +2093,7 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@18":
+"@types/react@^18.3.3":
   version "18.3.18"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.18.tgz#9b382c4cd32e13e463f97df07c2ee3bbcd26904b"
   integrity sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==
@@ -2651,7 +2651,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
+ansi-styles@^6.0.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -3421,7 +3421,7 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.5:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -6457,7 +6457,7 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^3.3.7:
+nanoid@^3.3.7, nanoid@^3.3.8:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
   integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
@@ -6845,7 +6845,7 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.12:
+path-to-regexp@0.1.12, path-to-regexp@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
@@ -7421,32 +7421,32 @@ roarr@^2.15.3:
     semver-compare "^1.0.0"
     sprintf-js "^1.1.2"
 
-rollup@^4.20.0:
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.28.1.tgz#7718ba34d62b449dfc49adbfd2f312b4fe0df4de"
-  integrity sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==
+rollup@^4.20.0, rollup@^4.22.4:
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.32.0.tgz#c405bf6fca494d1999d9088f7736d7f03e5cac5a"
+  integrity sha512-JmrhfQR31Q4AuNBjjAX4s+a/Pu/Q8Q9iwjWBsjRH1q52SPFE2NqRMK6fUZKKnvKO6id+h7JIRf0oYsph53eATg==
   dependencies:
     "@types/estree" "1.0.6"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.28.1"
-    "@rollup/rollup-android-arm64" "4.28.1"
-    "@rollup/rollup-darwin-arm64" "4.28.1"
-    "@rollup/rollup-darwin-x64" "4.28.1"
-    "@rollup/rollup-freebsd-arm64" "4.28.1"
-    "@rollup/rollup-freebsd-x64" "4.28.1"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.28.1"
-    "@rollup/rollup-linux-arm-musleabihf" "4.28.1"
-    "@rollup/rollup-linux-arm64-gnu" "4.28.1"
-    "@rollup/rollup-linux-arm64-musl" "4.28.1"
-    "@rollup/rollup-linux-loongarch64-gnu" "4.28.1"
-    "@rollup/rollup-linux-powerpc64le-gnu" "4.28.1"
-    "@rollup/rollup-linux-riscv64-gnu" "4.28.1"
-    "@rollup/rollup-linux-s390x-gnu" "4.28.1"
-    "@rollup/rollup-linux-x64-gnu" "4.28.1"
-    "@rollup/rollup-linux-x64-musl" "4.28.1"
-    "@rollup/rollup-win32-arm64-msvc" "4.28.1"
-    "@rollup/rollup-win32-ia32-msvc" "4.28.1"
-    "@rollup/rollup-win32-x64-msvc" "4.28.1"
+    "@rollup/rollup-android-arm-eabi" "4.32.0"
+    "@rollup/rollup-android-arm64" "4.32.0"
+    "@rollup/rollup-darwin-arm64" "4.32.0"
+    "@rollup/rollup-darwin-x64" "4.32.0"
+    "@rollup/rollup-freebsd-arm64" "4.32.0"
+    "@rollup/rollup-freebsd-x64" "4.32.0"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.32.0"
+    "@rollup/rollup-linux-arm-musleabihf" "4.32.0"
+    "@rollup/rollup-linux-arm64-gnu" "4.32.0"
+    "@rollup/rollup-linux-arm64-musl" "4.32.0"
+    "@rollup/rollup-linux-loongarch64-gnu" "4.32.0"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.32.0"
+    "@rollup/rollup-linux-riscv64-gnu" "4.32.0"
+    "@rollup/rollup-linux-s390x-gnu" "4.32.0"
+    "@rollup/rollup-linux-x64-gnu" "4.32.0"
+    "@rollup/rollup-linux-x64-musl" "4.32.0"
+    "@rollup/rollup-win32-arm64-msvc" "4.32.0"
+    "@rollup/rollup-win32-ia32-msvc" "4.32.0"
+    "@rollup/rollup-win32-x64-msvc" "4.32.0"
     fsevents "~2.3.2"
 
 rrweb-cssom@^0.6.0:
@@ -7839,7 +7839,7 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^5.0.1, string-width@^5.1.2:
+string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -8540,7 +8540,7 @@ vite-node@1.6.0:
     picocolors "^1.0.0"
     vite "^5.0.0"
 
-vite@^5.0.0, vite@^5.4.6:
+vite@^5.0.0, vite@^5.4.12, vite@^5.4.6:
   version "5.4.14"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.14.tgz#ff8255edb02134df180dcfca1916c37a6abe8408"
   integrity sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==
@@ -8718,7 +8718,7 @@ word-wrap@^1.2.5:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-ansi@^7.0.0:
+wrap-ansi@7.0.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0, wrap-ansi@^9.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8726,24 +8726,6 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
-
-wrap-ansi@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
-  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
-  dependencies:
-    ansi-styles "^6.1.0"
-    string-width "^5.0.1"
-    strip-ansi "^7.0.1"
-
-wrap-ansi@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.0.tgz#1a3dc8b70d85eeb8398ddfb1e4a02cd186e58b3e"
-  integrity sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==
-  dependencies:
-    ansi-styles "^6.2.1"
-    string-width "^7.0.0"
-    strip-ansi "^7.1.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
#### What is this PR doing?
- Fixes crash when selecting audio output device in waiting room on android
- Change UI to allow audio output UI even when not supported by showing "System Default" and allowing Test Speaker to run

#### How should this be manually tested?
- Need to test quite thoroughly on different browsers including android and iOS
- Test audio output UI in waiting room
- Test Speaker Test in waiting room
- Test audio output UI in Meeting Room
- Test Speaker Test in Meeting Room

On supported devices:
- set non-default audio output device
- unplug device
- open audio settings
- expect new device (default) to be selected

#### What are the relevant tickets?

Resolves [VIDCS-3273](https://jira.vonage.com/browse/VIDCS-3273)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?