### PR TITLE
VIDCS-3491: Report Issue Tooltip should update based on the state

### DIFF
--- a/frontend/src/components/MeetingRoom/ReportIssueButton/ReportIssueButton.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ReportIssueButton/ReportIssueButton.spec.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ReportIssueButton from './ReportIssueButton';
+
+describe('ReportIssueButton', () => {
+  it('should have a white icon when the form is closed', () => {
+    render(<ReportIssueButton handleClick={() => {}} isOpen={false} />);
+    expect(screen.getByTestId('FeedbackIcon')).toHaveStyle('color: rgb(255, 255, 255)');
+  });
+  it('should have a blue icon when the form is open', () => {
+    render(<ReportIssueButton handleClick={() => {}} isOpen />);
+    expect(screen.getByTestId('FeedbackIcon')).toHaveStyle('color: rgb(130, 177, 255)');
+  });
+  it('should invoke callback on click', () => {
+    const handleClick = vi.fn();
+    render(<ReportIssueButton handleClick={handleClick} isOpen />);
+    screen.getByRole('button').click();
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/MeetingRoom/ReportIssueButton/ReportIssueButton.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ReportIssueButton/ReportIssueButton.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import ReportIssueButton from './ReportIssueButton';
 
@@ -16,5 +17,19 @@ describe('ReportIssueButton', () => {
     render(<ReportIssueButton handleClick={handleClick} isOpen />);
     screen.getByRole('button').click();
     expect(handleClick).toHaveBeenCalled();
+  });
+  it('should have a tooltip title that indicates that chat can be opened', async () => {
+    render(<ReportIssueButton handleClick={() => {}} isOpen={false} />);
+    const button = await screen.findByRole('button');
+    await userEvent.hover(button);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Open report issue form');
+  });
+  it('should have a tooltip title that indicates that chat can be closed', async () => {
+    render(<ReportIssueButton handleClick={() => {}} isOpen />);
+    const button = await screen.findByRole('button');
+    await userEvent.hover(button);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Close report issue form');
   });
 });

--- a/frontend/src/components/MeetingRoom/ReportIssueButton/ReportIssueButton.tsx
+++ b/frontend/src/components/MeetingRoom/ReportIssueButton/ReportIssueButton.tsx
@@ -1,6 +1,7 @@
 import { Tooltip } from '@mui/material';
 import { ReactElement, useRef } from 'react';
 import FeedbackIcon from '@mui/icons-material/Feedback';
+import { blue } from '@mui/material/colors';
 import ToolbarButton from '../ToolbarButton';
 import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 
@@ -21,7 +22,10 @@ const ReportIssueButton = ({ handleClick, isOpen }: ReportIssueButtonProps): Rea
   const isSmallViewport = useIsSmallViewport();
   return (
     <div className="pr-3">
-      <Tooltip title="Report issue" aria-label="open report issue menu">
+      <Tooltip
+        title={isOpen ? 'Close report issue form' : 'Open report issue form'}
+        aria-label="toggle report issue form"
+      >
         <ToolbarButton
           data-testid="report-issue-button"
           sx={{
@@ -29,7 +33,7 @@ const ReportIssueButton = ({ handleClick, isOpen }: ReportIssueButtonProps): Rea
             marginRight: '0px',
           }}
           onClick={handleClick}
-          icon={<FeedbackIcon style={{ color: `${!isOpen ? 'white' : 'rgb(138, 180, 248)'}` }} />}
+          icon={<FeedbackIcon sx={{ color: isOpen ? blue.A100 : 'white' }} />}
           ref={anchorRef}
           isSmallViewPort={isSmallViewport}
         />


### PR DESCRIPTION
#### What is this PR doing?

This PR updates the Tooltip for the Report Issue button to be more consistent with other buttons. It also adds tests for the `ReportIssueButton` component.

#### How should this be manually tested?

Checkout this branch.
Hover over the Report Issue button and notice that it says "Open report issue form" -> click on the button.
Hover over the Report Issue button again and notice that it says "Close report issue form".
Notice that this is not the in `develop`. 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3491](https://jira.vonage.com/browse/VIDCS-3491)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?