### PR TITLE
VIDCS-3348: bump to 2.29.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^15.0.5",
     "@testing-library/user-event": "^14.5.1",
-    "@vonage/client-sdk-video": "^2.28.4",
+    "@vonage/client-sdk-video": "^2.29.0",
     "@vonage/vcr-sdk": "^1.3.0",
     "autolinker": "^4.0.0",
     "axios": "^1.7.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,10 +2371,10 @@
     "@vonage/jwt" "^1.11.0"
     debug "^4.3.4"
 
-"@vonage/client-sdk-video@^2.28.4":
-  version "2.28.4"
-  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.28.4.tgz#2ec171eceea6014512e1038f0c4150c186284ab7"
-  integrity sha512-KBk5Ko06MJplPNrfipQKztkV6JJi1uMYkkrUUAH8N1mNtIDquP99xkTpDOSJtGNA+TLsEnIAx2LxKu3ItP9B8w==
+"@vonage/client-sdk-video@^2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.0.tgz#055cb4abe8d55d6eb9cfbe6eb74625fd97974f2b"
+  integrity sha512-xpWwD28eC6TTwdBmZ8v/Z2URrNkLxeAl5vg2pLAJOkNgOzXuPw7MM1iKtztbKsao8aSW0pup9eYqVujIR4oc8g==
 
 "@vonage/conversations@^1.4.0":
   version "1.4.0"
@@ -7821,7 +7821,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7902,7 +7911,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
#### What is this PR doing?
Bumping SDK to 2.29.0

#### How should this be manually tested?
- go to meeting room with two participants, hopefully all is well

#### What are the relevant tickets?

Resolves [VIDCS-3348](https://jira.vonage.com/browse/VIDCS-3348)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?