### PR TITLE
VIDCS-3286: Auto-set Base Branch to Develop

### DIFF
--- a/.github/workflows/auto-set-base.yml
+++ b/.github/workflows/auto-set-base.yml
@@ -2,7 +2,7 @@ name: Auto-set Base Branch to Develop
 
 on:
   pull_request:
-    types: [opened]
+    # types: [opened]
 
 jobs:
   set-base-branch:
@@ -13,11 +13,11 @@ jobs:
 
       - name: Check and Update Base Branch
         run: |
-          if [ "${{ github.event.pull_request.base.ref }}" != "develop" ]; then
+          if [ "${{ github.event.pull_request.base.ref }}" == "main" ]; then
             gh pr edit ${{ github.event.pull_request.number }} --base develop
             echo "Base branch updated to 'develop'.";
           else
-            echo "Base branch is already 'develop'.";
+            echo "Base branch is not 'main'.";
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-set-base.yml
+++ b/.github/workflows/auto-set-base.yml
@@ -2,7 +2,7 @@ name: Auto-set Base Branch to Develop
 
 on:
   pull_request:
-    # types: [opened]
+    types: [opened]
 
 jobs:
   set-base-branch:

--- a/.github/workflows/auto-set-base.yml
+++ b/.github/workflows/auto-set-base.yml
@@ -8,6 +8,9 @@ jobs:
   set-base-branch:
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
       - name: Check and Update Base Branch
         run: |
           if [ "${{ github.event.pull_request.base.ref }}" != "develop" ]; then

--- a/.github/workflows/auto-set-base.yml
+++ b/.github/workflows/auto-set-base.yml
@@ -1,0 +1,20 @@
+name: Auto-set Base Branch to Develop
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  set-base-branch:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check and Update Base Branch
+        run: |
+          if [ "${{ github.event.pull_request.base.ref }}" != "develop" ]; then
+            gh pr edit ${{ github.event.pull_request.number }} --base develop
+            echo "Base branch updated to 'develop'.";
+          else
+            echo "Base branch is already 'develop'.";
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-set-base.yml
+++ b/.github/workflows/auto-set-base.yml
@@ -2,7 +2,7 @@ name: Auto-set Base Branch to Develop
 
 on:
   pull_request:
-    types: [opened]
+    # types: [opened]
 
 jobs:
   set-base-branch:

--- a/.github/workflows/auto-set-base.yml
+++ b/.github/workflows/auto-set-base.yml
@@ -2,7 +2,7 @@ name: Auto-set Base Branch to Develop
 
 on:
   pull_request:
-    types: [opened]
+    # types: [opened]
 
 jobs:
   set-base-branch:
@@ -13,11 +13,15 @@ jobs:
 
       - name: Check and Update Base Branch
         run: |
-          if [ "${{ github.event.pull_request.base.ref }}" == "main" ]; then
+          TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
+          BASE_BRANCH="${{ github.event.pull_request.head.ref }}"
+
+          if [ "$TARGET_BRANCH" = "main" ] && [ "$BASE_BRANCH" != "develop" ]; then
+            echo "Switching base branch from $TARGET_BRANCH to develop..."
             gh pr edit ${{ github.event.pull_request.number }} --base develop
-            echo "Base branch updated to 'develop'.";
+            echo "Base branch updated to 'develop'."
           else
-            echo "Base branch is not 'main'.";
+            echo "No changes needed: Target branch is '$TARGET_BRANCH' and base branch is '$BASE_BRANCH'."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### What is this PR doing?
This PR adds a GHA job to make develop as the base branch of the PR only on opening the PR. Which will acts as the default moving forward.
Also, we can re-change the default branch once the job is done to whatever we want. 

#### How should this be manually tested?
Notice below the default of this branch is changed to develop by bot
[Logs to the job before the last commit to make it run only on opening the PR
](https://github.com/Vonage/vonage-video-react-app/actions/runs/12948395663/job/36116971265)

#### What are the relevant tickets?

Resolves [VIDCS-3286](https://jira.vonage.com/browse/VIDCS-3286)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?