### PR TITLE
VIDCS-3490: Hide the badge on the menu button when the menu is open and we already see the chat badge

### DIFF
--- a/frontend/src/components/MeetingRoom/ToolbarOverflowButton/ToolbarOverflowButton.tsx
+++ b/frontend/src/components/MeetingRoom/ToolbarOverflowButton/ToolbarOverflowButton.tsx
@@ -31,7 +31,7 @@ const ToolbarOverflowButton = (): ReactElement => {
         title="Access additional toolbar items"
         aria-label="open additional toolbar items menu"
       >
-        <UnreadMessagesBadge>
+        <UnreadMessagesBadge isToolbarOverflowMenuOpen={isToolbarOverflowMenuOpen}>
           <ToolbarButton
             data-testid="hidden-toolbar-items"
             onClick={handleButtonToggle}

--- a/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
+++ b/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
@@ -122,7 +122,40 @@ describe('UnreadMessagesBadge', () => {
     );
 
     // the badge remains hidden since the overflow toolbar is currently opened
+    expect(screen.getByTestId('chat-button-unread-count').offsetHeight).toBe(0);
+    expect(screen.getByTestId('chat-button-unread-count').offsetWidth).toBe(0);
+  });
+
+  it('should show the unread message badge when a new message comes in and the toolbar was opened at first but is now closed', () => {
+    let sessionContextWithMessages: SessionContextType = {
+      ...sessionContext,
+      unreadCount: 0,
+    } as unknown as SessionContextType;
+    mockUseSessionContext.mockReturnValue(sessionContextWithMessages);
+    const { rerender } = render(
+      <UnreadMessagesBadge isToolbarOverflowMenuOpen>
+        <LittleButton />
+      </UnreadMessagesBadge>
+    );
+
+    const badge = screen.getByTestId('chat-button-unread-count');
+    // Check badge is hidden:  MUI hides badge by setting dimensions to 0x0
     expect(badge.offsetHeight).toBe(0);
     expect(badge.offsetWidth).toBe(0);
+
+    // a new message comes in and toolbar has been closed
+    sessionContextWithMessages = {
+      ...sessionContext,
+      unreadCount: 1,
+    } as unknown as SessionContextType;
+    mockUseSessionContext.mockReturnValue(sessionContextWithMessages);
+    rerender(
+      <UnreadMessagesBadge isToolbarOverflowMenuOpen={false}>
+        <LittleButton />
+      </UnreadMessagesBadge>
+    );
+
+    expect(screen.getByTestId('chat-button-unread-count')).toBeVisible();
+    expect(screen.getByTestId('chat-button-unread-count').textContent).toBe('1');
   });
 });

