### PR TITLE
VIDCS-3492: VERA waiting room has horizontal scroll on MBP screen (but not external monitor)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,7 +2,7 @@
   margin: 0 auto;
   text-align: center;
   height: 100dvh;
-  width: 100dvw;
+  width: 100%;
 }
 
 /*

--- a/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
+++ b/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
@@ -84,7 +84,7 @@ const WaitingRoom = (): ReactElement => {
     <div className="flex size-full flex-col bg-white" data-testid="waitingRoom">
       <Banner />
       <div className="flex w-full">
-        <div className="mb-8 flex w-full justify-center">
+        <div className="flex w-full justify-center">
           <div className="flex w-full flex-col items-center justify-center sm:min-h-[90vh] md:flex-row">
             <div
               className={`max-w-full flex-col ${isSmallViewport ? '' : 'h-[394px]'} sm: inline-flex`}


### PR DESCRIPTION
#### What is this PR doing?
##### Description
There was some horizontal scroll on low video height windows caused by the vertical scrollbar. This PR eliminates the vertical scrollbar for *most* screens and eliminates horizontal scroll in all screens.

##### After
<img width="954" alt="new-and-improved" src="https://github.com/user-attachments/assets/0d83425f-dfe0-4ef3-8e80-70bca390623d" />

##### Before
<img width="954" alt="old-and-bad" src="https://github.com/user-attachments/assets/6cea7683-bebd-4bec-a262-373d603575e2" />


#### How should this be manually tested?
##### Repro'ing bug
- go to the locally deployed VERA in a tab on your MBP's screen
- go to a waiting room
- notice there's a horizontal scrollbar, and a vertical scrollbar

##### Verifying fix
- checkout this branch
- go to a waiting room, again using your MBP's screen
- notice there's no horizontal scrollbar and no vertical scrollbar

##### Verifying nothing was broken
- please go through whole flow of: landing --> waiting room --> meeting room --> goodbye
- repeat on mobile

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3492](https://jira.vonage.com/browse/VIDCS-3492)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?