### PR TITLE
VIDCS-3673: Z index issue when we have a full participants list and opening the kebab for last participants

### DIFF
--- a/frontend/src/components/MeetingRoom/ParticipantListButton/ParticipantListButton.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListButton/ParticipantListButton.tsx
@@ -42,6 +42,7 @@ const ParticipantListButton = ({
             backgroundColor: 'rgb(95, 99, 104)',
           },
           marginRight: '12px',
+          zIndex: 1,
         }}
         overlap="circular"
       >

--- a/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListItemMenu/ParticipantListItemMenu.tsx
@@ -35,7 +35,7 @@ const ParticipantListItemMenu = ({
       <IconButton onClick={handleClick} sx={{ marginRight: '-8px' }}>
         <MoreVertIcon sx={{ fontSize: '18px' }} />
       </IconButton>
-      <Popper open={isOpen} anchorEl={anchorEl} placement="bottom-start">
+      <Popper open={isOpen} anchorEl={anchorEl} placement="bottom-start" sx={{ zIndex: 10 }}>
         <ClickAwayListener onClickAway={handleClose}>
           <Paper
             elevation={4}


### PR DESCRIPTION
#### What is this PR doing?

This PR fixes "Z index issue when we have a full participants list and opening the kebab for last participants" 

#### How should this be manually tested?

To reproduce the issue, add a lot of participants to the meeting the room.
Click on the kebab menu button and notice that the number badge is over the popup:
![image](https://github.com/user-attachments/assets/177e1875-d191-4517-a9eb-1982f26ae82b)

To reproduce the fix, checkout this branch and do the steps above.
Notice that it is no longer the case.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3673](https://jira.vonage.com/browse/VIDCS-3673)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?