### PR TITLE
VIDCS-3505: Change returns to constant in jsdoc

### DIFF
--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -1,14 +1,12 @@
 /**
- * The base URL determined by the current environment.
- * @constant {string}
+ * @constant {string} API_URL - The base URL determined by the current environment.
  */
 export const API_URL = window.location.origin.includes('localhost')
   ? 'http://localhost:3345'
   : window.location.origin;
 
 /**
- * An object representing various states for device access.
- * @constant {object}
+ * @constant {object} DEVICE_ACCESS_STATUS - An object representing various states for device access.
  * @property {string} PENDING - Status when the access to the device is pending.
  * @property {string} ACCEPTED - Status when the access to the device has been granted.
  * @property {string} REJECTED - Status when the access to the device was denied.
@@ -22,59 +20,50 @@ export const DEVICE_ACCESS_STATUS = {
 };
 
 /**
- * A message to alert the user that their microphone is muted.
- * @constant {string}
+ * @constant {string} MUTED_ALERT_MESSAGE - A message to alert the user that their microphone is muted.
  */
 export const MUTED_ALERT_MESSAGE =
   'Are you talking? Your mic is off. Click on the mic to turn it on.';
 
 /**
- * A message to alert the user that their microphone was muted by another participant.
- * @constant {string}
+ * @constant {string} FORCE_MUTED_ALERT_MESSAGE - A message to alert the user that their microphone was muted by another participant.
  */
 export const FORCE_MUTED_ALERT_MESSAGE =
   'You have been muted by another participant. Click on the mic to unmute yourself.';
 
 /**
- * A user-friendly message alerting the user of publishing issues.
- * @constant {string}
+ * @constant {string} PUBLISHING_BLOCKED_CAPTION - A user-friendly message alerting the user of publishing issues.
  */
 export const PUBLISHING_BLOCKED_CAPTION =
   "We're having trouble connecting you with others in the meeting room. Please check your network and try again.";
 
 /**
- * The text shadow style used for display purposes.
- * @constant {string}
+ * @constant {string} TEXT_SHADOW - The text shadow style used for display purposes.
  */
 export const TEXT_SHADOW = '[text-shadow:_0_1px_2px_rgb(0_0_0_/_60%)]';
 
 /**
- * The duration in milliseconds for which emojis are displayed.
- * @constant {number}
+ * @constant {number} EMOJI_DISPLAY_DURATION - The duration in milliseconds for which emojis are displayed.
  */
 export const EMOJI_DISPLAY_DURATION = 5_000;
 
 /**
- * The maximum number of characters allowed in the Report Issue form for the title input.
- * @constant {number}
+ * @constant {number} REPORT_TITLE_LIMIT - The maximum number of characters allowed in the Report Issue form for the title input.
  */
 export const REPORT_TITLE_LIMIT = 100;
 
 /**
- * The maximum number of characters allowed in the Report Issue form for the name input.
- * @constant {number}
+ * @constant {number} REPORT_NAME_LIMIT - The maximum number of characters allowed in the Report Issue form for the name input.
  */
 export const REPORT_NAME_LIMIT = 100;
 
 /**
- * The maximum number of characters allowed in the Report Issue form for the description input.
- * @constant {number}
+ * @constant {number} REPORT_DESCRIPTION_LIMIT - The maximum number of characters allowed in the Report Issue form for the description input.
  */
 export const REPORT_DESCRIPTION_LIMIT = 1000;
 
 /**
- * An object representing the browser name and link to download it
- * @constant {object}
+ * @constant {object} SupportedBrowser - An object representing the browser name and link to download it
  * @property {string} browser - The browser name.
  * @property {string} link - The link to download the said browser.
  */
