### PR TITLE
VIDCS-3539: Replace some mui/base imports to be more consistent

### DIFF
--- a/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridDesktop.tsx
+++ b/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridDesktop.tsx
@@ -1,6 +1,6 @@
-import { Grid, Grow, Paper, Popper } from '@mui/material';
+import { Grid, Grow, Paper, Popper, ClickAwayListener } from '@mui/material';
 import { ReactElement, RefObject } from 'react';
-import { ClickAwayListener, PopperChildrenProps } from '@mui/base';
+import { PopperChildrenProps } from '@mui/base';
 import SendEmojiButton from '../SendEmojiButton';
 import emojiMap from '../../../utils/emojis';
 

--- a/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridMobile.tsx
+++ b/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridMobile.tsx
@@ -1,5 +1,4 @@
-import { Box, Grid, Grow, Portal } from '@mui/material';
-import { ClickAwayListener } from '@mui/base';
+import { Box, Grid, Grow, Portal, ClickAwayListener } from '@mui/material';
 import { ReactElement } from 'react';
 import SendEmojiButton from '../SendEmojiButton';
 import emojiMap from '../../../utils/emojis';

--- a/frontend/src/components/MeetingRoom/ToolbarOverflowMenu/ToolbarOverflowMenu.tsx
+++ b/frontend/src/components/MeetingRoom/ToolbarOverflowMenu/ToolbarOverflowMenu.tsx
@@ -1,5 +1,4 @@
-import { ClickAwayListener, Portal } from '@mui/base';
-import { Box, Grow } from '@mui/material';
+import { ClickAwayListener, Portal, Box, Grow } from '@mui/material';
 import { Dispatch, ReactElement, SetStateAction } from 'react';
 import ArchivingButton from '../ArchivingButton';
 import EmojiGridButton from '../EmojiGridButton';


### PR DESCRIPTION
#### What is this PR doing?

This PR moves some imports from being imported from `@mui/base` to `@mui/material` to be more consistent with other imports.

#### How should this be manually tested?

Checkout this branch.
Ensure that the "kebab" menu opens up on mobile
Ensure that you are able to send emoji on desktop/mobile.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3539](https://jira.vonage.com/browse/VIDCS-3539)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?