--- a/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
+++ b/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
@@ -75,6 +75,24 @@ describe('UnreadMessagesBadge', () => {
   });
 
   it('should not show unread message badge when message count is non zero and the toolbar is open', () => {
+    const sessionContextWithMessages: SessionContextType = {
+      ...sessionContext,
+      unreadCount: 8,
+    } as unknown as SessionContextType;
+    mockUseSessionContext.mockReturnValue(sessionContextWithMessages);
+    render(
+      <UnreadMessagesBadge isToolbarOverflowMenuOpen>
+        <LittleButton />
+      </UnreadMessagesBadge>
+    );
+
+    const badge = screen.getByTestId('chat-button-unread-count');
+    // Check badge is hidden:  MUI hides badge by setting dimensions to 0x0
+    expect(badge.offsetHeight).toBe(0);
+    expect(badge.offsetWidth).toBe(0);
+  });
+
+  it('should not show unread message badge when a new message comes in and the toolbar is open', () => {
     let sessionContextWithMessages: SessionContextType = {
       ...sessionContext,
       unreadCount: 0,
@@ -104,24 +122,6 @@ describe('UnreadMessagesBadge', () => {
     );
 
     // the badge remains hidden since the overflow toolbar is currently opened
-    expect(badge.offsetHeight).toBe(0);
-    expect(badge.offsetWidth).toBe(0);
-  });
-
-  it('should not show unread message badge when a new message comes in and the toolbar is open', () => {
-    const sessionContextWithMessages: SessionContextType = {
-      ...sessionContext,
-      unreadCount: 8,
-    } as unknown as SessionContextType;
-    mockUseSessionContext.mockReturnValue(sessionContextWithMessages);
-    render(
-      <UnreadMessagesBadge isToolbarOverflowMenuOpen>
-        <LittleButton />
-      </UnreadMessagesBadge>
-    );
-
-    const badge = screen.getByTestId('chat-button-unread-count');
-    // Check badge is hidden:  MUI hides badge by setting dimensions to 0x0
     expect(badge.offsetHeight).toBe(0);
     expect(badge.offsetWidth).toBe(0);
   });

--- a/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
+++ b/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
@@ -61,7 +61,7 @@ describe('UnreadMessagesBadge', () => {
     expect(badge.offsetWidth).toBe(0);
   });
 
-  it('should not show unread message number when number is 0 and the toolbar is open', () => {
+  it('should not show unread message badge when message count is 0 and the toolbar is open', () => {
     render(
       <UnreadMessagesBadge isToolbarOverflowMenuOpen>
         <LittleButton />
@@ -74,7 +74,41 @@ describe('UnreadMessagesBadge', () => {
     expect(badge.offsetWidth).toBe(0);
   });
 
-  it('should not show unread message number when number is non zero and the toolbar is open', () => {
+  it('should not show unread message badge when message count is non zero and the toolbar is open', () => {
+    let sessionContextWithMessages: SessionContextType = {
+      ...sessionContext,
+      unreadCount: 0,
+    } as unknown as SessionContextType;
+    mockUseSessionContext.mockReturnValue(sessionContextWithMessages);
+    const { rerender } = render(
+      <UnreadMessagesBadge isToolbarOverflowMenuOpen>
+        <LittleButton />
+      </UnreadMessagesBadge>
+    );
+
+    const badge = screen.getByTestId('chat-button-unread-count');
+    // Check badge is hidden:  MUI hides badge by setting dimensions to 0x0
+    expect(badge.offsetHeight).toBe(0);
+    expect(badge.offsetWidth).toBe(0);
+
+    // a new message comes in
+    sessionContextWithMessages = {
+      ...sessionContext,
+      unreadCount: 1,
+    } as unknown as SessionContextType;
+    mockUseSessionContext.mockReturnValue(sessionContextWithMessages);
+    rerender(
+      <UnreadMessagesBadge isToolbarOverflowMenuOpen>
+        <LittleButton />
+      </UnreadMessagesBadge>
+    );
+
+    // the badge remains hidden since the overflow toolbar is currently opened
+    expect(badge.offsetHeight).toBe(0);
+    expect(badge.offsetWidth).toBe(0);
+  });
+
+  it('should not show unread message badge when a new message comes in and the toolbar is open', () => {
     const sessionContextWithMessages: SessionContextType = {
       ...sessionContext,
       unreadCount: 8,

--- a/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
+++ b/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
@@ -60,4 +60,35 @@ describe('UnreadMessagesBadge', () => {
     expect(badge.offsetHeight).toBe(0);
     expect(badge.offsetWidth).toBe(0);
   });
+
+  it('should not show unread message number when number is 0 and the toolbar is open', () => {
+    render(
+      <UnreadMessagesBadge isToolbarOverflowMenuOpen>
+        <LittleButton />
+      </UnreadMessagesBadge>
+    );
+
+    const badge = screen.getByTestId('chat-button-unread-count');
+    // Check badge is hidden:  MUI hides badge by setting dimensions to 0x0
+    expect(badge.offsetHeight).toBe(0);
+    expect(badge.offsetWidth).toBe(0);
+  });
+
+  it('should not show unread message number when number is non zero and the toolbar is open', () => {
+    const sessionContextWithMessages: SessionContextType = {
+      ...sessionContext,
+      unreadCount: 8,
+    } as unknown as SessionContextType;
+    mockUseSessionContext.mockReturnValue(sessionContextWithMessages);
+    render(
+      <UnreadMessagesBadge isToolbarOverflowMenuOpen>
+        <LittleButton />
+      </UnreadMessagesBadge>
+    );
+
+    const badge = screen.getByTestId('chat-button-unread-count');
+    // Check badge is hidden:  MUI hides badge by setting dimensions to 0x0
+    expect(badge.offsetHeight).toBe(0);
+    expect(badge.offsetWidth).toBe(0);
+  });
 });

--- a/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
+++ b/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.spec.tsx
@@ -122,8 +122,9 @@ describe('UnreadMessagesBadge', () => {
     );
 
     // the badge remains hidden since the overflow toolbar is currently opened
-    expect(screen.getByTestId('chat-button-unread-count').offsetHeight).toBe(0);
-    expect(screen.getByTestId('chat-button-unread-count').offsetWidth).toBe(0);
+    const updatedBadge = screen.getByTestId('chat-button-unread-count');
+    expect(updatedBadge.offsetHeight).toBe(0);
+    expect(updatedBadge.offsetWidth).toBe(0);
   });
 
   it('should show the unread message badge when a new message comes in and the toolbar was opened at first but is now closed', () => {
@@ -155,7 +156,8 @@ describe('UnreadMessagesBadge', () => {
       </UnreadMessagesBadge>
     );
 
-    expect(screen.getByTestId('chat-button-unread-count')).toBeVisible();
-    expect(screen.getByTestId('chat-button-unread-count').textContent).toBe('1');
+    const updatedBadge = screen.getByTestId('chat-button-unread-count');
+    expect(updatedBadge).toBeVisible();
+    expect(updatedBadge.textContent).toBe('1');
   });
 });

--- a/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.tsx
+++ b/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.tsx
@@ -22,13 +22,13 @@ const UnreadMessagesBadge = forwardRef(function UnreadMessagesBadge(
 ) {
   const { children, isToolbarOverflowMenuOpen, ...rest } = props;
   const { unreadCount } = useSessionContext();
-  const isMessageCountBadgeInvisible = unreadCount === 0 || isToolbarOverflowMenuOpen;
+  const isInvisible = unreadCount === 0 || isToolbarOverflowMenuOpen;
   return (
     <Badge
       {...rest}
       badgeContent={unreadCount}
       data-testid="chat-button-unread-count"
-      invisible={isMessageCountBadgeInvisible}
+      invisible={isInvisible}
       sx={{
         '& .MuiBadge-badge': {
           color: 'white',

--- a/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.tsx
+++ b/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.tsx
@@ -4,6 +4,7 @@ import useSessionContext from '../../../hooks/useSessionContext';
 
 export type UnreadMessagesBadgeProps = {
   children: ReactElement;
+  isToolbarOverflowMenuOpen?: boolean;
 };
 
 /**
@@ -12,21 +13,22 @@ export type UnreadMessagesBadgeProps = {
  * Displays a badge indicating the number of unread chat messages.
  * @param {UnreadMessagesBadgeProps} props - the props for the component
  *  @property {ReactElement} children - the ToolbarButton to be rendered
+ *  @property {boolean} isToolbarOverflowMenuOpen - (optional) indicates whether the overflow menu was opened
  * @returns {ReactElement} - The UnreadMessagesBadge component
  */
 const UnreadMessagesBadge = forwardRef(function UnreadMessagesBadge(
   props: UnreadMessagesBadgeProps,
   ref: ForwardedRef<HTMLSpanElement>
 ) {
-  const { children, ...rest } = props;
+  const { children, isToolbarOverflowMenuOpen, ...rest } = props;
   const { unreadCount } = useSessionContext();
-
+  const shouldDisplayMessageCount = unreadCount === 0 || isToolbarOverflowMenuOpen;
   return (
     <Badge
       {...rest}
       badgeContent={unreadCount}
       data-testid="chat-button-unread-count"
-      invisible={unreadCount === 0}
+      invisible={shouldDisplayMessageCount}
       sx={{
         '& .MuiBadge-badge': {
           color: 'white',

--- a/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.tsx
+++ b/frontend/src/components/MeetingRoom/UnreadMessagesBadge/UnreadMessagesBadge.tsx
@@ -22,13 +22,13 @@ const UnreadMessagesBadge = forwardRef(function UnreadMessagesBadge(
 ) {
   const { children, isToolbarOverflowMenuOpen, ...rest } = props;
   const { unreadCount } = useSessionContext();
-  const shouldDisplayMessageCount = unreadCount === 0 || isToolbarOverflowMenuOpen;
+  const isMessageCountBadgeInvisible = unreadCount === 0 || isToolbarOverflowMenuOpen;
   return (
     <Badge
       {...rest}
       badgeContent={unreadCount}
       data-testid="chat-button-unread-count"
-      invisible={shouldDisplayMessageCount}
+      invisible={isMessageCountBadgeInvisible}
       sx={{
         '& .MuiBadge-badge': {
           color: 'white',


### PR DESCRIPTION
#### What is this PR doing?

This PR hides the badge on the menu button when the menu is open and we already see the chat badge. 

before the change:
![before](https://github.com/user-attachments/assets/525cba40-076c-4418-8969-8fde2ad87ea5)

after the change:
![after](https://github.com/user-attachments/assets/18b7a623-8fb3-44fd-b989-130e7ab9951c)


#### How should this be manually tested?

Checkout this branch.
Open one tab in a mobile view, another tab can be in a regular desktop view.
Type up a message in a desktop tab. 
Navigate to the mobile view tab, and notice that there is an unread message badge on the "kebab" menu button.
Notice that the notification on the kebab menu disappears when you click on it.
If you click on the kebab menu again, it shows up again unless you navigate to the Chat tab and "read" the message. 


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3490](https://jira.vonage.com/browse/VIDCS-3490)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?