### PR TITLE
VIDCS-3661: Refactor how we interact with window.localStorage 

### DIFF
--- a/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
+++ b/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
@@ -99,7 +99,7 @@ const usePreviewPublisher = (): PreviewPublisherContextType => {
       });
     }
     setLocalBlur(!localBlur);
-    window.localStorage.setItem('backgroundBlur', JSON.stringify(!localBlur));
+    setStorageItem(STORAGE_KEYS.BACKGROUND_BLUR, JSON.stringify(!localBlur));
     if (setUser) {
       setUser((prevUser: UserType) => ({
         ...prevUser,

--- a/frontend/src/Context/user.tsx
+++ b/frontend/src/Context/user.tsx
@@ -7,6 +7,7 @@ import {
   Dispatch,
   ReactElement,
 } from 'react';
+import { getStorageItem, STORAGE_KEYS } from '../utils/storage';
 
 // Define the shape of the User context
 export type UserContextType = {
@@ -46,9 +47,9 @@ export type UserProviderProps = {
  */
 const UserProvider = ({ children }: UserProviderProps): ReactElement => {
   // Load initial settings from local storage
-  const noiseSuppression = window.localStorage.getItem('noiseSuppression') === 'true';
-  const blur = window.localStorage.getItem('backgroundBlur') === 'true';
-  const name = window.localStorage.getItem('username') ?? '';
+  const noiseSuppression = getStorageItem(STORAGE_KEYS.NOISE_SUPPRESSION) === 'true';
+  const blur = getStorageItem(STORAGE_KEYS.BACKGROUND_BLUR) === 'true';
+  const name = getStorageItem(STORAGE_KEYS.USERNAME) ?? '';
 
   const [user, setUser] = useState<UserType>({
     defaultSettings: {

--- a/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
+++ b/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
@@ -9,6 +9,7 @@ import ToggleOnIcon from '@mui/icons-material/ToggleOn';
 import usePublisherContext from '../../../hooks/usePublisherContext';
 import DropdownSeparator from '../DropdownSeparator';
 import SoundTest from '../../SoundTest';
+import { setStorageItem, STORAGE_KEYS } from '../../../utils/storage';
 
 export type ReduceNoiseTestSpeakersProps = {
   customLightBlueColor: string;
@@ -32,7 +33,7 @@ const ReduceNoiseTestSpeakers = ({
   const handleToggle = async () => {
     const newState = !isToggled;
     setIsToggled(newState);
-    window.localStorage.setItem('noiseSuppression', JSON.stringify(newState));
+    setStorageItem(STORAGE_KEYS.NOISE_SUPPRESSION, JSON.stringify(newState));
     if (newState) {
       await publisher?.applyAudioFilter({ type: 'advancedNoiseSuppression' });
     } else {

--- a/frontend/src/components/MeetingRoom/VideoDevicesOptions/VideoDevicesOptions.tsx
+++ b/frontend/src/components/MeetingRoom/VideoDevicesOptions/VideoDevicesOptions.tsx
@@ -5,6 +5,7 @@ import Grow from '@mui/material/Grow';
 import ToggleOffIcon from '@mui/icons-material/ToggleOff';
 import ToggleOnIcon from '@mui/icons-material/ToggleOn';
 import usePublisherContext from '../../../hooks/usePublisherContext';
+import { setStorageItem, STORAGE_KEYS } from '../../../utils/storage';
 
 export type VideoDevicesOptionsProps = {
   customLightBlueColor: string;
@@ -25,7 +26,7 @@ const VideoDevicesOptions = ({ customLightBlueColor }: VideoDevicesOptionsProps)
   const handleToggle = async () => {
     const newState = !isToggled;
     setIsToggled(newState);
-    window.localStorage.setItem('backgroundBlur', JSON.stringify(newState));
+    setStorageItem(STORAGE_KEYS.BACKGROUND_BLUR, JSON.stringify(newState));
     if (newState) {
       await publisher?.applyVideoFilter({
         type: 'backgroundBlur',

--- a/frontend/src/components/WaitingRoom/UserNameInput/UserNameInput.tsx
+++ b/frontend/src/components/WaitingRoom/UserNameInput/UserNameInput.tsx
@@ -7,6 +7,7 @@ import useUserContext from '../../../hooks/useUserContext';
 import { UserType } from '../../../Context/user';
 import useRoomName from '../../../hooks/useRoomName';
 import isValidRoomName from '../../../utils/isValidRoomName';
+import { setStorageItem, STORAGE_KEYS } from '../../../utils/storage';
 
 export type UserNameInputProps = {
   username: string;
@@ -78,7 +79,7 @@ const UsernameInput = ({ username, setUsername }: UserNameInputProps): ReactElem
           name: username,
         },
       }));
-      window.localStorage.setItem('username', username);
+      setStorageItem(STORAGE_KEYS.USERNAME, username);
       // This takes the user to the meeting room and allows them to enter it
       // Otherwise if they entered the room directly, they are going to be redirected back to the waiting room
       // Setting hasAccess is required so that we are not redirected back to the waiting room

--- a/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
+++ b/frontend/src/pages/WaitingRoom/WaitingRoom.tsx
@@ -7,6 +7,7 @@ import { DEVICE_ACCESS_STATUS } from '../../utils/constants';
 import DeviceAccessAlert from '../../components/DeviceAccessAlert';
 import Banner from '../../components/Banner';
 import useIsSmallViewport from '../../hooks/useIsSmallViewport';
+import { getStorageItem, STORAGE_KEYS } from '../../utils/storage';
 
 /**
  * WaitingRoom Component
@@ -29,7 +30,7 @@ const WaitingRoom = (): ReactElement => {
   const [openAudioInput, setOpenAudioInput] = useState<boolean>(false);
   const [openVideoInput, setOpenVideoInput] = useState<boolean>(false);
   const [openAudioOutput, setOpenAudioOutput] = useState<boolean>(false);
-  const [username, setUsername] = useState(window.localStorage.getItem('username') ?? '');
+  const [username, setUsername] = useState(getStorageItem(STORAGE_KEYS.USERNAME) ?? '');
   const isSmallViewport = useIsSmallViewport();
 
   useEffect(() => {

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,6 +1,9 @@
 export const STORAGE_KEYS = {
   AUDIO_SOURCE: 'audioSource',
   VIDEO_SOURCE: 'videoSource',
+  NOISE_SUPPRESSION: 'noiseSuppression',
+  BACKGROUND_BLUR: 'backgroundBlur',
+  USERNAME: 'username',
 };
 
 export const setStorageItem = (key: string, value: string) => {


### PR DESCRIPTION
#### What is this PR doing?

[This previous PR](https://github.com/Vonage/vonage-video-react-app/pull/139) introduced a little util that manages how we interact with `localStorage`. This PR changes that in other places where we interact with the `window.localStorage`. 


#### How should this be manually tested?

Checkout this branch.
Since this PR touches on background blur, noise suppression and username (in the waiting room), please ensure that the settings are saved between the session. For example, if you applied background blur in the meeting room, it should be there the next time you join the waiting/meeting rooms. Same goes for noise suppresion (only available in meeting room) and username.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3661](https://jira.vonage.com/browse/VIDCS-3661)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?