### PR TITLE
VIDCS-3453: Use a consistent orders for the Tailwind CSS classnames, based on the official order

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -60,7 +60,8 @@
           "screen-subscriber"
         ]
       }
-    ]
+    ],
+    "tailwindcss/classnames-order": ["error"]
   },
   "settings": {
     "tailwindcss": {


### PR DESCRIPTION
#### What is this PR doing?

This PR adds "Use a consistent orders for the Tailwind CSS classnames, based on the official order" 

#### How should this be manually tested?

Checkout this branch.
Open any file in the `frontend/` that has `className`s, for example, `frontend/src/components/MeetingRoom/Toolbar/Toolbar.tsx`.
Find some `className`s and change their order. For example, in `Toolbar.tsx` example change line 73 to be:
```
<div className="absolute left-0 bottom-0 flex h-[80px] w-full flex-col items-center bg-darkGray-100 p-4 md:flex-row md:justify-between">
```
if you have the right tools configured in VS code, it'll automatically highlight red for you (compared to yellow in `develop`). 
Save the file. Again, if you have the right tools set up, it'll automatically fix this for you.
But if you do not have the tools, save the file and run `yarn lint` in your terminal. Notice that it is going to fail with the error regarding class name order.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3453](https://jira.vonage.com/browse/VIDCS-3453)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?