### PR TITLE
VIDCS-3522: Fix mend issue Base64 High Entropy String

### DIFF
--- a/vcr-gha.yml
+++ b/vcr-gha.yml
@@ -16,7 +16,9 @@ instance:
       secret: VONAGE_PRIVATE_KEY
     - name: OT_API_KEY
       secret: OT_API_KEY
+    # pragma: allowlist secret
     - name: OT_API_SECRET
+      # pragma: allowlist secret
       secret: OT_API_SECRET
     - name: VITE_ENABLE_REPORT_ISSUE
       secret: VITE_ENABLE_REPORT_ISSUE


### PR DESCRIPTION
#### What is this PR doing?
This PR adds OT_API_SECRET to the allowlist to prevent false positives during mend's secret scanning. Hence closing the mend scan issue: https://github.com/Vonage/vonage-video-react-app/issues/82

I found [this which points to ignoring the string](https://github.com/Yelp/detect-secrets/issues/693)


#### How should this be manually tested?
Not sure how we can test this one, I think the only way is to merge it in and hope the issue is closed.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3522](https://jira.vonage.com/browse/VIDCS-3522)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?