### PR TITLE
VIDCS-3111: scrollbars appear for an instant and preview publisher is not full width in mobile waiting room

### DIFF
--- a/frontend/src/components/WaitingRoom/VideoLoading/VideoLoading.tsx
+++ b/frontend/src/components/WaitingRoom/VideoLoading/VideoLoading.tsx
@@ -11,7 +11,7 @@ const VideoLoading = (): ReactElement => {
   return (
     <div
       data-testid="VideoLoading"
-      className="absolute  flex items-center justify-center w-[584px] h-[328px] rounded-2xl bg-black"
+      className="absolute  flex items-center justify-center w-dvw h-[328px] rounded-2xl bg-black"
     >
       <CircularProgress
         sx={{

--- a/frontend/src/components/WaitingRoom/VideoLoading/VideoLoading.tsx
+++ b/frontend/src/components/WaitingRoom/VideoLoading/VideoLoading.tsx
@@ -11,7 +11,7 @@ const VideoLoading = (): ReactElement => {
   return (
     <div
       data-testid="VideoLoading"
-      className="absolute  flex items-center justify-center w-dvw h-[328px] rounded-2xl bg-black"
+      className="absolute flex items-center justify-center w-dvw h-[328px] rounded-2xl bg-black"
     >
       <CircularProgress
         sx={{


### PR DESCRIPTION
#### What is this PR doing?
Fixes the (horizontal) scrollbar issue and the preview publisher width issue. Sorry for no screenshots, it's difficult to capture in the less than 1s that it appears.

#### How should this be manually tested?
##### Repro'ing the issue
- checkout develop or use the live app
- go to a waiting room
- notice before the publisher preview appears, there's a horizontal scrollbar
- you may need to refresh to catch this, as it's there for an instant. It's most easily noticeable if you've visited the live app through your mobile device as the autofill will cause your device to scroll to the left (on iOS Safari at least)

##### Demoing the fix
- checkout this branch
- go to a waiting room
- notice there's *no* horizontal scrollbar

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3111](https://jira.vonage.com/browse/VIDCS-3111)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?