### PR TITLE
VIDCS-3473: Use Popper instead of Menu and close after clicking pin

### DIFF
--- a/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.spec.tsx
@@ -32,6 +32,16 @@ describe('ParticipantListItem', () => {
     mockUseSessionContext.mockImplementation(() => mockSessionContext);
   });
 
+  it('closes menu after clicking menu item', async () => {
+    render(<ParticipantListItemMenu {...defaultProps} />);
+    const menuButton = screen.getByRole('button');
+    await act(() => menuButton.click());
+    expect(screen.getByTestId('pin-menu-item')).toBeVisible();
+    const pinButton = await screen.getByText('Pin John Doe');
+    await act(() => pinButton.click());
+    expect(screen.getByTestId('pin-menu-item')).not.toBeVisible();
+  });
+
   it('can pin participant', async () => {
     render(<ParticipantListItemMenu {...defaultProps} />);
     const menuButton = screen.getByRole('button');

--- a/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.spec.tsx
@@ -39,7 +39,7 @@ describe('ParticipantListItem', () => {
     expect(screen.getByTestId('pin-menu-item')).toBeVisible();
     const pinButton = await screen.getByText('Pin John Doe');
     await act(() => pinButton.click());
-    expect(screen.getByTestId('pin-menu-item')).not.toBeVisible();
+    expect(screen.queryByTestId('pin-menu-item')).not.toBeInTheDocument();
   });
 
   it('can pin participant', async () => {

--- a/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
@@ -37,35 +37,24 @@ const ParticipantListItemMenu = ({
       <IconButton onClick={handleClick} sx={{ marginRight: '-8px' }}>
         <MoreVertIcon sx={{ fontSize: '18px' }} />
       </IconButton>
-      <Popper open={isOpen} anchorEl={anchorEl} transition placement="bottom-start">
-        {({ TransitionProps }: PopperChildrenProps) => (
-          <Grow
-            {...TransitionProps}
-            style={{
-              transformOrigin: 'center bottom',
+      <Popper open={isOpen} anchorEl={anchorEl} placement="bottom-start">
+        <ClickAwayListener onClickAway={handleClose}>
+          <Paper
+            elevation={4}
+            sx={{
+              paddingTop: 1,
+              paddingBottom: 1,
+              borderRadius: 1,
+              position: 'relative',
             }}
           >
-            <div className="text-left font-normal">
-              <ClickAwayListener onClickAway={handleClose}>
-                <Paper
-                  elevation={4}
-                  sx={{
-                    paddingTop: 1,
-                    paddingBottom: 1,
-                    borderRadius: 1,
-                    position: 'relative',
-                  }}
-                >
-                  <ParticipantPinMenuItem
-                    handleClick={handleClose}
-                    subscriberWrapper={subscriberWrapper}
-                    participantName={participantName}
-                  />
-                </Paper>
-              </ClickAwayListener>
-            </div>
-          </Grow>
-        )}
+            <ParticipantPinMenuItem
+              handleClick={handleClose}
+              subscriberWrapper={subscriberWrapper}
+              participantName={participantName}
+            />
+          </Paper>
+        </ClickAwayListener>
       </Popper>
     </>
   );

--- a/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
@@ -1,6 +1,8 @@
 import { useState, MouseEvent, ReactElement } from 'react';
-import { IconButton, Menu } from '@mui/material';
+import { ClickAwayListener, Grow, IconButton, Paper, Popper } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+// import { ClickAwayListener, Popper, PopperChildrenProps } from '@mui/base';
+import { PopperChildrenProps } from '@mui/base';
 import { SubscriberWrapper } from '../../../types/session';
 import ParticipantPinMenuItem from './ParticipantPinMenuItem';
 
@@ -35,21 +37,36 @@ const ParticipantListItemMenu = ({
       <IconButton onClick={handleClick} sx={{ marginRight: '-8px' }}>
         <MoreVertIcon sx={{ fontSize: '18px' }} />
       </IconButton>
-      <Menu
-        anchorEl={anchorEl}
-        open={isOpen}
-        onClose={handleClose}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 250,
-        }}
-      >
-        <ParticipantPinMenuItem
-          handleClick={handleClose}
-          subscriberWrapper={subscriberWrapper}
-          participantName={participantName}
-        />
-      </Menu>
+      <Popper open={isOpen} anchorEl={anchorEl} transition placement="bottom-start">
+        {({ TransitionProps }: PopperChildrenProps) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin: 'center bottom',
+            }}
+          >
+            <div className="text-left font-normal">
+              <ClickAwayListener onClickAway={handleClose}>
+                <Paper
+                  elevation={4}
+                  sx={{
+                    paddingTop: 1,
+                    paddingBottom: 1,
+                    borderRadius: 1,
+                    position: 'relative',
+                  }}
+                >
+                  <ParticipantPinMenuItem
+                    handleClick={handleClose}
+                    subscriberWrapper={subscriberWrapper}
+                    participantName={participantName}
+                  />
+                </Paper>
+              </ClickAwayListener>
+            </div>
+          </Grow>
+        )}
+      </Popper>
     </>
   );
 };

--- a/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
@@ -45,6 +45,7 @@ const ParticipantListItemMenu = ({
         }}
       >
         <ParticipantPinMenuItem
+          handleClick={handleClose}
           subscriberWrapper={subscriberWrapper}
           participantName={participantName}
         />

--- a/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
@@ -1,8 +1,6 @@
 import { useState, MouseEvent, ReactElement } from 'react';
-import { ClickAwayListener, Grow, IconButton, Paper, Popper } from '@mui/material';
+import { ClickAwayListener, IconButton, Paper, Popper } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-// import { ClickAwayListener, Popper, PopperChildrenProps } from '@mui/base';
-import { PopperChildrenProps } from '@mui/base';
 import { SubscriberWrapper } from '../../../types/session';
 import ParticipantPinMenuItem from './ParticipantPinMenuItem';
 

--- a/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantPinMenuItem.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantPinMenuItem.tsx
@@ -6,6 +6,7 @@ import PushPinOffIcon from '../../Icons/PushPinOffIcon';
 import useSessionContext from '../../../hooks/useSessionContext';
 
 export type ParticipantPinMenuItemProps = {
+  handleClick: () => void;
   participantName: string;
   subscriberWrapper: SubscriberWrapper;
 };
@@ -14,11 +15,13 @@ export type ParticipantPinMenuItemProps = {
  * ParticipantPinMenuItem
  * renders a MenuItem button to pin or unpin a participant
  * @param {ParticipantPinMenuItemProps} props - component props.
+ *  @property {Function} handleClick - click handler for item
  *  @property {string} participantName - participant name.
  *  @property {SubscriberWrapper} subscriberWrapper -  The SubscriberWrapper for the participant.
  * @returns {ReactElement} - ParticipantPinMenuItem
  */
 const ParticipantPinMenuItem = ({
+  handleClick,
   participantName,
   subscriberWrapper,
 }: ParticipantPinMenuItemProps): ReactElement => {
@@ -39,9 +42,15 @@ const ParticipantPinMenuItem = ({
     if (!isDisabled) {
       pinSubscriber(id);
     }
+    handleClick();
   };
   return (
-    <MenuItem disabled={isDisabled} sx={{ width: '280px' }} onClick={handlePinClick}>
+    <MenuItem
+      data-testid="pin-menu-item"
+      disabled={isDisabled}
+      sx={{ width: '280px' }}
+      onClick={handlePinClick}
+    >
       <ListItemIcon>
         {isPinned ? (
           <PushPinOffIcon fontSize="small" sx={{ color: 'black' }} />


### PR DESCRIPTION
#### What is this PR doing?
- Change menu behaviour to close after clicking
- Change Menu to Popper, in order to allow interaction with the rest of the page while menu is open

#### How should this be manually tested?
- test pinning, menu should close, pinning/un-pinning should happen as expected
- Other items should be clickable while the menu is open

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3473](https://jira.vonage.com/browse/VIDCS-3473)

#### Checklist
[👍 ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?