### PR TITLE
VIDCS-3375: Video tiles hidden under toolbar on mobile

### DIFF
--- a/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
@@ -75,7 +75,7 @@ const VideoTileCanvas = ({
   });
 
   // Height is 100vh - toolbar height (80px) - 24px wrapper margin
-  const heightClass = '@apply h-[calc(100vh_-_104px)]';
+  const heightClass = '@apply h-[calc(100dvh_-_104px)]';
   // Width is 100vw - 360px panel width - 24px panel right margin - 24px wrapper margin
   const widthClass = isRightPanelOpen
     ? '@apply w-[calc(100vw_-_392px)]'


### PR DESCRIPTION
#### What is this PR doing?
##### Description
There was an issue where the tiles of participants who were not the active speaker would be cut off on mobile. This PR fixes it.

##### Before
![bugged](https://github.com/user-attachments/assets/6f89808e-5f01-4efe-b5ea-736bd4e4792e)

##### After
![fixed](https://github.com/user-attachments/assets/3d100acb-1856-4109-b71f-e9833f1c9c87)

#### How should this be manually tested?
##### Repro'ing the issue
- checkout develop or go to the live link
- join a meeting room on mobile and desktop *with videos on*
- notice on mobile, the preview publisher is cut off

##### Testing the fix
- checkout this branch
- join a meeting room on mobile and desktop *with videos on*
- notice on mobile, both tiles are visible 🙌

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3375](https://jira.vonage.com/browse/VIDCS-3375)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?