### PR TITLE
VIDCS-3478: Bump VERA version to 1.0.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Express-based backend with authenticated routes.",
   "main": "index.js",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "private": true,
   "description": "React reference application for the Vonage Video web client SDK.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "build": "vite build && yarn cp-build",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-tests",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "integration test workspace for vonage video react app",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vonage-video-react-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "React reference application for the Vonage Video web client SDK.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
#### What is this PR doing?
Bumping version to 1.0.3

#### How should this be manually tested?
- n/a, CI passes

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3478](https://jira.vonage.com/browse/VIDCS-3478)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?