### PR TITLE
VIDCS-3664: Fix up Slack notify job in VERA deployment process

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -31,13 +31,6 @@ jobs:
                   ]
                 },
                 {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "📝 *Release Notes:*\n${{ github.event.release.body }}"
-                  }
-                },
-                {
                   "type": "actions",
                   "elements": [
                     {


### PR DESCRIPTION
#### What is this PR doing?

This PR fixes up Slack notify job in VERA deployment process by removing the section that includes the release notes. The reason being is that there is a lot that can go wrong with the section due to formatting and, unfortunately, resulting in a invalid JSON error. Removing this section is not a big deal though since the notification is going to include a button that take straight to the release page. 

example of a failed GitHub action: [here](https://github.com/Vonage/vonage-video-react-app/actions/runs/14580240929/job/40895168578)


#### How should this be manually tested?

not able to until the next release

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3664](https://jira.vonage.com/browse/VIDCS-3664)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?