### PR TITLE
VIDCS-3489: Video tile count fixes

### DIFF
--- a/frontend/src/Context/SessionProvider/session.tsx
+++ b/frontend/src/Context/SessionProvider/session.tsx
@@ -36,6 +36,7 @@ import {
   sortByDisplayPriority,
   togglePinAndSortByDisplayOrder,
 } from '../../utils/sessionStateOperations';
+import { MAX_PIN_COUNT_DESKTOP, MAX_PIN_COUNT_MOBILE } from '../../utils/constants';
 
 export type { ChatMessageType } from '../../types/chat';
 
@@ -134,7 +135,7 @@ export type SessionProviderProps = {
   children: ReactNode;
 };
 
-const MAX_PIN_COUNT = isMobile() ? 1 : 3;
+const MAX_PIN_COUNT = isMobile() ? MAX_PIN_COUNT_MOBILE : MAX_PIN_COUNT_DESKTOP;
 
 /**
  * SessionProvider - React Context Provider for SessionProvider

--- a/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
@@ -47,19 +47,21 @@ const VideoTileCanvas = ({
   const { connected, subscriberWrappers, layoutMode } = useSessionContext();
 
   // Determine if we will display a large video tile based on current layout mode and screenshare presence
-  const isViewingScreenshare = subscriberWrappers.some((subWrapper) => subWrapper.isScreenshare);
-  const sessionHasScreenshare = isViewingScreenshare || isSharingScreen;
-  const isViewingLargeTile = sessionHasScreenshare || layoutMode === 'active-speaker';
   const pinnedSubscriberCount = subscriberWrappers.filter(
     (subWrapper) => subWrapper.isPinned
   ).length;
+  const isViewingScreenshare = subscriberWrappers.some((subWrapper) => subWrapper.isScreenshare);
+  const sessionHasScreenshare = isViewingScreenshare || isSharingScreen;
+  const isViewingLargeTile =
+    sessionHasScreenshare || layoutMode === 'active-speaker' || !!pinnedSubscriberCount;
 
   // Check which subscribers we will display, in large calls we will hide some subscribers
-  const { hiddenSubscribers, subscribersOnScreen } = getSubscribersToDisplay(
+  const { hiddenSubscribers, subscribersOnScreen } = getSubscribersToDisplay({
     subscriberWrappers,
     isViewingLargeTile,
-    !!screensharingPublisher
-  );
+    isSharingScreen: !!screensharingPublisher,
+    pinnedSubscriberCount,
+  });
 
   // We keep track of the current position of subscribers so we can maintain position to avoid subscribers jumping around the screen
   const subscribersInDisplayOrder = useSubscribersInDisplayOrder(subscribersOnScreen);

--- a/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
@@ -57,7 +57,8 @@ const VideoTileCanvas = ({
   // Check which subscribers we will display, in large calls we will hide some subscribers
   const { hiddenSubscribers, subscribersOnScreen } = getSubscribersToDisplay(
     subscriberWrappers,
-    isViewingLargeTile
+    isViewingLargeTile,
+    !!screensharingPublisher
   );
 
   // We keep track of the current position of subscribers so we can maintain position to avoid subscribers jumping around the screen

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -87,3 +87,10 @@ export const SUPPORTED_BROWSERS = [
   { browser: 'Opera', link: 'https://www.opera.com/download' },
   { browser: 'Safari', link: 'https://www.apple.com/safari/' },
 ];
+
+export const MAX_PIN_COUNT_MOBILE = 1;
+export const MAX_PIN_COUNT_DESKTOP = 3;
+export const MAX_TILES_GRID_VIEW_DESKTOP = 11;
+export const MAX_TILES_SPEAKER_VIEW_DESKTOP = 5;
+export const MAX_TILES_GRID_VIEW_MOBILE = 3;
+export const MAX_TILES_SPEAKER_VIEW_MOBILE = 2;

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -88,9 +88,27 @@ export const SUPPORTED_BROWSERS = [
   { browser: 'Safari', link: 'https://www.apple.com/safari/' },
 ];
 
+/**
+ * @constant {number} MAX_PIN_COUNT_MOBILE - the maximum number of pinned participants on mobile
+ */
 export const MAX_PIN_COUNT_MOBILE = 1;
