### PR TITLE
VIDCS-3373: Add VIDEO_SERVICE_PROVIDER, VONAGE_APP_ID and VONAGE_PRIVATE_KEY to update screenshots job

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -10,8 +10,11 @@ permissions:
   contents: read
 
 env:
+  VIDEO_SERVICE_PROVIDER: ${{vars.VIDEO_SERVICE_PROVIDER}}
   OT_API_KEY: ${{secrets.API_KEY}}
   OT_API_SECRET: ${{secrets.API_SECRET}}
+  VONAGE_APP_ID: ${{secrets.VONAGE_APP_ID}}
+  VONAGE_PRIVATE_KEY: ${{secrets.VONAGE_PRIVATE_KEY}}
 
 jobs:
   run:


### PR DESCRIPTION
#### What is this PR doing?
Adding VIDEO_SERVICE_PROVIDER, VONAGE_APP_ID and VONAGE_PRIVATE_KEY to update screenshots job
It should have been a part of [this PR](https://github.com/Vonage/vonage-video-react-app/pull/33) but I missed to add these on the `update-screenshots` job.

#### How should this be manually tested?
n/a

#### What are the relevant tickets?

Resolves [VIDCS-3373](https://jira.vonage.com/browse/VIDCS-3373)

[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
[ ] If yes, did you close the item in `Issues`?