### PR TITLE
VIDCS-3386: Add back "yarn buid"

### DIFF
--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -45,6 +45,7 @@ jobs:
           sed -i "s/<DOMAIN>/${DOMAIN}/g" "${{ github.workspace }}/vcr-gha.yml"
           # removing .vcrignore temporarily
           rm .vcrignore
+          yarn build
           vcr deploy --filename vcr-gha.yml --app-id ${{secrets.APP_ID}} --api-key ${{ secrets.VCR_API_KEY }} --api-secret ${{ secrets.VCR_API_SECRET }} --region aws.euw1 --graphql-endpoint https://graphql.euw1.runtime.vonage.cloud/v1/graphql --timeout=15m  2>&1 | tee deploy-vcr-logs.log 
           echo "Checking if the deploy job is successful"
           if grep -Fxq '| Instance has been deployed!' ./deploy-vcr-logs.log ; then


### PR DESCRIPTION
#### What is this PR doing?
Adding back yarn build which wwas removed by mistake on https://github.com/Vonage/vonage-video-react-app/pull/64
My bad sorry

#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3386](https://jira.vonage.com/browse/VIDCS-3386)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?