### PR TITLE
VIDCS-3709: VIDCS-3712: Bump VERA version to 1.1.1 and Bump up OT version to 2.29.4

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Express-based backend with authenticated routes.",
   "main": "index.js",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "private": true,
   "description": "React reference application for the Vonage Video web client SDK.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "build": "vite build && yarn cp-build",
@@ -30,7 +30,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.4.1",
-    "@vonage/client-sdk-video": "^2.29.3",
+    "@vonage/client-sdk-video": "^2.29.4",
     "@vonage/vcr-sdk": "^1.3.0",
     "autolinker": "^4.0.0",
     "autoprefixer": "^10.4.19",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-tests",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "integration test workspace for vonage video react app",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vonage-video-react-app",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React reference application for the Vonage Video web client SDK.",
   "private": true,
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,10 +2572,10 @@
     "@vonage/jwt" "^1.11.0"
     debug "^4.3.4"
 
-"@vonage/client-sdk-video@^2.29.3":
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.3.tgz#6ba9528027d2f3000ea2b45a91e55e3618a61233"
-  integrity sha512-C+y79+d/j194N4rJ1lEViwz5gzOBQYBWWPeUMg/sIpM4xGyMAiFjQttZs/D2c1jaxbGWiIVrj8n/r3JL+ftEGg==
+"@vonage/client-sdk-video@^2.29.4":
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.4.tgz#80f9905aa465656df485acbee976c2bc139688e3"
+  integrity sha512-pXSCj3xcJsViPkEEtIe1Ox0nH/IpDlZUkfZCFSXvOxrBzmQwseBiPcZp6NCc1DM7TI3hnmFlT2rY5rx2HlhNyw==
 
 "@vonage/conversations@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
#### What is this PR doing?

This PR bumps VERA version to 1.1.1 and bumps up OT version to 2.29.4.

#### How should this be manually tested?

n/a

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3709](https://jira.vonage.com/browse/VIDCS-3709)
Resolves [VIDCS-3712](https://jira.vonage.com/browse/VIDCS-3712)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?