### PR TITLE
VIDCS-3281: Skip Sonarcloud scan and Integration tests if PR is from a fork (External Contributor)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -107,14 +107,14 @@ jobs:
           yarn test
 
       - name: SonarCloud Scan
-        if: steps.check-skip-ci.outputs.result == 'false'
+        if: steps.check-skip-ci.outputs.result == 'false' && github.event.pull_request.head.repo.fork == false
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Run integration tests
-        if: steps.check-skip-ci.outputs.result == 'false'
+        if: steps.check-skip-ci.outputs.result == 'false' && github.event.pull_request.head.repo.fork == false
         run: |
           Xvfb :99 & export DISPLAY=:99
           yarn test:integration


### PR DESCRIPTION
#### What is this PR doing?
Skip Sonarcloud scan and Integration tests if PR is from a fork (External)

#### How should this be manually tested?
I added this change to [this PR](https://github.com/Vonage/vonage-video-react-app/pull/4) which I created from my personal test github account (a an external contributor).
And the[ jobs are getting skipped ](https://github.com/Vonage/vonage-video-react-app/actions/runs/12931347172/job/36065065889?pr=4)
Which I believe should be enough testing for the PR

#### What are the relevant tickets?

Resolves [VIDCS-3281](https://jira.vonage.com/browse/VIDCS-3281)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?