### PR TITLE
VIDCS-3650: Remove unused ts-expect-error in VERA usePreviewPublisher

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,8 +42,7 @@
         "caughtErrors": "all",
         "caughtErrorsIgnorePattern": "^_",
         "destructuredArrayIgnorePattern": "^_",
-        "varsIgnorePattern": "^_",
-        "ignoreRestSiblings": true
+        "varsIgnorePattern": "^_"
       }
     ],
     "react/function-component-definition": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,22 @@
     // custom rules
     "@typescript-eslint/lines-between-class-members": "off",
     "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-throw-literal": "off",
     "@typescript-eslint/no-explicit-any": "error",
+    // we need to disable the "base" rule to avoid conflicts
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "args": "all",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "caughtErrorsIgnorePattern": "^_",
+        "destructuredArrayIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "ignoreRestSiblings": true
+      }
+    ],
     "react/function-component-definition": "off",
     "no-console": "off",
     "curly": ["error", "all"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,8 +34,6 @@
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-throw-literal": "off",
     "@typescript-eslint/no-explicit-any": "error",
-    // we need to disable the "base" rule to avoid conflicts
-    "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/backend/routes/feedback.ts
+++ b/backend/routes/feedback.ts
@@ -13,8 +13,9 @@ feedbackRouter.post('/report', async (req: Request, res: Response) => {
       return res.status(200).json({ feedbackData });
     }
     return res.status(500).json({ message: 'Failed to create a report ticket' });
-  } catch (_error) {
-    return res.status(500).json({ message: 'Error reporting issue' });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : error;
+    return res.status(500).json({ message: `Error reporting issue: ${message}` });
   }
 });
 

--- a/backend/routes/feedback.ts
+++ b/backend/routes/feedback.ts
@@ -13,7 +13,7 @@ feedbackRouter.post('/report', async (req: Request, res: Response) => {
       return res.status(200).json({ feedbackData });
     }
     return res.status(500).json({ message: 'Failed to create a report ticket' });
-  } catch (error) {
+  } catch (_error) {
     return res.status(500).json({ message: 'Error reporting issue' });
   }
 });

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -19,7 +19,7 @@ app.use(bodyParser.json());
 app.set('trust proxy', true);
 app.use(router);
 
