### PR TITLE
VIDCS-3387: CI tests not running due to deprecated actions/cache

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Setup node
         if: steps.check-skip-ci.outputs.result == 'false'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Setup node
         if: steps.check-skip-ci.outputs.result == 'false'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: steps.check-skip-ci.outputs.result == 'false' && github.event.pull_request.head.repo.fork == false
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
#### What is this PR doing?
CI wasn't running due to a deprecated library version of `actions/cache` being run. This was due to an old sonarcloud action. This PR updates the sonarcloud action.

#### How should this be manually tested?
- CI passes 🤞 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3387](https://jira.vonage.com/browse/VIDCS-3387)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?