### PR TITLE
VIDCS-3511: Resolve VERA Security Vulnerability

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "@vonage/vcr-sdk": "^1.3.0",
     "autolinker": "^4.0.0",
     "autoprefixer": "^10.4.19",
-    "axios": "^1.7.8",
+    "axios": "^1.8.2",
     "events": "^3.3.0",
     "lodash": "^4.17.21",
     "opentok-layout-js": "^5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2883,7 +2883,7 @@ axe-core@=4.7.0:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
 
-axios@^1.2.1, axios@^1.6.3, axios@^1.7.8:
+axios@^1.2.1, axios@^1.6.3, axios@^1.7.8, axios@^1.8.2:
   version "1.7.9"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
   integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==


### PR DESCRIPTION
#### What is this PR doing?

axios needs to be upgraded to `^1.8.2` to fix the security issue [mentioned here](https://security.snyk.io/vuln/SNYK-JS-AXIOS-9292519).

#### How should this be manually tested?

Checkout this branch.
Ensure that the functionality that requires the backend works - creating sessions (by joining meeting from two tabs), starting archives. 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3511](https://jira.vonage.com/browse/VIDCS-3511)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?