-app.use((req, res, next) => {
+app.use((_req, res, next) => {
   // This is needed to remove the deployed application from being indexed by Search engines
   res.setHeader('X-Robots-Tag', 'noindex, nofollow');
   next();

--- a/backend/tests/session.test.ts
+++ b/backend/tests/session.test.ts
@@ -42,7 +42,7 @@ const startServer = (await import('../server')).default;
 describe.each([
   ['InMemorySessionStorage', new InMemorySessionStorage()],
   ['VcrSessionStorage', mockVcrSessionStorage],
-])('/session using %s', (storageName, sessionStorage) => {
+])('/session using %s', (_storageName, sessionStorage) => {
   let server: Server;
   const roomName = 'awesomeRoomName';
 

--- a/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
+++ b/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
@@ -164,9 +164,7 @@ const usePreviewPublisher = (): PreviewPublisherContextType => {
    */
   const handleAccessDenied = useCallback(
     async (event: AccessDeniedEvent) => {
-      const deviceDeniedAccess = (
-        event.message?.startsWith('Microphone') ? 'microphone' : 'camera'
-      ) as PermissionName;
+      const deviceDeniedAccess = event.message?.startsWith('Microphone') ? 'microphone' : 'camera';
 
       setAccessStatus(DEVICE_ACCESS_STATUS.REJECTED);
 

--- a/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
+++ b/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
@@ -164,13 +164,14 @@ const usePreviewPublisher = (): PreviewPublisherContextType => {
    */
   const handleAccessDenied = useCallback(
     async (event: AccessDeniedEvent) => {
-      const deviceDeniedAccess = event.message?.startsWith('Microphone') ? 'microphone' : 'camera';
+      const deviceDeniedAccess = (
+        event.message?.startsWith('Microphone') ? 'microphone' : 'camera'
+      ) as PermissionName;
 
       setAccessStatus(DEVICE_ACCESS_STATUS.REJECTED);
 
       try {
         const permissionStatus = await window.navigator.permissions.query({
-          // @ts-expect-error The camera and microphone permissions are supported on all major browsers.
           name: deviceDeniedAccess,
         });
         permissionStatus.onchange = () => {

--- a/frontend/src/components/MeetingRoom/ReportIssue/FeedbackForm/FilePicker/FilePicker.tsx
+++ b/frontend/src/components/MeetingRoom/ReportIssue/FeedbackForm/FilePicker/FilePicker.tsx
@@ -63,7 +63,7 @@ const FilePicker = ({
       const screenshotData = await captureScreenshot();
       setImageSrc(screenshotData);
       onFileSelect(screenshotData);
-    } catch (error) {
+    } catch (_error) {
       // User cancelled screenshot, no action needed
     }
   };

--- a/frontend/src/components/MeetingRoom/ReportIssue/FeedbackForm/FilePicker/FilePicker.tsx
+++ b/frontend/src/components/MeetingRoom/ReportIssue/FeedbackForm/FilePicker/FilePicker.tsx
@@ -63,8 +63,10 @@ const FilePicker = ({
       const screenshotData = await captureScreenshot();
       setImageSrc(screenshotData);
       onFileSelect(screenshotData);
-    } catch (_error) {
-      // User cancelled screenshot, no action needed
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.warn(error.message);
+      }
     }
   };
   return (

--- a/frontend/src/components/WaitingRoom/BlurButton/BlurButton.tsx
+++ b/frontend/src/components/WaitingRoom/BlurButton/BlurButton.tsx
@@ -35,7 +35,6 @@ const BlurButton = (): ReactElement | false => {
         <Tooltip title={title} aria-label="toggle background blur">
           <VideoContainerButton
             onClick={toggleBlur}
-            isEnabled={!hasBlur}
             sx={{
               '&:hover': {
                 backgroundColor: 'rgba(255, 255, 255, 0.6)',

--- a/frontend/src/components/WaitingRoom/CameraButton/CameraButton.tsx
+++ b/frontend/src/components/WaitingRoom/CameraButton/CameraButton.tsx
@@ -47,7 +47,6 @@ const CameraButton = (): ReactElement => {
               <VideocamOffIcon sx={{ fontSize: '24px', color: 'white' }} />
             )
           }
-          isEnabled={isVideoEnabled}
         />
       </Tooltip>
     </Box>

--- a/frontend/src/components/WaitingRoom/MicButton/MicButton.tsx
+++ b/frontend/src/components/WaitingRoom/MicButton/MicButton.tsx
@@ -33,7 +33,6 @@ const MicButton = (): ReactElement => {
       <Tooltip title={title} aria-label="toggle audio">
         <VideoContainerButton
           onClick={toggleAudio}
-          isEnabled={isAudioEnabled}
           sx={{
             backgroundColor: !isAudioEnabled ? 'rgb(234, 67, 53)' : '',
             '&:hover': {

--- a/frontend/src/components/WaitingRoom/VideoContainerButton/VideoContainerButton.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainerButton/VideoContainerButton.tsx
@@ -5,7 +5,6 @@ export type VideoContainerButtonProps = {
   onClick: () => void;
   icon: ReactElement;
   sx?: SxProps;
-  isEnabled: boolean;
 };
 
 /**
@@ -16,7 +15,6 @@ export type VideoContainerButtonProps = {
  *  @property {Function} onClick - The on-click handler for the button.
  *  @property {ReactElement} icon - The Icon element for the button.
  *  @property {SxProps} sx - The style properties for the component.
- *  @property {boolean} isEnabled - Whether the button is toggled or not.
  * @returns {ReactElement} The VideoContainerButton component.
  */
 const VideoContainerButton = forwardRef(function VideoContainerButton(

--- a/frontend/src/components/WaitingRoom/VideoContainerButton/VideoContainerButton.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainerButton/VideoContainerButton.tsx
@@ -23,7 +23,7 @@ const VideoContainerButton = forwardRef(function VideoContainerButton(
   props: VideoContainerButtonProps,
   ref: ForwardedRef<HTMLButtonElement>
 ): ReactElement {
-  const { icon: Icon, sx = {}, isEnabled, ...rest } = props;
+  const { icon: Icon, sx = {}, ...rest } = props;
   return (
     <IconButton
       {...rest}

--- a/frontend/src/hooks/useArchives.tsx
+++ b/frontend/src/hooks/useArchives.tsx
@@ -23,7 +23,7 @@ const useArchives = ({ roomName }: UseArchivesProps): Archive[] | 'error' => {
           archiveData = await getArchives(roomName);
         } catch (error: unknown) {
           const message = error instanceof Error ? error.message : error;
-          console.log(`Error retrieving archive: ${message}`);
+          console.error(`Error retrieving archive: ${message}`);
           setArchives('error');
           return;
         }

--- a/frontend/src/hooks/useArchives.tsx
+++ b/frontend/src/hooks/useArchives.tsx
@@ -21,7 +21,9 @@ const useArchives = ({ roomName }: UseArchivesProps): Archive[] | 'error' => {
         let archiveData: ArchiveResponse;
         try {
           archiveData = await getArchives(roomName);
-        } catch (_err) {
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : error;
+          console.log(`Error retrieving archive: ${message}`);
           setArchives('error');
           return;
         }

--- a/frontend/src/hooks/useArchives.tsx
+++ b/frontend/src/hooks/useArchives.tsx
@@ -21,7 +21,7 @@ const useArchives = ({ roomName }: UseArchivesProps): Archive[] | 'error' => {
         let archiveData: ArchiveResponse;
         try {
           archiveData = await getArchives(roomName);
-        } catch (err) {
+        } catch (_err) {
           setArchives('error');
           return;
         }

--- a/frontend/src/pages/MeetingRoom/MeetingRoom.spec.tsx
+++ b/frontend/src/pages/MeetingRoom/MeetingRoom.spec.tsx
@@ -145,7 +145,7 @@ describe('MeetingRoom', () => {
       closeRightPanel: vi.fn(),
     } as unknown as SessionContextType;
     mockUseSpeakingDetector.mockReturnValue(false);
-    mockUseLayoutManager.mockImplementation(() => (dimensions, elements) => {
+    mockUseLayoutManager.mockImplementation(() => (_dimensions, elements) => {
       return Array(elements.length).fill({
         height: 720,
         left: 0,
@@ -261,7 +261,7 @@ describe('MeetingRoom', () => {
     sessionContext.layoutMode = 'active-speaker';
     const [sub1, sub2, sub3] = Array(3)
       .fill(0)
-      .map((s, index) => createSubscriberWrapper(`sub${index + 1}`));
+      .map((_s, index) => createSubscriberWrapper(`sub${index + 1}`));
     sessionContext.subscriberWrappers = [sub1];
     publisherContext.publisher = mockPublisher;
     const { rerender } = render(<MeetingRoomWithProviders />);

--- a/frontend/src/pages/WaitingRoom/WaitingRoom.spec.tsx
+++ b/frontend/src/pages/WaitingRoom/WaitingRoom.spec.tsx
@@ -70,7 +70,7 @@ const mockWaitUntilPlaying = vi.mocked(waitUntilPlaying);
 const reloadSpy = vi.fn();
 
 describe('WaitingRoom', () => {
-  const nativeWindowLocation = window.location;
+  const nativeWindowLocation = window.location as string & Location;
   let previewPublisherContext: PreviewPublisherContextType;
   let mockPublisher: Publisher;
   let mockPublisherVideoElement: HTMLVideoElement;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,7 +15,7 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
   },

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@cspell/eslint-plugin": "^8.14.4",
     "@types/node": "^20.12.7",
-    "@typescript-eslint/eslint-plugin": "^7.7.1",
-    "@typescript-eslint/parser": "^7.7.1",
+    "@typescript-eslint/eslint-plugin": "^8.30.1",
+    "@typescript-eslint/parser": "^8.30.1",
     "eslint": "^8",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "license-checker": "^25.0.1",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
-    "typescript": "^5.4.5"
+    "typescript": "^5.8.3"
   },
   "resolutions": {
     "wrap-ansi": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,86 +2181,86 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^7.7.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz"
-  integrity sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==
+"@typescript-eslint/eslint-plugin@^8.30.1":
+  version "8.30.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.30.1.tgz#9beb9e4fbfdde40410e96587cc56dded1942cdf1"
+  integrity sha512-v+VWphxMjn+1t48/jO4t950D6KR8JaJuNXzi33Ve6P8sEmPr5k6CEXjdGwT6+LodVnEa91EQCtwjWNUCPweo+Q==
   dependencies:
     "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "7.13.1"
-    "@typescript-eslint/type-utils" "7.13.1"
-    "@typescript-eslint/utils" "7.13.1"
-    "@typescript-eslint/visitor-keys" "7.13.1"
+    "@typescript-eslint/scope-manager" "8.30.1"
+    "@typescript-eslint/type-utils" "8.30.1"
+    "@typescript-eslint/utils" "8.30.1"
+    "@typescript-eslint/visitor-keys" "8.30.1"
     graphemer "^1.4.0"
     ignore "^5.3.1"
     natural-compare "^1.4.0"
-    ts-api-utils "^1.3.0"
+    ts-api-utils "^2.0.1"
 
-"@typescript-eslint/parser@^7.7.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz"
-  integrity sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==
+"@typescript-eslint/parser@^8.30.1":
+  version "8.30.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.30.1.tgz#8a9fa650b046e64656e21d4fdff86535b6a084b6"
+  integrity sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==
   dependencies:
-    "@typescript-eslint/scope-manager" "7.13.1"
-    "@typescript-eslint/types" "7.13.1"
-    "@typescript-eslint/typescript-estree" "7.13.1"
-    "@typescript-eslint/visitor-keys" "7.13.1"
+    "@typescript-eslint/scope-manager" "8.30.1"
+    "@typescript-eslint/types" "8.30.1"
+    "@typescript-eslint/typescript-estree" "8.30.1"
+    "@typescript-eslint/visitor-keys" "8.30.1"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz"
-  integrity sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==
+"@typescript-eslint/scope-manager@8.30.1":
+  version "8.30.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.30.1.tgz#f99c7efd53b5ff9fb57e55be71eb855603fd80b7"
+  integrity sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg==
   dependencies:
-    "@typescript-eslint/types" "7.13.1"
-    "@typescript-eslint/visitor-keys" "7.13.1"
+    "@typescript-eslint/types" "8.30.1"
+    "@typescript-eslint/visitor-keys" "8.30.1"
 
-"@typescript-eslint/type-utils@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz"
-  integrity sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==
+"@typescript-eslint/type-utils@8.30.1":
+  version "8.30.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.30.1.tgz#151ee0529d6e6df19d8a3a23e81c809d2e4f6b1a"
+  integrity sha512-64uBF76bfQiJyHgZISC7vcNz3adqQKIccVoKubyQcOnNcdJBvYOILV1v22Qhsw3tw3VQu5ll8ND6hycgAR5fEA==
   dependencies:
-    "@typescript-eslint/typescript-estree" "7.13.1"
-    "@typescript-eslint/utils" "7.13.1"
+    "@typescript-eslint/typescript-estree" "8.30.1"
+    "@typescript-eslint/utils" "8.30.1"
     debug "^4.3.4"
-    ts-api-utils "^1.3.0"
+    ts-api-utils "^2.0.1"
 
-"@typescript-eslint/types@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz"
-  integrity sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==
+"@typescript-eslint/types@8.30.1":
+  version "8.30.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.30.1.tgz#20ff6d66ab3d8fe0533aeb7092a487393d53f925"
+  integrity sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw==
 
-"@typescript-eslint/typescript-estree@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz"
-  integrity sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==
+"@typescript-eslint/typescript-estree@8.30.1":
+  version "8.30.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.30.1.tgz#f5c133e4a76a54d25607434f2c276409d7bec4ba"
+  integrity sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ==
   dependencies:
-    "@typescript-eslint/types" "7.13.1"
-    "@typescript-eslint/visitor-keys" "7.13.1"
+    "@typescript-eslint/types" "8.30.1"
+    "@typescript-eslint/visitor-keys" "8.30.1"
     debug "^4.3.4"
-    globby "^11.1.0"
+    fast-glob "^3.3.2"
     is-glob "^4.0.3"
     minimatch "^9.0.4"
     semver "^7.6.0"
-    ts-api-utils "^1.3.0"
+    ts-api-utils "^2.0.1"
 
-"@typescript-eslint/utils@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz"
-  integrity sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==
+"@typescript-eslint/utils@8.30.1":
+  version "8.30.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.30.1.tgz#23d4824394765948fe73dc7113892f85fdc80efd"
+  integrity sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
-    "@typescript-eslint/scope-manager" "7.13.1"
-    "@typescript-eslint/types" "7.13.1"
-    "@typescript-eslint/typescript-estree" "7.13.1"
+    "@typescript-eslint/scope-manager" "8.30.1"
+    "@typescript-eslint/types" "8.30.1"
+    "@typescript-eslint/typescript-estree" "8.30.1"
 
-"@typescript-eslint/visitor-keys@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz"
-  integrity sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==
+"@typescript-eslint/visitor-keys@8.30.1":
+  version "8.30.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.30.1.tgz#510955ef1fb56e08da4b7953a3377258e5942e36"
+  integrity sha512-aEhgas7aJ6vZnNFC7K4/vMGDGyOiqWcYZPpIWrTKuTAlsvDNKy2GFDqh9smL+iq069ZvR0YzEeq0B8NJlLzjFA==
   dependencies:
-    "@typescript-eslint/types" "7.13.1"
-    eslint-visitor-keys "^3.4.3"
+    "@typescript-eslint/types" "8.30.1"
+    eslint-visitor-keys "^4.2.0"
 
 "@ungap/structured-clone@^1.0.0", "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
@@ -2747,11 +2747,6 @@ array-timsort@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz"
   integrity sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==
-
-array-union@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz"
-  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array.prototype.findlast@^1.2.5:
   version "1.2.5"
@@ -3728,13 +3723,6 @@ diff-sequences@^29.6.3:
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
-dir-glob@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz"
-  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
-  dependencies:
-    path-type "^4.0.0"
-
 dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
@@ -4230,6 +4218,11 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
+eslint-visitor-keys@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz#687bacb2af884fcdda8a6e7d65c606f46a14cd45"
+  integrity sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==
+
 eslint@^8:
   version "8.57.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz"
@@ -4466,7 +4459,7 @@ fast-glob@^3.2.5:
     merge2 "^1.3.0"
     micromatch "^4.0.8"
 
-fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.2:
+fast-glob@^3.3.0, fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -4835,18 +4828,6 @@ globalthis@^1.0.1, globalthis@^1.0.3:
   dependencies:
     define-properties "^1.2.1"
     gopd "^1.0.1"
-
-globby@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz"
-  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.2.9"
-    ignore "^5.2.0"
-    merge2 "^1.4.1"
-    slash "^3.0.0"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -6309,9 +6290,9 @@ merge-stream@^2.0.0:
   resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0, merge2@^1.4.1:
+merge2@^1.3.0:
   version "1.4.1"
-  resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 methods@^1.1.2, methods@~1.1.2:
@@ -8231,10 +8212,10 @@ trim-lines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
   integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
 
-ts-api-utils@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz"
-  integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
+ts-api-utils@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
+  integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
 
 ts-interface-checker@^0.1.9:
   version "0.1.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8380,10 +8380,10 @@ typedoc@^0.26.10:
     shiki "^1.16.2"
     yaml "^2.5.1"
 
-typescript@^5.4.5:
-  version "5.4.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 ua-parser-js@^1.0.37:
   version "1.0.40"


### PR DESCRIPTION
#### What is this PR doing?

While doing some changes/refactoring in `usePreviewPublisher` I noticed the following:
<img width="746" alt="Screenshot 2025-04-14 at 2 58 22 PM" src="https://github.com/user-attachments/assets/a29f9ba2-dab1-4826-a43e-f91fcc490f9d" />

This PR removes the `ts-expect-error` and makes changes to `deviceDeniedAccess` to better handle the type of permission we are seeking.

Also upgrades the TypeScript version and linter while we at it. Linter needed to be updated because it wasn't compatible with the latest version of TS. 

#### How should this be manually tested?

Checkout this branch.
Ensure that you are getting the expected flow when giving/rejecting access to the hardware.
CI passes (especially linter)

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3650](https://jira.vonage.com/browse/VIDCS-3650)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?