@@ -84,8 +73,7 @@ export type SupportedBrowser = {
 };
 
 /**
- * The browsers supported by Vonage Video API Reference App, and their download links.
- * @constant {SupportedBrowser[]}
+ * @constant {SupportedBrowser[]} SUPPORTED_BROWSERS - The browsers supported by Vonage Video API Reference App, and their download links.
  */
 export const SUPPORTED_BROWSERS = [
   { browser: 'Chrome', link: 'https://www.google.com/chrome/' },

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -1,6 +1,6 @@
 /**
  * The base URL determined by the current environment.
- * @returns {string}
+ * @constant {string}
  */
 export const API_URL = window.location.origin.includes('localhost')
   ? 'http://localhost:3345'
@@ -8,7 +8,7 @@ export const API_URL = window.location.origin.includes('localhost')
 
 /**
  * An object representing various states for device access.
- * @returns {object}
+ * @constant {object}
  * @property {string} PENDING - Status when the access to the device is pending.
  * @property {string} ACCEPTED - Status when the access to the device has been granted.
  * @property {string} REJECTED - Status when the access to the device was denied.
@@ -23,62 +23,69 @@ export const DEVICE_ACCESS_STATUS = {
 
 /**
  * A message to alert the user that their microphone is muted.
- * @returns {string}
+ * @constant {string}
  */
 export const MUTED_ALERT_MESSAGE =
   'Are you talking? Your mic is off. Click on the mic to turn it on.';
 
 /**
  * A message to alert the user that their microphone was muted by another participant.
- * @returns {string}
+ * @constant {string}
  */
 export const FORCE_MUTED_ALERT_MESSAGE =
   'You have been muted by another participant. Click on the mic to unmute yourself.';
 
 /**
  * A user-friendly message alerting the user of publishing issues.
- * @returns {string}
+ * @constant {string}
  */
 export const PUBLISHING_BLOCKED_CAPTION =
   "We're having trouble connecting you with others in the meeting room. Please check your network and try again.";
 
 /**
  * The text shadow style used for display purposes.
- * @returns {string}
+ * @constant {string}
  */
 export const TEXT_SHADOW = '[text-shadow:_0_1px_2px_rgb(0_0_0_/_60%)]';
 
 /**
  * The duration in milliseconds for which emojis are displayed.
- * @returns {number}
+ * @constant {number}
  */
 export const EMOJI_DISPLAY_DURATION = 5_000;
 
 /**
  * The maximum number of characters allowed in the Report Issue form for the title input.
- * @returns {number}
+ * @constant {number}
  */
 export const REPORT_TITLE_LIMIT = 100;
 
 /**
  * The maximum number of characters allowed in the Report Issue form for the name input.
- * @returns {number}
+ * @constant {number}
  */
 export const REPORT_NAME_LIMIT = 100;
 
 /**
  * The maximum number of characters allowed in the Report Issue form for the description input.
- * @returns {number}
+ * @constant {number}
  */
 export const REPORT_DESCRIPTION_LIMIT = 1000;
 
+/**
+ * An object representing the browser name and link to download it
+ * @constant {object}
+ * @property {string} browser - The browser name.
+ * @property {string} link - The link to download the said browser.
+ */
 export type SupportedBrowser = {
   browser: string;
   link: string;
 };
+
 /**
  * The browsers supported by Vonage Video API Reference App, and their download links.
- * @returns {SupportedBrowser[]}
+ * @constant {SupportedBrowser[]}
  */
 export const SUPPORTED_BROWSERS = [
   { browser: 'Chrome', link: 'https://www.google.com/chrome/' },

--- a/frontend/tsdoc.json
+++ b/frontend/tsdoc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": [
+    "typedoc/tsdoc.json"
+  ],
+  "noStandardTags": false,
+  "tagDefinitions": [
+    {
+      "tagName": "@constant",
+      "syntaxKind": "block"
+    }
+  ]
+}


### PR DESCRIPTION
#### What is this PR doing?

This PR changes `@returns` to `@contant` in our `contstants.tsx` file but it also required some changes to how the docs get generated when using `yarn docs` since `@consant` is not one of the built-in ones recognized by the `typedoc` library.

#### How should this be manually tested?

Checkout this branch.
In your terminal, run `yarn docs.`
Notice that there are no warnings in your terminal related to the `@constant` tag - there might be some other warnings but it's not related to this PR.

The docs are going to be generated for you in `frontend/docs` -> open the `index.html` folder. 
Go to `utils` -> `constants.`
Verify that you see the `Constant` on the page. 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3505](https://jira.vonage.com/browse/VIDCS-3505)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?