### PR TITLE
VIDCS-3317: In waiting room on mobile, are you speaking alert is not centered

### DIFF
--- a/frontend/src/components/MeetingRoom/AudioControlButton/AudioControlButton.tsx
+++ b/frontend/src/components/MeetingRoom/AudioControlButton/AudioControlButton.tsx
@@ -34,7 +34,7 @@ const AudioControlButton = (): ReactElement => {
 
   return (
     <div className="hidden xs:inline">
-      <MutedAlert anchorRef={anchorRef} />
+      <MutedAlert />
       <ButtonGroup
         className="mr-3 mt-1 bg-notVeryGray-55"
         disableElevation

--- a/frontend/src/components/MutedAlert/MutedAlert.tsx
+++ b/frontend/src/components/MutedAlert/MutedAlert.tsx
@@ -1,9 +1,10 @@
 import Fade from '@mui/material/Fade';
 import { useState, useEffect, ReactElement } from 'react';
-import { Alert, Box } from '@mui/material';
+import { Alert } from '@mui/material';
 import { MUTED_ALERT_MESSAGE, FORCE_MUTED_ALERT_MESSAGE } from '../../utils/constants';
 import useSpeakingDetector from '../../hooks/useSpeakingDetector';
 import usePublisherContext from '../../hooks/usePublisherContext';
+import useIsSmallViewport from '../../hooks/useIsSmallViewport';
 
 /**
  * MutedAlert Component
@@ -13,35 +14,35 @@ import usePublisherContext from '../../hooks/usePublisherContext';
  */
 const MutedAlert = (): ReactElement => {
   const { publisher, isAudioEnabled, isForceMuted } = usePublisherContext();
-  const [open, setOpen] = useState<boolean>(true);
+  const [open, setOpen] = useState<boolean>(false);
   const isSpeakingWhileMuted = useSpeakingDetector({
     isAudioEnabled,
     selectedMicrophoneId: publisher?.getAudioSource()?.id,
   });
+  const isSmallViewport = useIsSmallViewport();
+  const messageToDisplay = isForceMuted ? FORCE_MUTED_ALERT_MESSAGE : MUTED_ALERT_MESSAGE;
 
   useEffect(() => {
     setOpen(isForceMuted || isSpeakingWhileMuted);
   }, [isForceMuted, isSpeakingWhileMuted]);
 
   return (
-    <Box
-      sx={{
-        position: 'absolute',
-        bottom: '96px',
-        display: 'flex',
-        left: '50%',
-        transform: 'translate(-50%, 0%)',
-        width: '100%',
-        maxWidth: '320px',
-      }}
-    >
-      <Fade in={open}>
-        <Alert severity="warning" onClose={() => setOpen(false)}>
-          {isForceMuted && <span>{FORCE_MUTED_ALERT_MESSAGE}</span>}
-          {isSpeakingWhileMuted && !isForceMuted && <span>{MUTED_ALERT_MESSAGE}</span>}
-        </Alert>
-      </Fade>
-    </Box>
+    <Fade in={open}>
+      <Alert
+        severity="warning"
+        onClose={() => setOpen(false)}
+        sx={{
+          position: 'absolute',
+          bottom: isSmallViewport ? '80px' : '96px',
+          left: '50%',
+          transform: 'translate(-50%, 0%)',
+          width: '100%',
+          maxWidth: '320px',
+        }}
+      >
+        {messageToDisplay}
+      </Alert>
+    </Fade>
   );
 };
 

--- a/frontend/src/components/MutedAlert/MutedAlert.tsx
+++ b/frontend/src/components/MutedAlert/MutedAlert.tsx
@@ -5,6 +5,7 @@ import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 import { useTheme } from '@mui/material/styles';
 import { useState, useEffect, RefObject, ReactElement } from 'react';
+import { Alert, Box } from '@mui/material';
 import { MUTED_ALERT_MESSAGE, FORCE_MUTED_ALERT_MESSAGE } from '../../utils/constants';
 import useSpeakingDetector from '../../hooks/useSpeakingDetector';
 import usePublisherContext from '../../hooks/usePublisherContext';
@@ -23,54 +24,74 @@ export type MutedAlertProps = {
  */
 const MutedAlert = ({ anchorRef }: MutedAlertProps): ReactElement => {
   const { publisher, isAudioEnabled, isForceMuted } = usePublisherContext();
-  const [open, setOpen] = useState<boolean>(false);
+  const [open, setOpen] = useState<boolean>(true);
   const isSpeakingWhileMuted = useSpeakingDetector({
     isAudioEnabled,
     selectedMicrophoneId: publisher?.getAudioSource()?.id,
   });
   const theme = useTheme();
 
-  useEffect(() => {
-    setOpen(isForceMuted || isSpeakingWhileMuted);
-  }, [isForceMuted, isSpeakingWhileMuted]);
+  // useEffect(() => {
+  //   setOpen(isForceMuted || isSpeakingWhileMuted);
+  // }, [isForceMuted, isSpeakingWhileMuted]);
 
   return (
-    <Popper open={open} anchorEl={anchorRef.current} placement="top" transition>
-      {({ TransitionProps }) => (
-        <Fade {...TransitionProps} timeout={350}>
-          <Paper
-            sx={{
-              p: 2,
-              backgroundColor: 'rgb(60, 64, 67)',
-              color: '#fff',
-              maxWidth: 300,
-              width: 'auto',
-              borderRadius: 2,
-              boxShadow: 3,
-              fontSize: '0.875rem',
-              transform: 'translateY(-10%) translateX(-40%)',
-              // this is needed to center align on small devices
-              [theme.breakpoints.down(700)]: {
-                transform: 'translateY(-10%) translateX(25%)',
-              },
-            }}
-          >
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              {isForceMuted && <span>{FORCE_MUTED_ALERT_MESSAGE}</span>}
-              {isSpeakingWhileMuted && !isForceMuted && <span>{MUTED_ALERT_MESSAGE}</span>}
-              <IconButton
-                onClick={() => setOpen(false)}
-                sx={{ color: '#fff', padding: 0, marginLeft: 1 }}
-                size="small"
-              >
-                <CloseIcon fontSize="small" />
-              </IconButton>
-            </div>
-          </Paper>
-        </Fade>
-      )}
-    </Popper>
+    <Alert
+      severity="warning"
+      sx={{
+        position: 'absolute',
+        maxWidth: '300px',
+        bottom: '96px',
+      }}
+    >
+      <span>{MUTED_ALERT_MESSAGE}</span>
+      <IconButton
+        onClick={() => setOpen(false)}
+        sx={{ color: '#fff', padding: 0, marginLeft: 1 }}
+        size="small"
+      >
+        <CloseIcon fontSize="small" />
+      </IconButton>
+    </Alert>
   );
+
+  // return (
+  //   <Popper open={open} anchorEl={anchorRef.current} placement="top" transition>
+  //     {({ TransitionProps }) => (
+  //       <Fade {...TransitionProps} timeout={350}>
+  //         <Paper
+  //           sx={{
+  //             p: 2,
+  //             backgroundColor: 'rgb(60, 64, 67)',
+  //             color: '#fff',
+  //             maxWidth: 300,
+  //             width: 'auto',
+  //             borderRadius: 2,
+  //             boxShadow: 3,
+  //             fontSize: '0.875rem',
+  //             transform: 'translateY(-10%) translateX(-40%)',
+  //             // this is needed to center align on small devices
+  //             [theme.breakpoints.down(700)]: {
+  //               transform: 'translateY(-10%) translateX(25%)',
+  //             },
+  //           }}
+  //         >
+  //           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+  //             {/* {isForceMuted && <span>{FORCE_MUTED_ALERT_MESSAGE}</span>} */}
+  //             <span>{MUTED_ALERT_MESSAGE}</span>
+  //             <IconButton
+  //               onClick={() => setOpen(false)}
+  //               sx={{ color: '#fff', padding: 0, marginLeft: 1 }}
+  //               size="small"
+  //             >
+  //               <CloseIcon fontSize="small" />
+  //             </IconButton>
+  //           </div>
+  //         </Paper>
+  //       </Fade>
+  //     )}
+  //   </Popper>
+  // );
 };
 
 export default MutedAlert;

--- a/frontend/src/components/MutedAlert/MutedAlert.tsx
+++ b/frontend/src/components/MutedAlert/MutedAlert.tsx
@@ -1,97 +1,48 @@
-import Paper from '@mui/material/Paper';
-import Popper from '@mui/material/Popper';
 import Fade from '@mui/material/Fade';
-import IconButton from '@mui/material/IconButton';
-import CloseIcon from '@mui/icons-material/Close';
-import { useTheme } from '@mui/material/styles';
-import { useState, useEffect, RefObject, ReactElement } from 'react';
+import { useState, useEffect, ReactElement } from 'react';
 import { Alert, Box } from '@mui/material';
 import { MUTED_ALERT_MESSAGE, FORCE_MUTED_ALERT_MESSAGE } from '../../utils/constants';
 import useSpeakingDetector from '../../hooks/useSpeakingDetector';
 import usePublisherContext from '../../hooks/usePublisherContext';
 
-export type MutedAlertProps = {
-  anchorRef: RefObject<HTMLInputElement>;
-};
-
 /**
  * MutedAlert Component
  *
  * Displays a dismissible notification when the user is speaking while muted or has been muted by another participant.
- * @param {MutedAlertProps} props - The props for the component.
- *  @property {RefObject<HTMLInputElement>} anchorRef - The reference element for the MutedAlert component.
  * @returns {ReactElement} - The MutedAlert component.
  */
-const MutedAlert = ({ anchorRef }: MutedAlertProps): ReactElement => {
+const MutedAlert = (): ReactElement => {
   const { publisher, isAudioEnabled, isForceMuted } = usePublisherContext();
   const [open, setOpen] = useState<boolean>(true);
   const isSpeakingWhileMuted = useSpeakingDetector({
     isAudioEnabled,
     selectedMicrophoneId: publisher?.getAudioSource()?.id,
   });
-  const theme = useTheme();
 
-  // useEffect(() => {
-  //   setOpen(isForceMuted || isSpeakingWhileMuted);
-  // }, [isForceMuted, isSpeakingWhileMuted]);
+  useEffect(() => {
+    setOpen(isForceMuted || isSpeakingWhileMuted);
+  }, [isForceMuted, isSpeakingWhileMuted]);
 
   return (
-    <Alert
-      severity="warning"
+    <Box
       sx={{
         position: 'absolute',
-        maxWidth: '300px',
         bottom: '96px',
+        display: 'flex',
+        left: '50%',
+        transform: 'translate(-50%, 0%)',
+        width: '100%',
+        maxWidth: '320px',
       }}
     >
-      <span>{MUTED_ALERT_MESSAGE}</span>
-      <IconButton
-        onClick={() => setOpen(false)}
-        sx={{ color: '#fff', padding: 0, marginLeft: 1 }}
-        size="small"
-      >
-        <CloseIcon fontSize="small" />
-      </IconButton>
-    </Alert>
+      <Fade in={open}>
+        <Alert severity="warning" onClose={() => setOpen(false)}>
+          {isForceMuted && <span>{FORCE_MUTED_ALERT_MESSAGE}</span>}
+          {isSpeakingWhileMuted && !isForceMuted && <span>{MUTED_ALERT_MESSAGE}</span>}
+        </Alert>
+      </Fade>
+    </Box>
   );
-
-  // return (
-  //   <Popper open={open} anchorEl={anchorRef.current} placement="top" transition>
-  //     {({ TransitionProps }) => (
-  //       <Fade {...TransitionProps} timeout={350}>
-  //         <Paper
-  //           sx={{
-  //             p: 2,
-  //             backgroundColor: 'rgb(60, 64, 67)',
-  //             color: '#fff',
-  //             maxWidth: 300,
-  //             width: 'auto',
-  //             borderRadius: 2,
-  //             boxShadow: 3,
-  //             fontSize: '0.875rem',
-  //             transform: 'translateY(-10%) translateX(-40%)',
-  //             // this is needed to center align on small devices
-  //             [theme.breakpoints.down(700)]: {
-  //               transform: 'translateY(-10%) translateX(25%)',
-  //             },
-  //           }}
-  //         >
-  //           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-  //             {/* {isForceMuted && <span>{FORCE_MUTED_ALERT_MESSAGE}</span>} */}
-  //             <span>{MUTED_ALERT_MESSAGE}</span>
-  //             <IconButton
-  //               onClick={() => setOpen(false)}
-  //               sx={{ color: '#fff', padding: 0, marginLeft: 1 }}
-  //               size="small"
-  //             >
-  //               <CloseIcon fontSize="small" />
-  //             </IconButton>
-  //           </div>
-  //         </Paper>
-  //       </Fade>
-  //     )}
-  //   </Popper>
-  // );
 };
 
 export default MutedAlert;


### PR DESCRIPTION
#### What is this PR doing?
##### Description
Centers the "are you speaking" alert for mobile users. On desktop, the alert isn't really aligned with anything so I centered it there, too. Does some refactoring so the component is easier to read and so it better follows MUI's example.

#### Screenshots and GIFs
![Screenshot 2025-02-27 at 3 32 59 PM](https://github.com/user-attachments/assets/2d9affd9-7a6c-45c0-b6da-07393fc63722)
![Screenshot 2025-02-27 at 3 33 12 PM](https://github.com/user-attachments/assets/22031c11-4baa-453b-b549-f46ea20ac4cf)


#### How should this be manually tested?
- checkout this branch
- enter a meeting room and mute yourself
- on mobile viewport, speak, notice the message looks okay
- on desktop viewport, speak, notice the message looks okay
- have someone else enter the room
- have the force-mute you
- on mobile viewport, speak, notice the message looks okay
- on desktop viewport, speak, notice the message looks okay

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3317](https://jira.vonage.com/browse/VIDCS-3317)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?