### PR TITLE
VIDCS-3477: Bump VERA to use JS SDK 2.29.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^15.0.5",
     "@testing-library/user-event": "^14.5.1",
-    "@vonage/client-sdk-video": "^2.29.1",
+    "@vonage/client-sdk-video": "^2.29.2",
     "@vonage/vcr-sdk": "^1.3.0",
     "autolinker": "^4.0.0",
     "autoprefixer": "^10.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,10 +2386,10 @@
     "@vonage/jwt" "^1.11.0"
     debug "^4.3.4"
 
-"@vonage/client-sdk-video@^2.29.1":
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.1.tgz#c0cb65d7c8c517d1e6a5afab332d231d2596305d"
-  integrity sha512-yu0jILzBexsWvnbzUr5Ykt+fYdrEFnUeffUh1+toTu4Qe1JOh9VOGEqiLkRzo9veEYf8XO6jCr0qMfZV0sO+8Q==
+"@vonage/client-sdk-video@^2.29.2":
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.2.tgz#c552bcd727f9b6f5d72c37f3e0bd8ff1d29ebf37"
+  integrity sha512-4gMWO4vFSkd+LDXuTfha1d3PRmoVIjHgC3lZHWaxui62sQEcN5YqrBd2Xgr4WQ2Z2VEDeoxTHOhB1UxhSbahOg==
 
 "@vonage/conversations@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
#### What is this PR doing?
JS SDK to 2.29.2

#### How should this be manually tested?
- n/a, CI passes

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3477](https://jira.vonage.com/browse/VIDCS-3477)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?