+/**
+ * @constant {number} MAX_PIN_COUNT_DESKTOP - the maximum number of pinned participants on desktop
+ */
 export const MAX_PIN_COUNT_DESKTOP = 3;
+/**
+ * @constant {number} MAX_TILES_GRID_VIEW_DESKTOP - the maximum number of subscriber video tiles in grid view on desktop
+ */
 export const MAX_TILES_GRID_VIEW_DESKTOP = 11;
+/**
+ * @constant {number} MAX_TILES_SPEAKER_VIEW_DESKTOP - the maximum number of subscriber video tiles in active-speaker view on desktop
+ */
 export const MAX_TILES_SPEAKER_VIEW_DESKTOP = 5;
+/**
+ * @constant {number} MAX_TILES_GRID_VIEW_MOBILE - the maximum number of subscriber video tiles in grid view on mobile
+ */
 export const MAX_TILES_GRID_VIEW_MOBILE = 3;
+/**
+ * @constant {number} MAX_TILES_SPEAKER_VIEW_MOBILE - the maximum number of subscriber video tiles in active-speaker view on mobile
+ */
 export const MAX_TILES_SPEAKER_VIEW_MOBILE = 2;

--- a/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/getMaxSubscriberOnScreenCount.spec.ts
+++ b/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/getMaxSubscriberOnScreenCount.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import getMaxSubscriberOnScreenCount from './getMaxSubscriberOnScreenCount';
 import { isMobile } from '../../util';
+import getMaxSubscriberOnScreenCount from './getMaxSubscriberOnScreenCount';
 
 vi.mock('../../util');
 
@@ -15,14 +15,24 @@ describe('getMaxSubscribersOnScreenCount', () => {
     });
     it('should return 2 when viewing large screen', () => {
       const isViewingLargeTile = true;
-      const isPublishingScreenshare = false;
-      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      const isSharingScreen = false;
+      const pinnedSubscriberCount = 0;
+      const max = getMaxSubscriberOnScreenCount({
+        isViewingLargeTile,
+        isSharingScreen,
+        pinnedSubscriberCount,
+      });
       expect(max).toBe(2);
     });
     it('should return 3 when not viewing large screen', () => {
       const isViewingLargeTile = false;
-      const isPublishingScreenshare = false;
-      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      const isSharingScreen = false;
+      const pinnedSubscriberCount = 0;
+      const max = getMaxSubscriberOnScreenCount({
+        isViewingLargeTile,
+        isSharingScreen,
+        pinnedSubscriberCount,
+      });
       expect(max).toBe(3);
     });
   });
@@ -32,21 +42,61 @@ describe('getMaxSubscribersOnScreenCount', () => {
     });
     it('should return 5 when viewing large screen', () => {
       const isViewingLargeTile = true;
-      const isPublishingScreenshare = false;
-      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      const isSharingScreen = false;
+      const pinnedSubscriberCount = 0;
+      const max = getMaxSubscriberOnScreenCount({
+        isViewingLargeTile,
+        isSharingScreen,
+        pinnedSubscriberCount,
+      });
       expect(max).toBe(5);
     });
     it('should return 11 when not viewing large screen', () => {
       const isViewingLargeTile = false;
-      const isPublishingScreenshare = false;
-      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      const isSharingScreen = false;
+      const pinnedSubscriberCount = 0;
+      const max = getMaxSubscriberOnScreenCount({
+        isViewingLargeTile,
+        isSharingScreen,
+        pinnedSubscriberCount,
+      });
       expect(max).toBe(11);
     });
     it('should return 4 when publishing screenshare', () => {
       const isViewingLargeTile = true;
-      const isPublishingScreenshare = true;
-      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      const isSharingScreen = true;
+      const pinnedSubscriberCount = 0;
+      const max = getMaxSubscriberOnScreenCount({
+        isViewingLargeTile,
+        isSharingScreen,
+        pinnedSubscriberCount,
+      });
       expect(max).toBe(4);
+    });
+    it('should adjust count when multiple subscribers are pinned', () => {
+      const isViewingLargeTile = true;
+      const isSharingScreen = false;
+      expect(
+        getMaxSubscriberOnScreenCount({
+          isViewingLargeTile,
+          isSharingScreen,
+          pinnedSubscriberCount: 1,
+        })
+      ).toBe(5);
+      expect(
+        getMaxSubscriberOnScreenCount({
+          isViewingLargeTile,
+          isSharingScreen,
+          pinnedSubscriberCount: 2,
+        })
+      ).toBe(6);
+      expect(
+        getMaxSubscriberOnScreenCount({
+          isViewingLargeTile,
+          isSharingScreen,
+          pinnedSubscriberCount: 3,
+        })
+      ).toBe(7);
     });
   });
 });

