### PR TITLE
VIDCS-3445: Bump @vonage/client-sdk-video to 2.29.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^15.0.5",
     "@testing-library/user-event": "^14.5.1",
-    "@vonage/client-sdk-video": "^2.29.0",
+    "@vonage/client-sdk-video": "^2.29.1",
     "@vonage/vcr-sdk": "^1.3.0",
     "autolinker": "^4.0.0",
     "autoprefixer": "^10.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,10 +2386,10 @@
     "@vonage/jwt" "^1.11.0"
     debug "^4.3.4"
 
-"@vonage/client-sdk-video@^2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.0.tgz#055cb4abe8d55d6eb9cfbe6eb74625fd97974f2b"
-  integrity sha512-xpWwD28eC6TTwdBmZ8v/Z2URrNkLxeAl5vg2pLAJOkNgOzXuPw7MM1iKtztbKsao8aSW0pup9eYqVujIR4oc8g==
+"@vonage/client-sdk-video@^2.29.1":
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.1.tgz#c0cb65d7c8c517d1e6a5afab332d231d2596305d"
+  integrity sha512-yu0jILzBexsWvnbzUr5Ykt+fYdrEFnUeffUh1+toTu4Qe1JOh9VOGEqiLkRzo9veEYf8XO6jCr0qMfZV0sO+8Q==
 
 "@vonage/conversations@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
#### What is this PR doing?
Bump @vonage/client-sdk-video to 2.29.1

#### How should this be manually tested?
- check things work including blur

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3445](https://jira.vonage.com/browse/VIDCS-3445)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?