### PR TITLE
VIDCS-3566: Remove unnecessary logs from vera CI

### DIFF
--- a/integration-tests/fixtures/testWithLogging.ts
+++ b/integration-tests/fixtures/testWithLogging.ts
@@ -16,14 +16,15 @@ const baseURL = 'http://127.0.0.1:3345/';
 const addLogger = (page: Page, context: BrowserContext) => {
   // Get page index to help identify which tab logs are coming from
   const index = context.pages().length;
-  // log only errors of Console Messages to node console
+  // log all page Console Messages to node console
   page.on('console', (msg) => {
-    if (msg.type() === 'error') {
-      console.error(`Browser console error from page ${index}: ${msg.text()}`);
-    }
+    console.log(`Browser console ${msg.type()} from page ${index}: ${msg.text()}`);
   });
   // log all uncaught page errors to node console
   page.on('pageerror', (err) => {
+    if (err.message.includes('too much recursion')) {
+      return; // Ignore this error
+    }
     console.error(`Browser uncaught error from page ${index}: "${err.message}" - ${err.stack}`);
   });
   return page;

--- a/integration-tests/fixtures/testWithLogging.ts
+++ b/integration-tests/fixtures/testWithLogging.ts
@@ -24,9 +24,6 @@ const addLogger = (page: Page, context: BrowserContext) => {
   });
   // log all uncaught page errors to node console
   page.on('pageerror', (err) => {
-    if (err.message.includes('too much recursion')) {
-      return; // Ignore this error
-    }
     console.error(`Browser uncaught error from page ${index}: "${err.message}" - ${err.stack}`);
   });
   return page;

--- a/integration-tests/fixtures/testWithLogging.ts
+++ b/integration-tests/fixtures/testWithLogging.ts
@@ -16,9 +16,11 @@ const baseURL = 'http://127.0.0.1:3345/';
 const addLogger = (page: Page, context: BrowserContext) => {
   // Get page index to help identify which tab logs are coming from
   const index = context.pages().length;
-  // log all page Console Messages to node console
+  // log only errors of Console Messages to node console
   page.on('console', (msg) => {
-    console.log(`Browser console ${msg.type()} from page ${index}: ${msg.text()}`);
+    if (msg.type() === 'error') {
+      console.error(`Browser console error from page ${index}: ${msg.text()}`);
+    }
   });
   // log all uncaught page errors to node console
   page.on('pageerror', (err) => {

--- a/integration-tests/fixtures/testWithLogging.ts
+++ b/integration-tests/fixtures/testWithLogging.ts
@@ -16,9 +16,11 @@ const baseURL = 'http://127.0.0.1:3345/';
 const addLogger = (page: Page, context: BrowserContext) => {
   // Get page index to help identify which tab logs are coming from
   const index = context.pages().length;
-  // log all page Console Messages to node console
+  // log all page Console Message errors to node console
   page.on('console', (msg) => {
-    console.log(`Browser console ${msg.type()} from page ${index}: ${msg.text()}`);
+    if (msg.type() === 'error') {
+      console.error(`Browser console error from page ${index}: ${msg.text()}`);
+    }
   });
   // log all uncaught page errors to node console
   page.on('pageerror', (err) => {


### PR DESCRIPTION
#### What is this PR doing?
Remove unnecessary logs.
Currently, [we are getting so many logs](https://github.com/Vonage/vonage-video-react-app/actions/runs/14089483964/job/39462290295#step:15:44), this PR logs only browser console errors to CI logs.

#### How should this be manually tested?
Notice the _integration tests_ logs are shorter.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3566](https://jira.vonage.com/browse/VIDCS-3566)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?