### PR TITLE
VIDCS-3603: Build app on VCR

### DIFF
--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Deploy vcr
         run: |
-          yarn build
+          # yarn build
           sed -i "s/<DOMAIN>/${DOMAIN}/g" "${{ github.workspace }}/vcr-gha.yml"
           # removing .vcrignore so that build files are sent to VCR
           # rm .vcrignore

--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -45,7 +45,7 @@ jobs:
           yarn build
           sed -i "s/<DOMAIN>/${DOMAIN}/g" "${{ github.workspace }}/vcr-gha.yml"
           # removing .vcrignore so that build files are sent to VCR
-          rm .vcrignore
+          # rm .vcrignore
           vcr deploy --filename vcr-gha.yml --app-id ${{secrets.APP_ID}} --api-key ${{ secrets.VCR_API_KEY }} --api-secret ${{ secrets.VCR_API_SECRET }} --region aws.euw1 --graphql-endpoint https://graphql.euw1.runtime.vonage.cloud/v1/graphql --timeout=15m  2>&1 | tee deploy-vcr-logs.log 
           echo "Checking if the deploy job is successful"
           if grep -Fxq '| Instance has been deployed!' ./deploy-vcr-logs.log ; then

--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -2,9 +2,9 @@ name: Deploy to VCR
 
 on:
   pull_request:
-    # branches:
-    #   - develop
-    # types: [closed]
+    branches:
+      - develop
+    types: [closed]
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-test:
-    # if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: [vcp-runner]
 
     steps:
@@ -28,11 +28,6 @@ jobs:
           node-version: 22.4
           cache: npm
 
-      - name: Install Dependencies
-        run: |
-          node -v
-          npm -v
-
       - name: Install VCR CLI
         run: |
           sudo curl -L https://raw.githubusercontent.com/Vonage/cloud-runtime-cli/main/script/install.sh | sudo sh
@@ -40,7 +35,7 @@ jobs:
 
       - name: Deploy vcr
         run: |
-          sed -i "s/<DOMAIN>/${DOMAIN}/g" "${{ github.workspace }}/vcr-gha.yml" .vcrignore
+          sed -i "s/<DOMAIN>/${DOMAIN}/g" "${{ github.workspace }}/vcr-gha.yml"
           vcr deploy --filename vcr-gha.yml --app-id ${{secrets.APP_ID}} --api-key ${{ secrets.VCR_API_KEY }} --api-secret ${{ secrets.VCR_API_SECRET }} --region aws.euw1 --graphql-endpoint https://graphql.euw1.runtime.vonage.cloud/v1/graphql --timeout=15m  2>&1 | tee deploy-vcr-logs.log 
           echo "Checking if the deploy job is successful"
           if grep -Fxq '| Instance has been deployed!' ./deploy-vcr-logs.log ; then

--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -2,9 +2,9 @@ name: Deploy to VCR
 
 on:
   pull_request:
-    branches:
-      - develop
-    types: [closed]
+    # branches:
+    #   - develop
+    # types: [closed]
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-test:
-    if: github.event.pull_request.merged == true
+    # if: github.event.pull_request.merged == true
     runs-on: [vcp-runner]
 
     steps:

--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -10,7 +10,6 @@ permissions:
   contents: read
 
 env:
-  VITE_ENABLE_REPORT_ISSUE: ${{secrets.VITE_ENABLE_REPORT_ISSUE}}
   DOMAIN: ${{secrets.DOMAIN}}
 
 jobs:

--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -32,8 +32,6 @@ jobs:
         run: |
           node -v
           npm -v
-          npm install --global yarn
-          yarn
 
       - name: Install VCR CLI
         run: |
@@ -42,10 +40,7 @@ jobs:
 
       - name: Deploy vcr
         run: |
-          # yarn build
-          sed -i "s/<DOMAIN>/${DOMAIN}/g" "${{ github.workspace }}/vcr-gha.yml"
-          # removing .vcrignore so that build files are sent to VCR
-          # rm .vcrignore
+          sed -i "s/<DOMAIN>/${DOMAIN}/g" "${{ github.workspace }}/vcr-gha.yml" .vcrignore
           vcr deploy --filename vcr-gha.yml --app-id ${{secrets.APP_ID}} --api-key ${{ secrets.VCR_API_KEY }} --api-secret ${{ secrets.VCR_API_SECRET }} --region aws.euw1 --graphql-endpoint https://graphql.euw1.runtime.vonage.cloud/v1/graphql --timeout=15m  2>&1 | tee deploy-vcr-logs.log 
           echo "Checking if the deploy job is successful"
           if grep -Fxq '| Instance has been deployed!' ./deploy-vcr-logs.log ; then

--- a/.vcrignore
+++ b/.vcrignore
@@ -26,5 +26,6 @@ server.csr
 coverage/
 
 /.vscode
+build
 
 /scripts/allLicenseResults.json

--- a/.vcrignore
+++ b/.vcrignore
@@ -26,6 +26,5 @@ server.csr
 coverage/
 
 /.vscode
-build
 
 /scripts/allLicenseResults.json

--- a/vcr-gha.yml
+++ b/vcr-gha.yml
@@ -5,7 +5,7 @@ instance:
   runtime: nodejs22
   region: aws.euw1
   entrypoint: [yarn, run-server]
-  build-script: './vcrBuild.sh'
+  build-script: './vcrGhaBuild.sh'
   # The placeholder <DOMAIN> will be replaced by sed in .github/workflows/deploy-to-vcr.yml
   domains: <DOMAIN>
   environment:

--- a/vcr-gha.yml
+++ b/vcr-gha.yml
@@ -5,6 +5,7 @@ instance:
   runtime: nodejs22
   region: aws.euw1
   entrypoint: [yarn, run-server]
+  build-script: './vcrBuild.sh'
   # The placeholder <DOMAIN> will be replaced by sed in .github/workflows/deploy-to-vcr.yml
   domains: <DOMAIN>
   environment:

--- a/vcrGhaBuild.sh
+++ b/vcrGhaBuild.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script is used to install dependencies and build the app in the machine used by VCR 
+# rather than uploading the build built locally
+# https://developer.vonage.com/en/vonage-cloud-runtime/guides/manifest#build-script
+
+# run install skipping post install script which requires husky
+export VITE_ENABLE_REPORT_ISSUE=true
+
+yarn install --ignore-scripts
+
+yarn build


### PR DESCRIPTION
#### What is this PR doing?
Moving to Build App on VCR.
Also, needed to add VITE_ENABLE_REPORT_ISSUE on `vcrGhaBuild.sh` so that it is accessible on vcr when it builds the app.

This cuts down on the deployment time from 14 to 6 minutes, which has started giving timeout issues issues.

#### How should this be manually tested?
n/a
See, logs of a successful job before the cleanup commit: https://github.com/Vonage/vonage-video-react-app/actions/runs/14245728258/job/39926074602?pr=141

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3603](https://jira.vonage.com/browse/VIDCS-3603)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?