### PR TITLE
VIDCS-3319: In goodbye page on mobile, the webpage is scrollable

### DIFF
--- a/frontend/src/components/GoodBye/GoodbyeMessage/GoodbyeMessage.tsx
+++ b/frontend/src/components/GoodBye/GoodbyeMessage/GoodbyeMessage.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { ReactElement } from 'react';
 import GoToLandingPageButton from '../GoToLandingPageButton';
 import ReenterRoomButton from '../ReenterRoomButton';
+import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 
 export type GoodByeMessageProps = {
   header: string;
@@ -16,6 +17,7 @@ export type GoodByeMessageProps = {
  * @returns {ReactElement} The GoodByeMessage component.
  */
 const GoodByeMessage = ({ header, message, roomName }: GoodByeMessageProps): ReactElement => {
+  const isSmallViewport = useIsSmallViewport();
   const navigate = useNavigate();
   const handleLanding = () => {
     navigate('/');
@@ -27,7 +29,9 @@ const GoodByeMessage = ({ header, message, roomName }: GoodByeMessageProps): Rea
   return (
     <div className="ps-12 py-4 h-auto w-full shrink text-left">
       <h2 className="text-5xl text-black pb-5 w-9/12">{header}</h2>
-      <h3 className="text-large text-slate-500 min-[400px]:w-[400px] pr-12">{message}</h3>
+      <h3 className={`text-large text-slate-500 pr-12 ${isSmallViewport ? 'w-dvw' : 'w-[400px]'}`}>
+        {message}
+      </h3>
       <div className="flex flex-row mt-6 items-center pr-0">
         <ReenterRoomButton handleReenter={handleReenter} roomName={roomName} />
 

--- a/frontend/src/components/GoodBye/GoodbyeMessage/GoodbyeMessage.tsx
+++ b/frontend/src/components/GoodBye/GoodbyeMessage/GoodbyeMessage.tsx
@@ -29,7 +29,7 @@ const GoodByeMessage = ({ header, message, roomName }: GoodByeMessageProps): Rea
   return (
     <div className="ps-12 py-4 h-auto w-full shrink text-left">
       <h2 className="text-5xl text-black pb-5 w-9/12">{header}</h2>
-      <h3 className={`text-large text-slate-500 pr-12 ${isSmallViewport ? 'w-dvw' : 'w-[400px]'}`}>
+      <h3 className={`text-large text-slate-500 pr-12 ${isSmallViewport ? 'w-full' : 'w-[400px]'}`}>
         {message}
       </h3>
       <div className="flex flex-row mt-6 items-center pr-0">

--- a/frontend/src/pages/GoodBye/GoodBye.tsx
+++ b/frontend/src/pages/GoodBye/GoodBye.tsx
@@ -39,11 +39,9 @@ const GoodBye = (): ReactElement => {
           <div className="max-w-[400px]">
             <GoodByeMessage header={header} message={caption} roomName={roomName} />
           </div>
-          <div className="w-full">
-            <div className="ps-12 py-4 h-auto shrink w-full text-left">
-              <h3 className="text-4xl text-black pb-5 w-9/12">Recordings</h3>
-              <ArchiveList archives={archives} />
-            </div>
+          <div className="ps-12 py-4 h-auto shrink w-full text-left">
+            <h3 className="text-4xl text-black pb-5 w-9/12">Recordings</h3>
+            <ArchiveList archives={archives} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
#### What is this PR doing?
Removes some horizontal scroll on the goodbye page for mobile

##### Screenshots
###### After
![fixed-real](https://github.com/user-attachments/assets/98192a51-6ce7-4cfa-8aca-48eccdcf241a)


###### Before
![broken-real](https://github.com/user-attachments/assets/1c4e77f6-8798-4818-bfac-2c36c30d972c)


#### How should this be manually tested?
##### Repro'ing the issue
- on a mobile device or use mobile view, go to the goodbye page, `/goodbye`
- notice there's a horizontal scrollbar

##### Verifying the fix
- checkout this branch
- on a mobile device or use mobile view, go to the goodbye page, `/goodbye`
- notice there's no horizontal scrollbar

##### Verifying lack of funkiness
- open `/goodbye` on your desktop
- drag your window to reduce your viewport until it's as small as it can get (see gif at bottom of comments)

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3319](https://jira.vonage.com/browse/VIDCS-3319)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?