### PR TITLE
VIDCS-3274: Add spinner while session connects

### DIFF
--- a/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
@@ -86,7 +86,10 @@ const VideoTileCanvas = ({
     <div ref={wrapRef} id="wrapper" className={`m-3 ${widthClass} ${heightClass}`}>
       <div id="video-container" className="relative w-full h-full">
         {!connected ? (
-          <CircularProgress sx={{ position: 'absolute', top: '50%' }} />
+          <CircularProgress
+            data-testid="progress-spinner"
+            sx={{ position: 'absolute', top: '50%' }}
+          />
         ) : (
           <>
             {isPublishing && layoutBoxes.publisherBox && (

--- a/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useRef } from 'react';
 import { Publisher as OTPublisher } from '@vonage/client-sdk-video';
+import { CircularProgress } from '@mui/material';
 import useLayoutManager from '../../../hooks/useLayoutManager';
 import usePublisherContext from '../../../hooks/usePublisherContext';
 import useSessionContext from '../../../hooks/useSessionContext';
@@ -14,6 +15,7 @@ import getLayoutBoxes from '../../../utils/helpers/getLayoutBoxes';
 import useActiveSpeaker from '../../../hooks/useActiveSpeaker';
 
 export type VideoTileCanvasProps = {
+  connected: boolean | null;
   isSharingScreen: boolean;
   screensharingPublisher: OTPublisher | null;
   screenshareVideoElement: HTMLVideoElement | HTMLObjectElement | undefined;
@@ -29,6 +31,7 @@ export type VideoTileCanvasProps = {
  * @returns {ReactElement} VideoTileCanvas
  */
 const VideoTileCanvas = ({
+  connected,
   isSharingScreen,
   screensharingPublisher,
   screenshareVideoElement,
@@ -82,31 +85,41 @@ const VideoTileCanvas = ({
   return (
     <div ref={wrapRef} id="wrapper" className={`m-3 ${widthClass} ${heightClass}`}>
       <div id="video-container" className="relative w-full h-full">
-        {isPublishing && layoutBoxes.publisherBox && <Publisher box={layoutBoxes.publisherBox} />}
-        {isSharingScreen && (
-          <ScreenSharePublisher
-            publisher={screensharingPublisher}
-            box={layoutBoxes.localScreenshareBox}
-            element={screenshareVideoElement}
-          />
-        )}
-        {// Note: we still render hidden subscribers with flag `hidden`
-        // inside the subscriber component we will unsubscribe to video to save bandwidth
-        [...subscribersInDisplayOrder, ...hiddenSubscribers]?.map((subscriberWrapper, index) => (
-          <Subscriber
-            key={subscriberWrapper.id}
-            subscriberWrapper={subscriberWrapper}
-            isHidden={!subscribersInDisplayOrder.includes(subscriberWrapper)}
-            box={layoutBoxes.subscriberBoxes?.[index]}
-            isActiveSpeaker={activeSpeakerId === subscriberWrapper.id}
-          />
-        ))}
-        {!!hiddenSubscribers.length && layoutBoxes.hiddenParticipantsBox && (
-          <HiddenParticipantsTile
-            hiddenSubscribers={hiddenSubscribers}
-            box={layoutBoxes.hiddenParticipantsBox}
-            handleClick={toggleParticipantList}
-          />
+        {!connected ? (
+          <CircularProgress sx={{ position: 'absolute', top: '50%' }} />
+        ) : (
+          <>
+            {isPublishing && layoutBoxes.publisherBox && (
+              <Publisher box={layoutBoxes.publisherBox} />
+            )}
+            {isSharingScreen && (
+              <ScreenSharePublisher
+                publisher={screensharingPublisher}
+                box={layoutBoxes.localScreenshareBox}
+                element={screenshareVideoElement}
+              />
+            )}
+            {// Note: we still render hidden subscribers with flag `hidden`
+            // inside the subscriber component we will unsubscribe to video to save bandwidth
+            [...subscribersInDisplayOrder, ...hiddenSubscribers]?.map(
+              (subscriberWrapper, index) => (
+                <Subscriber
+                  key={subscriberWrapper.id}
+                  subscriberWrapper={subscriberWrapper}
+                  isHidden={!subscribersInDisplayOrder.includes(subscriberWrapper)}
+                  box={layoutBoxes.subscriberBoxes?.[index]}
+                  isActiveSpeaker={activeSpeakerId === subscriberWrapper.id}
+                />
+              )
+            )}
+            {!!hiddenSubscribers.length && layoutBoxes.hiddenParticipantsBox && (
+              <HiddenParticipantsTile
+                hiddenSubscribers={hiddenSubscribers}
+                box={layoutBoxes.hiddenParticipantsBox}
+                handleClick={toggleParticipantList}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
@@ -15,7 +15,6 @@ import getLayoutBoxes from '../../../utils/helpers/getLayoutBoxes';
 import useActiveSpeaker from '../../../hooks/useActiveSpeaker';
 
 export type VideoTileCanvasProps = {
-  connected: boolean | null;
   isSharingScreen: boolean;
   screensharingPublisher: OTPublisher | null;
   screenshareVideoElement: HTMLVideoElement | HTMLObjectElement | undefined;
@@ -31,7 +30,6 @@ export type VideoTileCanvasProps = {
  * @returns {ReactElement} VideoTileCanvas
  */
 const VideoTileCanvas = ({
-  connected,
   isSharingScreen,
   screensharingPublisher,
   screenshareVideoElement,
@@ -45,7 +43,7 @@ const VideoTileCanvas = ({
   const activeSpeakerId = useActiveSpeaker();
   const { isPublishing, publisher } = usePublisherContext();
   const getLayout = useLayoutManager();
-  const { subscriberWrappers, layoutMode } = useSessionContext();
+  const { connected, subscriberWrappers, layoutMode } = useSessionContext();
 
   // Determine if we will display a large video tile based on current layout mode and screenshare presence
   const isViewingScreenshare = subscriberWrappers.some((subWrapper) => subWrapper.isScreenshare);

--- a/frontend/src/pages/MeetingRoom/MeetingRoom.spec.tsx
+++ b/frontend/src/pages/MeetingRoom/MeetingRoom.spec.tsx
@@ -189,8 +189,8 @@ describe('MeetingRoom', () => {
     publisherContext.publisher = mockPublisher;
     const { rerender } = render(<MeetingRoomWithProviders />);
     rerender(<MeetingRoomWithProviders />);
-    sessionContext.connected = true;
     expect(screen.getByTestId('progress-spinner')).toBeInTheDocument();
+    sessionContext.connected = true;
     rerender(<MeetingRoomWithProviders />);
     expect(screen.queryByTestId('progress-spinner')).not.toBeInTheDocument();
   });

--- a/frontend/src/pages/MeetingRoom/MeetingRoom.spec.tsx
+++ b/frontend/src/pages/MeetingRoom/MeetingRoom.spec.tsx
@@ -184,6 +184,17 @@ describe('MeetingRoom', () => {
     expect(screen.getByTestId('publisher-container')).toBeInTheDocument();
   });
 
+  it('should display spinner until session is connected', () => {
+    sessionContext.connected = false;
+    publisherContext.publisher = mockPublisher;
+    const { rerender } = render(<MeetingRoomWithProviders />);
+    rerender(<MeetingRoomWithProviders />);
+    sessionContext.connected = true;
+    expect(screen.getByTestId('progress-spinner')).toBeInTheDocument();
+    rerender(<MeetingRoomWithProviders />);
+    expect(screen.queryByTestId('progress-spinner')).not.toBeInTheDocument();
+  });
+
   it('should hide subscribers and show participant hidden tile', () => {
     sessionContext.connected = true;
     sessionContext.layoutMode = 'active-speaker';

--- a/frontend/src/pages/MeetingRoom/MeetingRoom.tsx
+++ b/frontend/src/pages/MeetingRoom/MeetingRoom.tsx
@@ -89,7 +89,6 @@ const MeetingRoom = (): ReactElement => {
   return (
     <div data-testid="meetingRoom" className="meetingRoom w-screen" style={{ height }}>
       <VideoTileCanvas
-        connected={connected}
         isSharingScreen={isSharingScreen}
         screensharingPublisher={screensharingPublisher}
         screenshareVideoElement={screenshareVideoElement}

--- a/frontend/src/pages/MeetingRoom/MeetingRoom.tsx
+++ b/frontend/src/pages/MeetingRoom/MeetingRoom.tsx
@@ -89,6 +89,7 @@ const MeetingRoom = (): ReactElement => {
   return (
     <div data-testid="meetingRoom" className="meetingRoom w-screen" style={{ height }}>
       <VideoTileCanvas
+        connected={connected}
         isSharingScreen={isSharingScreen}
         screensharingPublisher={screensharingPublisher}
         screenshareVideoElement={screenshareVideoElement}


### PR DESCRIPTION
#### What is this PR doing?
- Adds a loading spinner while the session connects
- Helps with issue where it appears you're alone in the room but really you're still connecting

#### How should this be manually tested?
- run locally, test on slow and fast networks
- spinner should not appear during reconnections

#### What are the relevant tickets?

Resolves [VIDCS-3274](https://jira.vonage.com/browse/VIDCS-3274)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?