### PR TITLE
VIDCS-3435: Issue with waiting room on extra-wide viewports

### DIFF
--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
@@ -47,6 +47,8 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
       myVideoElement.style.marginLeft = 'auto';
       myVideoElement.style.marginRight = 'auto';
       myVideoElement.style.transform = 'scaleX(-1)';
+      myVideoElement.style.objectFit = 'contain';
+      myVideoElement.style.aspectRatio = '16 / 9';
       myVideoElement.style.boxShadow =
         '0 1px 2px 0 rgba(60, 64, 67, .3), 0 1px 3px 1px rgba(60, 64, 67, .15)';
 

--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
@@ -47,8 +47,6 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
       myVideoElement.style.marginLeft = 'auto';
       myVideoElement.style.marginRight = 'auto';
       myVideoElement.style.transform = 'scaleX(-1)';
-      myVideoElement.style.objectFit = 'cover';
-      myVideoElement.style.aspectRatio = '1.85 / 1';
       myVideoElement.style.boxShadow =
         '0 1px 2px 0 rgba(60, 64, 67, .3), 0 1px 3px 1px rgba(60, 64, 67, .15)';
 
@@ -60,7 +58,7 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
 
   return (
     <div
-      className="relative max-w-full w-[584px] bg-black h-[25dvh] sm:h-[328px] flex flex-col items-center justify-center md:rounded-xl"
+      className="relative max-w-full w-[584px] bg-black sm:h-[328px] flex flex-col items-center justify-center md:rounded-xl"
       // this was added because overflow: hidden causes issues with rendering
       // see https://stackoverflow.com/questions/77748631/element-rounded-corners-leaking-out-to-front-when-using-overflow-hidden
       style={{ WebkitMask: 'linear-gradient(#000 0 0)' }}

--- a/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
+++ b/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
@@ -6,6 +6,7 @@ import UsernameInput from '../../components/WaitingRoom/UserNameInput';
 import { DEVICE_ACCESS_STATUS } from '../../utils/constants';
 import DeviceAccessAlert from '../../components/DeviceAccessAlert';
 import Banner from '../../components/Banner';
+import useIsSmallViewport from '../../hooks/useIsSmallViewport';
 
 /**
  * WaitingRoom Component
@@ -29,6 +30,7 @@ const WaitingRoom = (): ReactElement => {
   const [openVideoInput, setOpenVideoInput] = useState<boolean>(false);
   const [openAudioOutput, setOpenAudioOutput] = useState<boolean>(false);
   const [username, setUsername] = useState(window.localStorage.getItem('username') ?? '');
+  const isSmallViewport = useIsSmallViewport();
 
   useEffect(() => {
     if (!publisher) {
@@ -84,7 +86,9 @@ const WaitingRoom = (): ReactElement => {
       <div className="flex w-full">
         <div className="w-full flex justify-center mb-8">
           <div className="sm:min-h-[90vh] flex flex-col md:flex-row items-center justify-center w-full">
-            <div className="flex-col max-w-full h-[277px] sm:h-[394px] inline-flex">
+            <div
+              className={`flex-col max-w-full ${isSmallViewport ? '' : 'h-[394px]'} sm: inline-flex`}
+            >
               <VideoContainer username={username} />
               {accessStatus === DEVICE_ACCESS_STATUS.ACCEPTED && (
                 <ControlPanel


### PR DESCRIPTION
#### What is this PR doing?
##### Description
Fixes the regression that Mike found in the waiting room on very large monitors.

##### Screenie/GIF
![waiting-room-fix-v2](https://github.com/user-attachments/assets/0e18ac5c-9755-4978-8a91-759560b20444)

![on-device](https://github.com/user-attachments/assets/be777d00-6aee-45aa-acbc-20e9d611f4e8)


#### How should this be manually tested?
##### waiting room fix
- checkout this branch
- using the dev tools, expand your viewport to `572 x 1476`
- see there's no funky overlap
- expand viewport to max
- shrink viewport, ensuring no funkiness present visually
- check on a mobile device for good measure

##### ensure preview publisher matches meeting room publisher
- create a new meeting room and enter on desktop
- join waiting room on mobile
- note the preview publisher
- join the meeting room
- on desktop, ensure the meeting room subscriber more-or-less matches the mobile preview publisher

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3435](https://jira.vonage.com/browse/VIDCS-3435)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?