--- a/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/getMaxSubscriberOnScreenCount.spec.ts
+++ b/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/getMaxSubscriberOnScreenCount.spec.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import getMaxSubscriberOnScreenCount from './getMaxSubscriberOnScreenCount';
+import { isMobile } from '../../util';
+
+vi.mock('../../util');
+
+describe('getMaxSubscribersOnScreenCount', () => {
+  const mockedIsMobile = vi.mocked(isMobile);
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+  describe('on mobile', () => {
+    beforeEach(() => {
+      mockedIsMobile.mockImplementation(() => true);
+    });
+    it('should return 2 when viewing large screen', () => {
+      const isViewingLargeTile = true;
+      const isPublishingScreenshare = false;
+      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      expect(max).toBe(2);
+    });
+    it('should return 3 when not viewing large screen', () => {
+      const isViewingLargeTile = false;
+      const isPublishingScreenshare = false;
+      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      expect(max).toBe(3);
+    });
+  });
+  describe('on desktop', () => {
+    beforeEach(() => {
+      mockedIsMobile.mockImplementation(() => false);
+    });
+    it('should return 5 when viewing large screen', () => {
+      const isViewingLargeTile = true;
+      const isPublishingScreenshare = false;
+      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      expect(max).toBe(5);
+    });
+    it('should return 11 when not viewing large screen', () => {
+      const isViewingLargeTile = false;
+      const isPublishingScreenshare = false;
+      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      expect(max).toBe(11);
+    });
+    it('should return 4 when publishing screenshare', () => {
+      const isViewingLargeTile = true;
+      const isPublishingScreenshare = true;
+      const max = getMaxSubscriberOnScreenCount(isViewingLargeTile, isPublishingScreenshare);
+      expect(max).toBe(4);
+    });
+  });
+});

--- a/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/getMaxSubscriberOnScreenCount.ts
+++ b/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/getMaxSubscriberOnScreenCount.ts
@@ -6,25 +6,40 @@ import {
 } from '../../constants';
 import { isMobile } from '../../util';
 
+export type GetMaxSubscriberOnScreenCountProps = {
+  isViewingLargeTile: boolean;
+  isSharingScreen: boolean;
+  pinnedSubscriberCount: number;
+};
+
 /**
  * Util to get the maximum number of subscribers we should show on screen based on layout mode and device type
- * @param {boolean} isViewingLargeTile - is there a screenshare of large active speaker tile on screen
- * @param {boolean} isPublishingScreenshare - whether we are publishing screenshare
+ * @param {GetMaxSubscriberOnScreenCountProps} props- function props
+ *  @property {boolean} isViewingLargeTile - is there a screenshare of large active speaker tile on screen
+ *  @property {boolean} isSharingScreen - whether we are publishing screenshare
+ *  @property {boolean} pinnedSubscriberCount - current pinned subscriber count
  * @returns {number} maxSubscriberOnScreenCount - maximum number of subscribers to display
  */
