### PR TITLE
VIDCS-3370: Onclick listener is on an icon, not the button

### DIFF
--- a/frontend/src/components/MeetingRoom/AudioIndicator/AudioIndicator.tsx
+++ b/frontend/src/components/MeetingRoom/AudioIndicator/AudioIndicator.tsx
@@ -81,12 +81,9 @@ const AudioIndicator = ({
             borderRadius: '50%',
             cursor: hasAudio ? 'pointer' : 'default',
           }}
+          onClick={hasAudio ? handleClick : undefined}
         >
-          {hasAudio ? (
-            <Mic sx={sxProperties} onClick={handleClick} />
-          ) : (
-            <MicOff sx={sxProperties} />
-          )}
+          {hasAudio ? <Mic sx={sxProperties} /> : <MicOff sx={sxProperties} />}
         </IconButton>
       </Tooltip>
       <PopupDialog


### PR DESCRIPTION
#### What is this PR doing?
Fixes a tiny issue where the `onclick` handler was on an icon, not the button. This caused the browser console to log an error.

#### How should this be manually tested?
##### Repro'ing the error
- checkout develop
- join a room with a user, open the browser console
- join the same room in another tab
- notice in the browser console, there's a an error

##### Verifying the fix
- checkout this branch
- repeat steps above, but hopefully the error isn't present 🤞 

#### What are the relevant tickets?

Resolves [VIDCS-3370](https://jira.vonage.com/browse/VIDCS-3370)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?