### PR TITLE
VIDCS-3664: Fix up Slack notify job in the deployment process

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -10,8 +10,9 @@ jobs:
     steps:
       - name: Send to slack channels
         uses: slackapi/slack-github-action@v2.0.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           errors: true
           payload: |

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -5,14 +5,14 @@ on:
     types: [published]
 
 jobs:
-  notify:
+  notify-release:
     runs-on: ubuntu-22.04
+    name: Notify Release
     steps:
       - name: Send to slack channels
         uses: slackapi/slack-github-action@v2.0.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           errors: true
           payload: |
@@ -26,7 +26,7 @@ jobs:
                   type: "mrkdwn"
                   text: "${{ github.event.release.body }}"
               - type: "divider"
-              - type: "actions"
+              - type: "section"
                 text:
                   type: "mrkdwn"
                   text: "You can view the full change log <${{github.event.release.html_url }}|here>"

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -8,7 +8,7 @@ jobs:
   notify:
     runs-on: ubuntu-22.04
     steps:
-      - name: Send to slack channles
+      - name: Send to slack channels
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -8,45 +8,24 @@ jobs:
   notify:
     runs-on: ubuntu-22.04
     steps:
-      - name: Send Slack notification
-        uses: slackapi/slack-github-action@v1.24.0
+      - name: Send to slack channles
+        uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          errors: true
           payload: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "🎉 New Vonage Video Reference App Just Released!"
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "🏷️ *Version:*\n`${{ github.event.release.tag_name }}`"
-                    }
-                  ]
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "🔗 View Release"
-                      },
-                      "url": "${{ github.event.release.html_url }}"
-                    }
-                  ]
-                },
-                {
-                  "type": "divider"
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            blocks:
+              - type: "header"
+                text:
+                  type: "plain_text"
+                  text: ":tada: Version ${{ github.event.release.name }} of the Vonage Video Reference App Just Released!"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ github.event.release.body }}"
+              - type: "divider"
+              - type: "actions"
+                text:
+                  type: "mrkdwn"
+                  text: "You can view the full change log <${{github.event.release.html_url }}|here>"


### PR DESCRIPTION
#### What is this PR doing?

[This PR](https://github.com/Vonage/vonage-video-react-app/pull/150) resolved one issue but brought up another. I found another sample that uses a later version of the `slack-github-action` library so hopefully that works.

#### How should this be manually tested?

TBD.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3664](https://jira.vonage.com/browse/VIDCS-3664)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?