### PR TITLE
VIDCS-3459: On mobile, waiting room preview publisher initials widget is displayed over mute buttons

### DIFF
--- a/frontend/src/components/WaitingRoom/PreviewAvatar/PreviewAvatar.tsx
+++ b/frontend/src/components/WaitingRoom/PreviewAvatar/PreviewAvatar.tsx
@@ -28,10 +28,10 @@ const PreviewAvatar = ({
   isVideoEnabled,
   isVideoLoading,
 }: PreviewAvatarProps): ReactElement | null => {
-  const displayWidth = useWindowWidth() * 0.46;
+  const smallDisplayDimensions = useWindowWidth() * 0.46;
   const isSmallViewPort = useIsSmallViewport();
-  const height = isSmallViewPort ? displayWidth : 328;
-  const width = isSmallViewPort ? displayWidth : 584;
+  const height = isSmallViewPort ? smallDisplayDimensions : 328;
+  const width = isSmallViewPort ? smallDisplayDimensions : 584;
   if (isVideoEnabled || isVideoLoading) {
     return null;
   }

--- a/frontend/src/components/WaitingRoom/PreviewAvatar/PreviewAvatar.tsx
+++ b/frontend/src/components/WaitingRoom/PreviewAvatar/PreviewAvatar.tsx
@@ -1,6 +1,7 @@
 import { Avatar } from '@mui/material';
-import { ReactElement } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import AvatarInitials from '../../AvatarInitials';
+import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 
 export type PreviewAvatarProps = {
   username: string;
@@ -26,6 +27,22 @@ const PreviewAvatar = ({
   isVideoEnabled,
   isVideoLoading,
 }: PreviewAvatarProps): ReactElement | null => {
+  const useWindowWidth = () => {
+    const [width, setWidth] = useState(window.innerWidth);
+
+    useEffect(() => {
+      const handleResize = () => setWidth(window.innerWidth);
+      window.addEventListener('resize', handleResize);
+
+      return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    return width;
+  };
+  const displayWidth = useWindowWidth() * 0.46;
+  const isSmallViewPort = useIsSmallViewport();
+  const height = isSmallViewPort ? displayWidth : 328;
+  const width = isSmallViewPort ? displayWidth : 584;
   if (isVideoEnabled || isVideoLoading) {
     return null;
   }
@@ -38,8 +55,8 @@ const PreviewAvatar = ({
         zIndex: isVideoEnabled ? 0 : 1,
       }}
       username={username}
-      height={328}
-      width={584}
+      height={height}
+      width={width}
     />
   ) : (
     <Avatar

--- a/frontend/src/components/WaitingRoom/PreviewAvatar/PreviewAvatar.tsx
+++ b/frontend/src/components/WaitingRoom/PreviewAvatar/PreviewAvatar.tsx
@@ -1,5 +1,6 @@
 import { Avatar } from '@mui/material';
-import { ReactElement, useEffect, useState } from 'react';
+import { ReactElement } from 'react';
+import useWindowWidth from '../../../hooks/useWindowWidth';
 import AvatarInitials from '../../AvatarInitials';
 import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 
@@ -27,18 +28,6 @@ const PreviewAvatar = ({
   isVideoEnabled,
   isVideoLoading,
 }: PreviewAvatarProps): ReactElement | null => {
-  const useWindowWidth = () => {
-    const [width, setWidth] = useState(window.innerWidth);
-
-    useEffect(() => {
-      const handleResize = () => setWidth(window.innerWidth);
-      window.addEventListener('resize', handleResize);
-
-      return () => window.removeEventListener('resize', handleResize);
-    }, []);
-
-    return width;
-  };
   const displayWidth = useWindowWidth() * 0.46;
   const isSmallViewPort = useIsSmallViewport();
   const height = isSmallViewPort ? displayWidth : 328;

--- a/frontend/src/hooks/tests/useWindowWidth.spec.tsx
+++ b/frontend/src/hooks/tests/useWindowWidth.spec.tsx
@@ -1,0 +1,41 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import useWindowWidth from '../useWindowWidth';
+
+describe('useWindowWidth', () => {
+  const nativeWindowInnerWidth = window.innerWidth;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: nativeWindowInnerWidth,
+    });
+  });
+
+  it('should return the initial state', () => {
+    const { result } = renderHook(() => useWindowWidth());
+
+    expect(result.current).toBe(1024);
+  });
+
+  it('should update value on window resize', () => {
+    const newWidth = 768;
+    const { result } = renderHook(() => useWindowWidth());
+
+    act(() => {
+      window.innerWidth = newWidth;
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(result.current).toBe(newWidth);
+  });
+});

--- a/frontend/src/hooks/useWindowWidth.tsx
+++ b/frontend/src/hooks/useWindowWidth.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
 
 /**
- * useWindowWidth
- *
- * Hook to find the current window width.
+ * React hook to find the current window width.
  * @returns {number} - How wide the current window is
  */
 const useWindowWidth = () => {

--- a/frontend/src/hooks/useWindowWidth.tsx
+++ b/frontend/src/hooks/useWindowWidth.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useWindowWidth
+ *
+ * Hook to find the current window width.
+ * @returns {number} - How wide the current window is
+ */
+const useWindowWidth = () => {
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return width;
+};
+
+export default useWindowWidth;


### PR DESCRIPTION
#### What is this PR doing?
##### Description
Fixes the avatar overlapping the video container buttons

##### GIFs 🌱 🌴 
![avatar-fix](https://github.com/user-attachments/assets/97e2e1bc-aafb-4a5e-8d96-62c8531e27ed)


#### How should this be manually tested?
- checkout this branch
- go to waiting room, mute video
- resize from minimum width (360px) up to a desktop viewport
- notice there's no overlap with the video container buttons


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3459](https://jira.vonage.com/browse/VIDCS-3459)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?