### PR TITLE
VIDCS-3584: VERA version bump and VIDCS-3587: OT version bump

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Express-based backend with authenticated routes.",
   "main": "index.js",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^15.0.5",
     "@testing-library/user-event": "^14.5.1",
-    "@vonage/client-sdk-video": "^2.29.2",
+    "@vonage/client-sdk-video": "^2.29.3",
     "@vonage/vcr-sdk": "^1.3.0",
     "autolinker": "^4.0.0",
     "autoprefixer": "^10.4.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "private": true,
   "description": "React reference application for the Vonage Video web client SDK.",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "build": "vite build && yarn cp-build",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-tests",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "integration test workspace for vonage video react app",
   "main": "main.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,10 +2386,10 @@
     "@vonage/jwt" "^1.11.0"
     debug "^4.3.4"
 
-"@vonage/client-sdk-video@^2.29.2":
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.2.tgz#c552bcd727f9b6f5d72c37f3e0bd8ff1d29ebf37"
-  integrity sha512-4gMWO4vFSkd+LDXuTfha1d3PRmoVIjHgC3lZHWaxui62sQEcN5YqrBd2Xgr4WQ2Z2VEDeoxTHOhB1UxhSbahOg==
+"@vonage/client-sdk-video@^2.29.3":
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.3.tgz#6ba9528027d2f3000ea2b45a91e55e3618a61233"
+  integrity sha512-C+y79+d/j194N4rJ1lEViwz5gzOBQYBWWPeUMg/sIpM4xGyMAiFjQttZs/D2c1jaxbGWiIVrj8n/r3JL+ftEGg==
 
 "@vonage/conversations@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
#### What is this PR doing?

This PR bumps up VERA version to 2.29.3 and OT version to 2.29.3

#### How should this be manually tested?

n/a, CI passes.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3584](https://jira.vonage.com/browse/VIDCS-3584)
Resolves [VIDCS-3587](https://jira.vonage.com/browse/VIDCS-3587)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?