### PR TITLE
VIDCS-3463: On mobile, waiting room loading spinner is not present and horizontal scroll

### DIFF
--- a/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
+++ b/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
@@ -71,7 +71,7 @@ const ControlPanel = ({
   };
 
   return (
-    <div className="my-4" data-testid="ControlPanel">
+    <div className="m-auto my-4 max-w-[100dvw]" data-testid="ControlPanel">
       <div className="flex flex-row justify-evenly min-[400px]:w-[400px]">
         <Button
           sx={buttonSx}

--- a/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
+++ b/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.tsx
@@ -71,7 +71,7 @@ const ControlPanel = ({
   };
 
   return (
-    <div className="m-auto my-4" data-testid="ControlPanel">
+    <div className="my-4" data-testid="ControlPanel">
       <div className="flex flex-row justify-evenly min-[400px]:w-[400px]">
         <Button
           sx={buttonSx}

--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
@@ -12,6 +12,7 @@ import PreviewAvatar from '../PreviewAvatar';
 import VoiceIndicatorIcon from '../../MeetingRoom/VoiceIndicator/VoiceIndicator';
 import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 import VignetteEffect from '../VignetteEffect';
+import useWindowWidth from '../../../hooks/useWindowWidth';
 
 export type VideoContainerProps = {
   username: string;
@@ -34,6 +35,10 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
     usePreviewPublisherContext();
   const initials = getInitials(username);
   const isSmallViewport = useIsSmallViewport();
+  const deviceWidth = useWindowWidth();
+  const videoHeight = Math.round((deviceWidth * 9) / 16);
+  const videoHeightClass = `h-[${videoHeight}px]`;
+  const videoContainerClass = `relative flex aspect-video w-[584px] max-w-full flex-col items-center justify-center bg-black sm:h-[328px] md:rounded-xl`;
 
   useEffect(() => {
     if (publisherVideoElement && containerRef.current) {
@@ -42,7 +47,7 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
       myVideoElement.classList.add('video__element');
       myVideoElement.title = 'publisher-preview';
       myVideoElement.style.borderRadius = isSmallViewport ? '0px' : '12px';
-      myVideoElement.style.height = isSmallViewport ? '' : '328px';
+      myVideoElement.style.height = isSmallViewport ? `${videoHeight}px` : '328px';
       myVideoElement.style.width = isSmallViewport ? '100dvw' : '584px';
       myVideoElement.style.marginLeft = 'auto';
       myVideoElement.style.marginRight = 'auto';
@@ -56,11 +61,11 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
         setVideoLoading(false);
       });
     }
-  }, [isSmallViewport, publisherVideoElement]);
+  }, [isSmallViewport, publisherVideoElement, videoHeight]);
 
   return (
     <div
-      className="relative flex w-[584px] max-w-full flex-col items-center justify-center bg-black sm:h-[328px] md:rounded-xl"
+      className={videoContainerClass}
       // this was added because overflow: hidden causes issues with rendering
       // see https://stackoverflow.com/questions/77748631/element-rounded-corners-leaking-out-to-front-when-using-overflow-hidden
       style={{ WebkitMask: 'linear-gradient(#000 0 0)' }}

--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
@@ -12,7 +12,6 @@ import PreviewAvatar from '../PreviewAvatar';
 import VoiceIndicatorIcon from '../../MeetingRoom/VoiceIndicator/VoiceIndicator';
 import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 import VignetteEffect from '../VignetteEffect';
-import useWindowWidth from '../../../hooks/useWindowWidth';
 
 export type VideoContainerProps = {
   username: string;
@@ -35,10 +34,6 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
     usePreviewPublisherContext();
   const initials = getInitials(username);
   const isSmallViewport = useIsSmallViewport();
-  const deviceWidth = useWindowWidth();
-  const videoHeight = Math.round((deviceWidth * 9) / 16);
-  const videoHeightClass = `h-[${videoHeight}px]`;
-  const videoContainerClass = `relative flex aspect-video w-[584px] max-w-full flex-col items-center justify-center bg-black sm:h-[328px] md:rounded-xl`;
 
   useEffect(() => {
     if (publisherVideoElement && containerRef.current) {
@@ -47,7 +42,7 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
       myVideoElement.classList.add('video__element');
       myVideoElement.title = 'publisher-preview';
       myVideoElement.style.borderRadius = isSmallViewport ? '0px' : '12px';
-      myVideoElement.style.height = isSmallViewport ? `${videoHeight}px` : '328px';
+      myVideoElement.style.height = isSmallViewport ? '' : '328px';
       myVideoElement.style.width = isSmallViewport ? '100dvw' : '584px';
       myVideoElement.style.marginLeft = 'auto';
       myVideoElement.style.marginRight = 'auto';
@@ -61,11 +56,11 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
         setVideoLoading(false);
       });
     }
-  }, [isSmallViewport, publisherVideoElement, videoHeight]);
+  }, [isSmallViewport, publisherVideoElement]);
 
   return (
     <div
-      className={videoContainerClass}
+      className="relative flex aspect-video w-[584px] max-w-full flex-col items-center justify-center bg-black sm:h-[328px] md:rounded-xl"
       // this was added because overflow: hidden causes issues with rendering
       // see https://stackoverflow.com/questions/77748631/element-rounded-corners-leaking-out-to-front-when-using-overflow-hidden
       style={{ WebkitMask: 'linear-gradient(#000 0 0)' }}

--- a/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
+++ b/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
@@ -7,7 +7,6 @@ import { DEVICE_ACCESS_STATUS } from '../../utils/constants';
 import DeviceAccessAlert from '../../components/DeviceAccessAlert';
 import Banner from '../../components/Banner';
 import useIsSmallViewport from '../../hooks/useIsSmallViewport';
-import useWindowWidth from '../../hooks/useWindowWidth';
 
 /**
  * WaitingRoom Component
@@ -32,9 +31,6 @@ const WaitingRoom = (): ReactElement => {
   const [openAudioOutput, setOpenAudioOutput] = useState<boolean>(false);
   const [username, setUsername] = useState(window.localStorage.getItem('username') ?? '');
   const isSmallViewport = useIsSmallViewport();
-  const deviceWidth = useWindowWidth();
-  const videoHeight = (deviceWidth * 9) / 16;
-  const videoHeightClass = `h-[${videoHeight}px]`;
 
   useEffect(() => {
     if (!publisher) {
@@ -91,7 +87,7 @@ const WaitingRoom = (): ReactElement => {
         <div className="mb-8 flex w-full justify-center">
           <div className="flex w-full flex-col items-center justify-center sm:min-h-[90vh] md:flex-row">
             <div
-              className={`max-w-full flex-col ${isSmallViewport ? videoHeightClass : 'h-[394px]'} sm: inline-flex`}
+              className={`max-w-full flex-col ${isSmallViewport ? '' : 'h-[394px]'} sm: inline-flex`}
             >
               <VideoContainer username={username} />
               {accessStatus === DEVICE_ACCESS_STATUS.ACCEPTED && (

--- a/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
+++ b/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
@@ -7,6 +7,7 @@ import { DEVICE_ACCESS_STATUS } from '../../utils/constants';
 import DeviceAccessAlert from '../../components/DeviceAccessAlert';
 import Banner from '../../components/Banner';
 import useIsSmallViewport from '../../hooks/useIsSmallViewport';
+import useWindowWidth from '../../hooks/useWindowWidth';
 
 /**
  * WaitingRoom Component
@@ -31,6 +32,9 @@ const WaitingRoom = (): ReactElement => {
   const [openAudioOutput, setOpenAudioOutput] = useState<boolean>(false);
   const [username, setUsername] = useState(window.localStorage.getItem('username') ?? '');
   const isSmallViewport = useIsSmallViewport();
+  const deviceWidth = useWindowWidth();
+  const videoHeight = (deviceWidth * 9) / 16;
+  const videoHeightClass = `h-[${videoHeight}px]`;
 
   useEffect(() => {
     if (!publisher) {
@@ -87,7 +91,7 @@ const WaitingRoom = (): ReactElement => {
         <div className="mb-8 flex w-full justify-center">
           <div className="flex w-full flex-col items-center justify-center sm:min-h-[90vh] md:flex-row">
             <div
-              className={`max-w-full flex-col ${isSmallViewport ? '' : 'h-[394px]'} sm: inline-flex`}
+              className={`max-w-full flex-col ${isSmallViewport ? videoHeightClass : 'h-[394px]'} sm: inline-flex`}
             >
               <VideoContainer username={username} />
               {accessStatus === DEVICE_ACCESS_STATUS.ACCEPTED && (


### PR DESCRIPTION
#### What is this PR doing?
##### Description
Will need to rebase before asking for review. This PR adds the missing loading spinner for mobile devices.

##### GIF
![loading-gif-spinner](https://github.com/user-attachments/assets/602f8e4e-6658-4ff6-80d9-b87db8dfd860)
![viewport-gif](https://github.com/user-attachments/assets/dbb197a9-a523-404f-a3ea-7e35292b3607)

#### How should this be manually tested?
- checkout this branch
- enter waiting room with a mobile view
- ensure loading spinner is there
- ensure there's no horizontal scrolling
- enter waiting room with desktop view and ensure no weirdness

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3463](https://jira.vonage.com/browse/VIDCS-3463)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?