### PR TITLE
VIDCS-3291: Update contributing doc to Reflect New Develop Branch Workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,10 @@
 
 #### How should this be manually tested?
 
+
 #### What are the relevant tickets?
 A maintainer will add this ticket number.
+
 Resolves [VIDCS-](https://jira.vonage.com/browse/VIDCS-)
 
 #### Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,13 +3,13 @@
 
 #### How should this be manually tested?
 
-
 #### What are the relevant tickets?
-
+A maintainer will add this ticket number.
 Resolves [VIDCS-](https://jira.vonage.com/browse/VIDCS-)
 
+#### Checklist
+[ ] Branch is based on `develop` (not `main`).
 [ ] Resolves a `Known Issue`.
 [ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
 [ ] Resolves an item reported in `Issues`.
 If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
-[ ] If yes, did you close the item in `Issues`?

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,6 +25,6 @@ When you're ready to start coding, fork this repository to your own GitHub accou
 
 Our *main* branch is the evergreen source of truth for the Vonage Video API Reference App for React. However, all new development should be done in the develop branch. Contributions should be made by branching off develop, and pull requests should be submitted against develop. Periodically, develop will be merged into main as a batch.
  
-Internally, we use Jira for issue tracking. Issue and feature branches use the format DEVELOPERNAME/TICKETNUMBER-SHORTDESCRIPTION e.g. alicesmith/VIDCS-123-fix-broken-icon. If you'd like to contribute a pull request, please use a branch on your fork with a descriptive name e.g. alicesmith/vonage-video-react-app/tree/fix-broken-icon.
+Internally, we use Jira for issue tracking. Issue and feature branches use the format DEVELOPERNAME/TICKETNUMBER-SHORTDESCRIPTION e.g. alicesmith/VIDCS-123-fix-broken-icon. If you'd like to contribute a pull request, please use a branch on your fork with a descriptive name e.g. fix-broken-icon.
 
 Release versions use the format rc-RELEASENUMBER number, e.g. rc-1.0.0. We use [semantic versioning](https://semver.org/) for our releases. 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,6 +25,6 @@ When you're ready to start coding, fork this repository to your own GitHub accou
 
 Our *main* branch is the evergreen source of truth for the Vonage Video API Reference App for React. However, all new development should be done in the develop branch. Contributions should be made by branching off develop, and pull requests should be submitted against develop. Periodically, develop will be merged into main as a batch.
  
-Internally, we use Jira for issue tracking. Issue and feature branches use the format DEVELOPERNAME/TICKETNUMBER-SHORTDESCRIPTION e.g. alicesmith/VIDCS-123-fix-broken-icon. If you'd like to contribute a pull request, please use a branch on your fork with a descriptive name e.g. alicesmith:fix-broken-icon.
+Internally, we use Jira for issue tracking. Issue and feature branches use the format DEVELOPERNAME/TICKETNUMBER-SHORTDESCRIPTION e.g. alicesmith/VIDCS-123-fix-broken-icon. If you'd like to contribute a pull request, please use a branch on your fork with a descriptive name e.g. alicesmith/vonage-video-react-app/tree/fix-broken-icon.
 
 Release versions use the format rc-RELEASENUMBER number, e.g. rc-1.0.0. We use [semantic versioning](https://semver.org/) for our releases. 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,10 +19,11 @@ We always welcome feedback, if you've seen something that isn't quite right or y
 
 We're always open to pull requests, but these should be small and clearly described so that we can understand what you're trying to do. Feel free to open an issue first and get some discussion going.
 
-When you're ready to start coding, fork this repository to your own GitHub account and make your changes in a new branch. Once you're happy, open a pull request and explain what the change is and why you think we should include it in our project.
+When you're ready to start coding, fork this repository to your own GitHub account and make your changes in a new branch based on develop. Once you're happy, open a pull request to merge into develop and explain what the change is and why you think we should include it in our project.
 
 ### Branching 
 
-Our *main* branch is the evergreen source of truth for the Vonage Video API Reference App for React. Internally, we use Jira for issue tracking. Issue and feature branches use the format DEVELOPERNAME/TICKETNUMBER-SHORTDESCRIPTION e.g. alicesmith/VIDCS-123-fix-broken-icon. If you'd like to contribute a pull request, please use a branch on your fork with a descriptive name.
+Our *main* branch is the evergreen source of truth for the Vonage Video API Reference App for React. However, all new development should be done in the develop branch. Contributions should be made by branching off develop, and pull requests should be submitted against develop. Periodically, develop will be merged into main as a batch.
+ Internally, we use Jira for issue tracking. Issue and feature branches use the format DEVELOPERNAME/TICKETNUMBER-SHORTDESCRIPTION e.g. alicesmith/VIDCS-123-fix-broken-icon. If you'd like to contribute a pull request, please use a branch on your fork with a descriptive name.
 
 Release versions use the format rc-RELEASENUMBER number, e.g. rc-1.0.0. We use [semantic versioning](https://semver.org/) for our releases. 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,6 +24,7 @@ When you're ready to start coding, fork this repository to your own GitHub accou
 ### Branching 
 
 Our *main* branch is the evergreen source of truth for the Vonage Video API Reference App for React. However, all new development should be done in the develop branch. Contributions should be made by branching off develop, and pull requests should be submitted against develop. Periodically, develop will be merged into main as a batch.
- Internally, we use Jira for issue tracking. Issue and feature branches use the format DEVELOPERNAME/TICKETNUMBER-SHORTDESCRIPTION e.g. alicesmith/VIDCS-123-fix-broken-icon. If you'd like to contribute a pull request, please use a branch on your fork with a descriptive name.
+ 
+Internally, we use Jira for issue tracking. Issue and feature branches use the format DEVELOPERNAME/TICKETNUMBER-SHORTDESCRIPTION e.g. alicesmith/VIDCS-123-fix-broken-icon. If you'd like to contribute a pull request, please use a branch on your fork with a descriptive name e.g. alicesmith:fix-broken-icon.
 
 Release versions use the format rc-RELEASENUMBER number, e.g. rc-1.0.0. We use [semantic versioning](https://semver.org/) for our releases. 


### PR DESCRIPTION
#### What is this PR doing?
Update contributing doc to Reflect New Develop Branch Workflow.
See new[ contributing doc](https://github.com/Vonage/vonage-video-react-app/blob/VIDCS-3291-update-contributing-doc/docs/CONTRIBUTING.md) and [PR template](https://github.com/Vonage/vonage-video-react-app/blob/VIDCS-3291-update-contributing-doc/.github/pull_request_template.md)

#### How should this be manually tested?
n/a

#### What are the relevant tickets?

Resolves [VIDCS-3291](https://jira.vonage.com/browse/VIDCS-3291)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?