### PR TITLE
VIDCS-3320: Implement chat indicator unread messages on mobile

### DIFF
--- a/frontend/src/components/MeetingRoom/ToolbarOverflowButton/ToolbarOverflowButton.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ToolbarOverflowButton/ToolbarOverflowButton.spec.tsx
@@ -56,10 +56,9 @@ describe('ToolbarOverflowButton', () => {
 
   describe('unread messages', () => {
     it('should show unread message number when number is 8', () => {
-      const unreadCount = 8;
       const sessionContextWithMessages: SessionContextType = {
         ...sessionContext,
-        unreadCount,
+        unreadCount: 8,
       } as unknown as SessionContextType;
       mockUseSessionContext.mockReturnValue(sessionContextWithMessages);
 

--- a/frontend/src/components/MeetingRoom/ToolbarOverflowButton/ToolbarOverflowButton.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ToolbarOverflowButton/ToolbarOverflowButton.spec.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import useSessionContext from '../../../hooks/useSessionContext';
 import { SessionContextType } from '../../../Context/SessionProvider/session';
 import ToolbarOverflowButton from './ToolbarOverflowButton';
@@ -24,6 +24,7 @@ const sessionContext = {
   subscriberWrappers: [],
   layoutMode: 'grid',
   setLayoutMode: vi.fn(),
+  unreadCount: 0,
 } as unknown as SessionContextType;
 
 describe('ToolbarOverflowButton', () => {
@@ -51,5 +52,30 @@ describe('ToolbarOverflowButton', () => {
     expect(screen.queryByTestId('layout-toggle')).toBeVisible();
     expect(screen.queryByTestId('emoji-grid-toggle')).toBeVisible();
     expect(screen.queryByTestId('archiving-toggle')).toBeVisible();
+  });
+
+  describe('unread messages', () => {
+    it('should show unread message number when number is 8', () => {
+      const unreadCount = 8;
+      const sessionContextWithMessages: SessionContextType = {
+        ...sessionContext,
+        unreadCount,
+      } as unknown as SessionContextType;
+      mockUseSessionContext.mockReturnValue(sessionContextWithMessages);
+
+      render(<ToolbarOverflowButton />);
+
+      expect(screen.getByTestId('hidden-toolbar-unread-count')).toBeVisible();
+      expect(screen.getByTestId('hidden-toolbar-unread-count').textContent).toBe('8');
+    });
+
+    it('should not show unread message number when number is 0', () => {
+      render(<ToolbarOverflowButton />);
+
+      const badge = within(screen.getByTestId('hidden-toolbar-unread-count')).getByText('0');
+      // Check badge is hidden:  MUI hides badge by setting dimensions to 0x0
+      expect(badge.offsetHeight).toBe(0);
+      expect(badge.offsetWidth).toBe(0);
+    });
   });
 });

--- a/frontend/src/components/MeetingRoom/ToolbarOverflowButton/ToolbarOverflowButton.tsx
+++ b/frontend/src/components/MeetingRoom/ToolbarOverflowButton/ToolbarOverflowButton.tsx
@@ -1,19 +1,22 @@
 import { ReactElement, useRef, useState } from 'react';
-import { Tooltip } from '@mui/material';
+import { Tooltip, Badge } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import ToolbarButton from '../ToolbarButton';
 import ToolbarOverflowMenu from '../ToolbarOverflowMenu';
+import useSessionContext from '../../../hooks/useSessionContext';
 
 /**
  * ToolbarOverflowButton Component
  *
- * Displays a clickable button that opens a grid of hidden toolbar buttons for smaller viewport devices.
+ * Displays a clickable button that opens a grid of hidden toolbar buttons for smaller viewport devices. There
+ * is an unread chat messages indicator that is shown when there are messages to be viewed.
  * @returns {ReactElement} - The ToolbarOverflowButton Component.
  */
 const ToolbarOverflowButton = (): ReactElement => {
   const anchorRef = useRef<HTMLButtonElement>(null);
   const [isToolbarOverflowMenuOpen, setIsToolbarOverflowMenuOpen] = useState<boolean>(false);
   const [openEmojiGridMobile, setOpenEmojiGridMobile] = useState<boolean>(true);
+  const { unreadCount } = useSessionContext();
 
   const handleButtonToggle = () => {
     setIsToolbarOverflowMenuOpen((prevOpen) => !prevOpen);
@@ -29,16 +32,29 @@ const ToolbarOverflowButton = (): ReactElement => {
         title="Access additional toolbar items"
         aria-label="open additional toolbar items menu"
       >
-        <ToolbarButton
-          data-testid="hidden-toolbar-items"
-          onClick={handleButtonToggle}
-          icon={
-            <MoreVertIcon
-              style={{ color: `${!isToolbarOverflowMenuOpen ? 'white' : 'rgb(138, 180, 248)'}` }}
-            />
-          }
-          ref={anchorRef}
-        />
+        <Badge
+          badgeContent={unreadCount}
+          data-testid="hidden-toolbar-unread-count"
+          invisible={unreadCount === 0}
+          sx={{
+            '& .MuiBadge-badge': {
+              color: 'white',
+              backgroundColor: '#FA7B17',
+            },
+          }}
+          overlap="circular"
+        >
+          <ToolbarButton
+            data-testid="hidden-toolbar-items"
+            onClick={handleButtonToggle}
+            icon={
+              <MoreVertIcon
+                style={{ color: `${!isToolbarOverflowMenuOpen ? 'white' : 'rgb(138, 180, 248)'}` }}
+              />
+            }
+            ref={anchorRef}
+          />
+        </Badge>
       </Tooltip>
       <ToolbarOverflowMenu
         isToolbarOverflowMenuOpen={isToolbarOverflowMenuOpen}


### PR DESCRIPTION
#### What is this PR doing?
Adds chat indicator messages to the overflow toolbar button.

#### How should this be manually tested?
- checkout this branch
- enter a new meeting room on mobile/narrow view and on desktop/normal view
- on desktop, send a chat message
- notice the unread messages indicator appears on mobile
- on mobile window, expand viewport and open the chat
- on mobile window, reduce viewport back to mobile and notice no badge is present

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3320](https://jira.vonage.com/browse/VIDCS-3320)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?