### PR TITLE
VIDCS-3387: CI tests not running due to deprecated actions/cache #2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: SonarCloud Branch Analysis On base branch
         if: steps.check-skip-ci.outputs.result == 'false' && github.event.pull_request.head.repo.fork == false
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
#### What is this PR doing?
CI wasn't running due to a deprecated library version of `actions/cache` being run. This was due to an old sonarcloud action. This PR updates the sonarcloud action.

#### How should this be manually tested?
- CI passes 🤞 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3387](https://jira.vonage.com/browse/VIDCS-3387)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?