### PR TITLE
VIDCS-3641: Ensure auto-commit of screenshots runs regardless of previous step failures

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -117,7 +117,7 @@ jobs:
           yarn test:integrationUpdateScreenshots
 
       - name: Auto-commit updated screenshots
-        if: steps.check-update-screenshots.outputs.result == 'true'
+        if: always() && steps.check-update-screenshots.outputs.result == 'true'
         run: |
           echo "Committing screenshots to "$BRANCH_NAME""
           FILES_CHANGED=$(git status --porcelain | awk '{print $2}')


### PR DESCRIPTION
#### What is this PR doing?
This PR updates the workflow to ensure the Auto-commit updated screenshots step runs even if earlier steps fail. 
Ex: https://github.com/Vonage/vonage-video-react-app/actions/runs/14385670298/job/40340361059

#### How should this be manually tested?
n/a

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3641](https://jira.vonage.com/browse/VIDCS-3641)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?