-const getMaxSubscriberOnScreenCount = (
-  isViewingLargeTile: boolean,
-  isPublishingScreenshare: boolean
-): number => {
+const getMaxSubscriberOnScreenCount = ({
+  isViewingLargeTile,
+  isSharingScreen,
+  pinnedSubscriberCount,
+}: GetMaxSubscriberOnScreenCountProps): number => {
   if (isMobile()) {
     return isViewingLargeTile ? MAX_TILES_SPEAKER_VIEW_MOBILE : MAX_TILES_GRID_VIEW_MOBILE;
   }
-  const maxTileCount = isViewingLargeTile
-    ? MAX_TILES_SPEAKER_VIEW_DESKTOP
-    : MAX_TILES_GRID_VIEW_DESKTOP;
 
-  // If we are publishing screenshare we allow one less subscriber on screen
-  return isPublishingScreenshare ? maxTileCount - 1 : maxTileCount;
+  if (!isViewingLargeTile) {
+    return MAX_TILES_GRID_VIEW_DESKTOP;
+  }
+  if (isSharingScreen) {
+    return MAX_TILES_SPEAKER_VIEW_DESKTOP - 1;
+  }
+  if (pinnedSubscriberCount > 1) {
+    // As subscribers are moved to the pinned area, we allow for one more subscriber in the non-pinned are to replace it.
+    return MAX_TILES_SPEAKER_VIEW_DESKTOP + pinnedSubscriberCount - 1;
+  }
+  return MAX_TILES_SPEAKER_VIEW_DESKTOP;
 };
 
 export default getMaxSubscriberOnScreenCount;

--- a/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/getMaxSubscriberOnScreenCount.ts
+++ b/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/getMaxSubscriberOnScreenCount.ts
@@ -1,0 +1,30 @@
+import {
+  MAX_TILES_GRID_VIEW_DESKTOP,
+  MAX_TILES_GRID_VIEW_MOBILE,
+  MAX_TILES_SPEAKER_VIEW_DESKTOP,
+  MAX_TILES_SPEAKER_VIEW_MOBILE,
+} from '../../constants';
+import { isMobile } from '../../util';
+
+/**
+ * Util to get the maximum number of subscribers we should show on screen based on layout mode and device type
+ * @param {boolean} isViewingLargeTile - is there a screenshare of large active speaker tile on screen
+ * @param {boolean} isPublishingScreenshare - whether we are publishing screenshare
+ * @returns {number} maxSubscriberOnScreenCount - maximum number of subscribers to display
+ */
+const getMaxSubscriberOnScreenCount = (
+  isViewingLargeTile: boolean,
+  isPublishingScreenshare: boolean
+): number => {
+  if (isMobile()) {
+    return isViewingLargeTile ? MAX_TILES_SPEAKER_VIEW_MOBILE : MAX_TILES_GRID_VIEW_MOBILE;
+  }
+  const maxTileCount = isViewingLargeTile
+    ? MAX_TILES_SPEAKER_VIEW_DESKTOP
+    : MAX_TILES_GRID_VIEW_DESKTOP;
+
+  // If we are publishing screenshare we allow one less subscriber on screen
+  return isPublishingScreenshare ? maxTileCount - 1 : maxTileCount;
+};
+
+export default getMaxSubscriberOnScreenCount;

--- a/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/index.ts
+++ b/frontend/src/utils/helpers/getMaxSubscriberOnScreenCount/index.ts
@@ -1,0 +1,3 @@
+import getMaxSubscriberOnScreenCount from './getMaxSubscriberOnScreenCount';
+
+export default getMaxSubscriberOnScreenCount;

--- a/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
+++ b/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
@@ -1,32 +1,5 @@
 import { SubscriberWrapper } from '../../../types/session';
-import {
-  MAX_TILES_GRID_VIEW_DESKTOP,
-  MAX_TILES_GRID_VIEW_MOBILE,
-  MAX_TILES_SPEAKER_VIEW_DESKTOP,
-  MAX_TILES_SPEAKER_VIEW_MOBILE,
-} from '../../constants';
-import { isMobile } from '../../util';
-
-/**
- * Util to get the maximum number of subscribers we should show on screen based on layout mode and device type
- * @param {boolean} isViewingLargeTile - is there a screenshare of large active speaker tile on screen
- * @param {boolean} isPublishingScreenshare - whether we are publishing screenshare
- * @returns {number} maxSubscriberOnScreenCount - maximum number of subscribers to display
- */
-const getMaxSubscriberOnScreenCount = (
-  isViewingLargeTile: boolean,
-  isPublishingScreenshare: boolean
-): number => {
-  if (isMobile()) {
-    return isViewingLargeTile ? MAX_TILES_SPEAKER_VIEW_MOBILE : MAX_TILES_GRID_VIEW_MOBILE;
-  }
-  const maxTileCount = isViewingLargeTile
-    ? MAX_TILES_SPEAKER_VIEW_DESKTOP
-    : MAX_TILES_GRID_VIEW_DESKTOP;
-
-  // If we are publishing screenshare we allow one less subscriber on screen
-  return isPublishingScreenshare ? maxTileCount - 1 : maxTileCount;
-};
+import getMaxSubscriberOnScreenCount from '../getMaxSubscriberOnScreenCount';
 
 export type SubscribersToDisplayAndHide = {
   hiddenSubscribers: SubscriberWrapper[];

--- a/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
+++ b/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
@@ -10,13 +10,21 @@ import { isMobile } from '../../util';
 /**
  * Util to get the maximum number of subscribers we should show on screen based on layout mode and device type
  * @param {boolean} isViewingLargeTile - is there a screenshare of large active speaker tile on screen
+ * @param {boolean} isPublishingScreenshare - whether we are publishing screenshare
  * @returns {number} maxSubscriberOnScreenCount - maximum number of subscribers to display
  */
-const getMaxSubscriberOnScreenCount = (isViewingLargeTile: boolean): number => {
+const getMaxSubscriberOnScreenCount = (
+  isViewingLargeTile: boolean,
+  isPublishingScreenshare: boolean
+): number => {
   if (isMobile()) {
     return isViewingLargeTile ? MAX_TILES_SPEAKER_VIEW_MOBILE : MAX_TILES_GRID_VIEW_MOBILE;
   }
-  return isViewingLargeTile ? MAX_TILES_SPEAKER_VIEW_DESKTOP : MAX_TILES_GRID_VIEW_DESKTOP;
+  const maxTileCount = isViewingLargeTile
+    ? MAX_TILES_SPEAKER_VIEW_DESKTOP
+    : MAX_TILES_GRID_VIEW_DESKTOP;
+
+  return isPublishingScreenshare ? maxTileCount - 1 : maxTileCount;
 };
 
 export type SubscribersToDisplayAndHide = {
@@ -28,14 +36,19 @@ export type SubscribersToDisplayAndHide = {
  * Util to separate subscribers into two arrays, the subscribers to display and subscribers that are hidden
  * @param {SubscriberWrapper[]} subscriberWrappers - SubscriberWrapper in display priority order
  * @param {boolean} isViewingLargeTile - is there a large tile (screenshare or active-speaker)
+ * @param {boolean} isPublishingScreenshare - whether we are publishing screenshare
  * @returns {SubscribersToDisplayAndHide} - Subscribers to be hidden and Subscribers to be shown
  * }}
  */
 const getSubscribersToDisplay = (
   subscriberWrappers: SubscriberWrapper[],
-  isViewingLargeTile: boolean
+  isViewingLargeTile: boolean,
+  isPublishingScreenshare: boolean
 ): SubscribersToDisplayAndHide => {
-  const maxSubscribersOnScreenCount = getMaxSubscriberOnScreenCount(isViewingLargeTile);
+  const maxSubscribersOnScreenCount = getMaxSubscriberOnScreenCount(
+    isViewingLargeTile,
+    isPublishingScreenshare
+  );
   const shouldHideSubscribers = subscriberWrappers.length > maxSubscribersOnScreenCount;
 
   // If hiding subscribers we slice at max - 1 to make room for hidden participant tile.

--- a/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
+++ b/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
@@ -24,6 +24,7 @@ const getMaxSubscriberOnScreenCount = (
     ? MAX_TILES_SPEAKER_VIEW_DESKTOP
     : MAX_TILES_GRID_VIEW_DESKTOP;
 
+  // If we are publishing screenshare we allow one less subscriber on screen
   return isPublishingScreenshare ? maxTileCount - 1 : maxTileCount;
 };
 

--- a/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
+++ b/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
@@ -6,23 +6,33 @@ export type SubscribersToDisplayAndHide = {
   subscribersOnScreen: SubscriberWrapper[];
 };
 
+export type GetSubscribersToDisplayProps = {
+  subscriberWrappers: SubscriberWrapper[];
+  isSharingScreen: boolean;
+  pinnedSubscriberCount: number;
+  isViewingLargeTile: boolean;
+};
+
 /**
  * Util to separate subscribers into two arrays, the subscribers to display and subscribers that are hidden
- * @param {SubscriberWrapper[]} subscriberWrappers - SubscriberWrapper in display priority order
- * @param {boolean} isViewingLargeTile - is there a large tile (screenshare or active-speaker)
- * @param {boolean} isPublishingScreenshare - whether we are publishing screenshare
+ * @param {GetSubscribersToDisplayProps} props- function props
+ *  @property {SubscriberWrapper[]} subscriberWrappers - SubscriberWrapper in display priority order
+ *  @property {boolean} isViewingLargeTile - is there a large tile (screenshare or active-speaker)
+ *  @property {boolean} isPublishingScreenshare - whether we are publishing screenshare
  * @returns {SubscribersToDisplayAndHide} - Subscribers to be hidden and Subscribers to be shown
  * }}
  */
-const getSubscribersToDisplay = (
-  subscriberWrappers: SubscriberWrapper[],
-  isViewingLargeTile: boolean,
-  isPublishingScreenshare: boolean
-): SubscribersToDisplayAndHide => {
-  const maxSubscribersOnScreenCount = getMaxSubscriberOnScreenCount(
+const getSubscribersToDisplay = ({
+  subscriberWrappers,
+  isViewingLargeTile,
+  isSharingScreen,
+  pinnedSubscriberCount,
+}: GetSubscribersToDisplayProps): SubscribersToDisplayAndHide => {
+  const maxSubscribersOnScreenCount = getMaxSubscriberOnScreenCount({
     isViewingLargeTile,
-    isPublishingScreenshare
-  );
+    isSharingScreen,
+    pinnedSubscriberCount,
+  });
   const shouldHideSubscribers = subscriberWrappers.length > maxSubscribersOnScreenCount;
 
   // If hiding subscribers we slice at max - 1 to make room for hidden participant tile.

--- a/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
+++ b/frontend/src/utils/helpers/getSubscribersToDisplay/getSubscribersToDisplay.ts
@@ -1,4 +1,10 @@
 import { SubscriberWrapper } from '../../../types/session';
+import {
+  MAX_TILES_GRID_VIEW_DESKTOP,
+  MAX_TILES_GRID_VIEW_MOBILE,
+  MAX_TILES_SPEAKER_VIEW_DESKTOP,
+  MAX_TILES_SPEAKER_VIEW_MOBILE,
+} from '../../constants';
 import { isMobile } from '../../util';
 
 /**
@@ -8,9 +14,9 @@ import { isMobile } from '../../util';
  */
 const getMaxSubscriberOnScreenCount = (isViewingLargeTile: boolean): number => {
   if (isMobile()) {
-    return isViewingLargeTile ? 2 : 3;
+    return isViewingLargeTile ? MAX_TILES_SPEAKER_VIEW_MOBILE : MAX_TILES_GRID_VIEW_MOBILE;
   }
-  return isViewingLargeTile ? 5 : 9;
+  return isViewingLargeTile ? MAX_TILES_SPEAKER_VIEW_DESKTOP : MAX_TILES_GRID_VIEW_DESKTOP;
 };
 
 export type SubscribersToDisplayAndHide = {


### PR DESCRIPTION
#### What is this PR doing?
This PR adds several fixed for layout numbers
- extra constants to constants file
- account for screenshare publisher when deciding how many subscribers to show (previously ignored)
- up grid subscriber number to 11 (total video 12 with publisher)
- Allow more subscribers in the sidebar when more than 1 subscriber is pinned to the large tile area
- fix bug where pinning in grid view allowed the total grid view number of participants when really it should act the same as screenshare/active-speaker view 

#### How should this be manually tested?
- run locally and test all these cases 😬 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3489](https://jira.vonage.com/browse/VIDCS-3489)

#### Checklist
[👍  ] Branch is based on `develop` (not `main`).
[ 👎 ] Resolves a `Known Issue`.
[ 👎 ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ 👎 ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?