### PR TITLE
VIDCS-3289: Update the Vera deploy to VCR job to trigger on merge to develop

### DIFF
--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -3,7 +3,7 @@ name: Deploy to VCR
 on:
   pull_request:
     branches:
-      - main
+      - develop
     types: [closed]
 
 permissions:


### PR DESCRIPTION
#### What is this PR doing?
This PR updates the VCR deployment job to trigger automatically upon merges to the develop branch, enabling dogfooding and testing of the develop branch before releasing or merging into the main branch.

#### How should this be manually tested?
n/a

#### What are the relevant tickets?

Resolves [VIDCS-3289](https://jira.vonage.com/browse/VIDCS-3289)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?