### PR TITLE
VIDCS-3548: Console warning regarding anchorEl

### DIFF
--- a/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGrid.spec.tsx
+++ b/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGrid.spec.tsx
@@ -54,7 +54,7 @@ describe('EmojiGrid', () => {
     it('displays emoji grid when open', () => {
       render(<TestComponent defaultOpenEmojiGrid />);
 
-      expect(screen.queryByTestId('send-emoji-button')).toBeVisible();
+      expect(screen.getByTestId('send-emoji-button')).toBeVisible();
     });
 
     it('displays nothing when closed', () => {

--- a/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGrid.tsx
+++ b/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGrid.tsx
@@ -6,7 +6,7 @@ import EmojiGridDesktop from './EmojiGridDesktop';
 export type EmojiGridProps = {
   isEmojiGridOpen: boolean;
   setIsEmojiGridOpen: Dispatch<SetStateAction<boolean>>;
-  anchorRef: RefObject<HTMLButtonElement | null>;
+  anchorRef: RefObject<HTMLButtonElement>;
   isParentOpen: boolean;
 };
 

--- a/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGrid.tsx
+++ b/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGrid.tsx
@@ -6,7 +6,7 @@ import EmojiGridDesktop from './EmojiGridDesktop';
 export type EmojiGridProps = {
   isEmojiGridOpen: boolean;
   setIsEmojiGridOpen: Dispatch<SetStateAction<boolean>>;
-  anchorRef: RefObject<HTMLButtonElement>;
+  anchorRef: RefObject<HTMLButtonElement | null>;
   isParentOpen: boolean;
 };
 

--- a/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridDesktop.tsx
+++ b/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridDesktop.tsx
@@ -1,5 +1,5 @@
 import { Grid, Grow, Paper, Popper, ClickAwayListener } from '@mui/material';
-import { ReactElement, RefObject } from 'react';
+import { ReactElement, RefObject, useEffect, useState } from 'react';
 import { PopperChildrenProps } from '@mui/base';
 import SendEmojiButton from '../SendEmojiButton';
 import emojiMap from '../../../utils/emojis';
@@ -18,64 +18,76 @@ export type EmojiGridDesktopProps = {
  *  @property {(event: MouseEvent | TouchEvent) => void} handleClickAway - handles clicking away from the emoji grid
  *  @property {boolean} isEmojiGridOpen - whether the component is open
  *  @property {RefObject<HTMLButtonElement | null>} anchorRef - the button ref for the grid
- * @returns {ReactElement | null} - The EmojiGridDesktop Component
+ * @returns {ReactElement | false} - The EmojiGridDesktop Component
  */
 
 const EmojiGridDesktop = ({
   handleClickAway,
   isEmojiGridOpen,
   anchorRef,
-}: EmojiGridDesktopProps): ReactElement | null =>
-  anchorRef.current && (
-    <Popper
-      open={isEmojiGridOpen}
-      anchorEl={anchorRef.current}
-      transition
-      disablePortal
-      placement="bottom"
-    >
-      {({ TransitionProps, placement }: PopperChildrenProps) => (
-        <Grow
-          {...TransitionProps}
-          style={{
-            transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
-          }}
-        >
-          <div className="flex text-left font-normal">
-            <ClickAwayListener onClickAway={handleClickAway}>
-              <Paper
-                className="flex items-center justify-center"
-                data-testid="emoji-grid"
-                sx={{
-                  backgroundColor: 'rgb(32, 33, 36)',
-                  color: '#fff',
-                  padding: { xs: 1 },
-                  borderRadius: 2,
-                  zIndex: 1,
-                  transform: 'translateY(-5%)',
-                  // Each button is 66px, 8px left and right padding = 280px
-                  maxWidth: '280px',
-                  position: 'relative',
-                }}
-              >
-                <Grid
-                  container
-                  spacing={0}
-                  display={isEmojiGridOpen ? 'flex' : 'none'}
+}: EmojiGridDesktopProps): ReactElement | false => {
+  const [isRendered, setIsRendered] = useState<boolean>(false);
+  useEffect(() => {
+    // useRef is not immediately assigned on first render
+    // We ensure the component renders only after the anchorRef is assigned
+    if (anchorRef.current) {
+      setIsRendered(true);
+    }
+  }, [anchorRef]);
+
+  return (
+    isRendered && (
+      <Popper
+        open={isEmojiGridOpen}
+        anchorEl={anchorRef.current}
+        transition
+        disablePortal
+        placement="bottom"
+      >
+        {({ TransitionProps, placement }: PopperChildrenProps) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
+            }}
+          >
+            <div className="flex text-left font-normal">
+              <ClickAwayListener onClickAway={handleClickAway}>
+                <Paper
+                  className="flex items-center justify-center"
+                  data-testid="emoji-grid"
                   sx={{
-                    width: '100%',
+                    backgroundColor: 'rgb(32, 33, 36)',
+                    color: '#fff',
+                    padding: { xs: 1 },
+                    borderRadius: 2,
+                    zIndex: 1,
+                    transform: 'translateY(-5%)',
+                    // Each button is 66px, 8px left and right padding = 280px
+                    maxWidth: '280px',
+                    position: 'relative',
                   }}
                 >
-                  {Object.values(emojiMap).map((emoji) => (
-                    <SendEmojiButton key={emoji} emoji={emoji} />
-                  ))}
-                </Grid>
-              </Paper>
-            </ClickAwayListener>
-          </div>
-        </Grow>
-      )}
-    </Popper>
+                  <Grid
+                    container
+                    spacing={0}
+                    display={isEmojiGridOpen ? 'flex' : 'none'}
+                    sx={{
+                      width: '100%',
+                    }}
+                  >
+                    {Object.values(emojiMap).map((emoji) => (
+                      <SendEmojiButton key={emoji} emoji={emoji} />
+                    ))}
+                  </Grid>
+                </Paper>
+              </ClickAwayListener>
+            </div>
+          </Grow>
+        )}
+      </Popper>
+    )
   );
+};
 
 export default EmojiGridDesktop;

--- a/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridDesktop.tsx
+++ b/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridDesktop.tsx
@@ -18,63 +18,63 @@ export type EmojiGridDesktopProps = {
  *  @property {(event: MouseEvent | TouchEvent) => void} handleClickAway - handles clicking away from the emoji grid
  *  @property {boolean} isEmojiGridOpen - whether the component is open
  *  @property {RefObject<HTMLButtonElement | null>} anchorRef - the button ref for the grid
- * @returns {ReactElement} - The EmojiGridDesktop Component
+ * @returns {ReactElement | null} - The EmojiGridDesktop Component
  */
 
 const EmojiGridDesktop = ({
   handleClickAway,
   isEmojiGridOpen,
   anchorRef,
-}: EmojiGridDesktopProps): ReactElement => (
-  <Popper
-    open={isEmojiGridOpen}
-    anchorEl={anchorRef.current}
-    transition
-    disablePortal
-    placement="bottom"
-  >
-    {({ TransitionProps, placement }: PopperChildrenProps) => (
-      <Grow
-        {...TransitionProps}
-        style={{
-          transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
-        }}
-      >
-        <div className="flex text-left font-normal">
-          <ClickAwayListener onClickAway={handleClickAway}>
-            <Paper
-              className="flex items-center justify-center"
-              data-testid="emoji-grid"
-              sx={{
-                backgroundColor: 'rgb(32, 33, 36)',
-                color: '#fff',
-                padding: { xs: 1 },
-                borderRadius: 2,
-                zIndex: 1,
-                transform: 'translateY(-5%)',
-                // Each button is 66px, 8px left and right padding = 280px
-                maxWidth: '280px',
-                position: 'relative',
-              }}
-            >
-              <Grid
-                container
-                spacing={0}
-                display={isEmojiGridOpen ? 'flex' : 'none'}
+}: EmojiGridDesktopProps): ReactElement | null =>
+  anchorRef.current && (
+    <Popper
+      open={isEmojiGridOpen}
+      anchorEl={anchorRef.current}
+      transition
+      disablePortal
+      placement="bottom"
+    >
+      {({ TransitionProps, placement }: PopperChildrenProps) => (
+        <Grow
+          {...TransitionProps}
+          style={{
+            transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
+          }}
+        >
+          <div className="flex text-left font-normal">
+            <ClickAwayListener onClickAway={handleClickAway}>
+              <Paper
+                className="flex items-center justify-center"
+                data-testid="emoji-grid"
                 sx={{
-                  width: '100%',
+                  backgroundColor: 'rgb(32, 33, 36)',
+                  color: '#fff',
+                  padding: { xs: 1 },
+                  borderRadius: 2,
+                  zIndex: 1,
+                  transform: 'translateY(-5%)',
+                  // Each button is 66px, 8px left and right padding = 280px
+                  maxWidth: '280px',
+                  position: 'relative',
                 }}
               >
-                {Object.values(emojiMap).map((emoji) => (
-                  <SendEmojiButton key={emoji} emoji={emoji} />
-                ))}
-              </Grid>
-            </Paper>
-          </ClickAwayListener>
-        </div>
-      </Grow>
-    )}
-  </Popper>
-);
-
+                <Grid
+                  container
+                  spacing={0}
+                  display={isEmojiGridOpen ? 'flex' : 'none'}
+                  sx={{
+                    width: '100%',
+                  }}
+                >
+                  {Object.values(emojiMap).map((emoji) => (
+                    <SendEmojiButton key={emoji} emoji={emoji} />
+                  ))}
+                </Grid>
+              </Paper>
+            </ClickAwayListener>
+          </div>
+        </Grow>
+      )}
+    </Popper>
+  );
 export default EmojiGridDesktop;

--- a/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridDesktop.tsx
+++ b/frontend/src/components/MeetingRoom/EmojiGrid/EmojiGridDesktop.tsx
@@ -77,4 +77,5 @@ const EmojiGridDesktop = ({
       )}
     </Popper>
   );
+
 export default EmojiGridDesktop;


### PR DESCRIPTION
#### What is this PR doing?
Resolves an annoying console warning due to the `ref` being `null` on initial render.

#### How should this be manually tested?
##### Reproing issue
- checkout `develop`
- open console
- go to a room
- see warning regarding `anchorEl`

##### Verifying fix
- checkout this branch, `cpettet/vidcs-3548-console-warning`
- open console
- go to a room
- verify there's no `anchorEl` warning

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3548](https://jira.vonage.com/browse/VIDCS-3548)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?