### PR TITLE
VIDCS-3442: Refactor session context

### DIFF
--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.spec.tsx
@@ -53,11 +53,11 @@ describe('usePublisher', () => {
     (initPublisher as Mock).mockImplementation(mockedInitPublisher);
 
     sessionMock = {
-      publish: mockedSessionPublish,
       unpublish: mockedSessionUnpublish,
     } as unknown as Mocked<Session>;
     sessionContext = {
       session: sessionMock,
+      publish: mockedSessionPublish,
     } as unknown as SessionContextType;
     mockUseSessionContext.mockReturnValue(sessionContext as unknown as SessionContextType);
   });
@@ -123,24 +123,23 @@ describe('usePublisher', () => {
     });
 
     it('should log errors', async () => {
-      sessionMock = {
-        publish: vi.fn(() => {
-          throw new Error('There is an error.');
-        }),
-      } as unknown as Mocked<Session>;
+      mockedSessionPublish.mockImplementation(() => {
+        throw new Error('There is an error.');
+      });
 
       const { result } = renderHook(() => usePublisher());
-      result.current.initializeLocalPublisher({});
-      await result.current.publish();
+
+      await act(async () => {
+        result.current.initializeLocalPublisher({});
+
+        await result.current.publish();
+      });
 
       expect(consoleWarnSpy).toHaveBeenCalled();
     });
 
     it('should only publish to session once', async () => {
       (initPublisher as Mock).mockImplementation(() => mockPublisher);
-      mockedSessionPublish.mockImplementation((_, callback) => {
-        callback();
-      });
 
       const { result } = renderHook(() => usePublisher());
 

--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
@@ -242,11 +242,7 @@ const usePublisher = (): PublisherContextType => {
         return;
       }
 
-      mSession.session.publish(publisherRef.current, (error) => {
-        if (error) {
-          throw new Error(`${error.name}: ${error.message}`);
-        }
-      });
+      mSession.publish(publisherRef.current);
       setIsPublishingToSession(true);
     } catch (err: unknown) {
       if (err instanceof Error) {

--- a/frontend/src/components/MeetingRoom/EmojisOrigin/EmojisOrigin.tsx
+++ b/frontend/src/components/MeetingRoom/EmojisOrigin/EmojisOrigin.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
-import useEmoji from '../../../hooks/useEmoji';
 import Emoji from '../Emoji/Emoji';
+import useSessionContext from '../../../hooks/useSessionContext';
 
 /**
  * EmojisOrigin Component
@@ -9,7 +9,7 @@ import Emoji from '../Emoji/Emoji';
  * @returns {ReactElement} - The EmojisOrigin Component.
  */
 const EmojisOrigin = (): ReactElement => {
-  const { emojiQueue } = useEmoji();
+  const { emojiQueue } = useSessionContext();
 
   return (
     <>

--- a/frontend/src/components/MeetingRoom/SendEmojiButton/SendEmojiButton.tsx
+++ b/frontend/src/components/MeetingRoom/SendEmojiButton/SendEmojiButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Grid, GridSize } from '@mui/material';
 import { ReactElement } from 'react';
-import useEmoji from '../../../hooks/useEmoji';
 import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
+import useSessionContext from '../../../hooks/useSessionContext';
 
 export type SendEmojiButtonProps = {
   emoji: string;
@@ -15,7 +15,7 @@ export type SendEmojiButtonProps = {
  * @returns {ReactElement} The SendEmojiButton component.
  */
 const SendEmojiButton = ({ emoji }: SendEmojiButtonProps): ReactElement => {
-  const { sendEmoji } = useEmoji();
+  const { sendEmoji } = useSessionContext();
   const isSmallViewport = useIsSmallViewport();
   const xs: GridSize = isSmallViewport ? 2 : 3;
   const size = isSmallViewport ? 'small' : 'large';

--- a/frontend/src/hooks/tests/useChat.spec.tsx
+++ b/frontend/src/hooks/tests/useChat.spec.tsx
@@ -1,10 +1,10 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, Mock, Mocked, vi } from 'vitest';
-import { RefObject } from 'react';
-import { Session } from '@vonage/client-sdk-video';
+import { MutableRefObject } from 'react';
 import useChat from '../useChat';
 import useUserContext from '../useUserContext';
 import { UserContextType } from '../../Context/user';
+import VonageVideoClient from '../../utils/VonageVideoClient';
 
 vi.mock('../useUserContext.tsx');
 const mockUseUserContext = useUserContext as Mock<[], UserContextType>;
@@ -15,16 +15,16 @@ const mockUserContext = {
 } as UserContextType;
 
 describe('useChat', () => {
-  let sessionMock: Mocked<Session>;
-  let sessionRefMock: RefObject<Session | null>;
+  let sessionMock: Mocked<VonageVideoClient>;
+  let sessionRefMock: MutableRefObject<VonageVideoClient | null>;
   beforeEach(() => {
     mockUseUserContext.mockImplementation(() => mockUserContext);
     sessionMock = {
       signal: vi.fn(),
-    } as unknown as Mocked<Session>;
+    } as unknown as Mocked<VonageVideoClient>;
     sessionRefMock = {
       current: sessionMock,
-    } as unknown as RefObject<Session | null>;
+    } as unknown as MutableRefObject<VonageVideoClient | null>;
   });
 
   it('onChatMessage should parse message and update messages state', () => {

--- a/frontend/src/hooks/tests/useCollectBrowserInformation.spec.tsx
+++ b/frontend/src/hooks/tests/useCollectBrowserInformation.spec.tsx
@@ -11,9 +11,7 @@ describe('useCollectBrowserInformation', () => {
     (useSessionContext as Mock).mockReturnValue({
       session: {
         sessionId: 'someSessionId',
-        connection: {
-          connectionId: 'yourConnectionId',
-        },
+        connectionId: 'yourConnectionId',
       },
     });
 

--- a/frontend/src/hooks/tests/useEmoji.spec.tsx
+++ b/frontend/src/hooks/tests/useEmoji.spec.tsx
@@ -2,16 +2,19 @@ import { describe, it, expect, vi, beforeEach, Mock, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { EventEmitter } from 'events';
 import { Connection } from '@vonage/client-sdk-video';
+import { MutableRefObject } from 'react';
 import useSessionContext from '../useSessionContext';
 import { SessionContextType } from '../../Context/SessionProvider/session';
 import useEmoji, { EmojiWrapper } from '../useEmoji';
+import VonageVideoClient from '../../utils/VonageVideoClient';
+import { SignalEvent, SubscriberWrapper } from '../../types/session';
 
 vi.mock('../useSessionContext');
 
 const mockUseSessionContext = useSessionContext as Mock<[], SessionContextType>;
 
 describe('useEmoji', () => {
-  let mockSession: EventEmitter & { connection: Connection; signal: Mock };
+  let vonageVideoClient: MutableRefObject<VonageVideoClient | null>;
   let mockConnection: Connection;
   let mockSubscriberWrapperVideo: {
     subscriber: { stream: { connection: Connection; name: string } };
@@ -29,10 +32,12 @@ describe('useEmoji', () => {
 
   beforeEach(() => {
     // Create an EventEmitter to simulate the session
-    mockSession = Object.assign(new EventEmitter(), {
-      signal: vi.fn() as Mock,
-      connection: { connectionId: '123' } as Connection,
-    });
+    vonageVideoClient = {
+      current: Object.assign(new EventEmitter(), {
+        signal: vi.fn(),
+        connectionId: '123',
+      }) as unknown as VonageVideoClient,
+    };
 
     mockConnection = { connectionId: '456' } as Connection;
 
@@ -57,7 +62,7 @@ describe('useEmoji', () => {
     };
 
     const mockSessionContext = {
-      session: mockSession,
+      session: vonageVideoClient,
       subscriberWrappers: [mockSubscriberWrapperVideo, mockSubscriberWrapperScreen],
     } as unknown as SessionContextType;
 
@@ -73,68 +78,112 @@ describe('useEmoji', () => {
   describe('sendEmoji', () => {
     it('calls Session.signal with the emoji and current time', async () => {
       vi.setSystemTime(12_000_000);
-      const { result } = renderHook(() => useEmoji());
+      const { result } = renderHook(() => useEmoji({ vonageVideoClient }));
 
       act(() => {
         result.current.sendEmoji('❤️');
       });
 
-      expect(mockSession.signal).toBeCalledTimes(1);
-      expect(mockSession.signal).toBeCalledWith(
-        {
-          type: 'emoji',
-          data: '{"emoji":"❤️","time":12000000}',
-        },
-        expect.any(Function)
-      );
+      expect(vonageVideoClient.current?.signal).toBeCalledTimes(1);
+      expect(vonageVideoClient.current?.signal).toBeCalledWith({
+        type: 'emoji',
+        data: '{"emoji":"❤️","time":12000000}',
+      });
     });
 
     it('when called multiple times, sendEmoji throttles calls to once every 500ms', async () => {
       vi.useFakeTimers();
-      const { result } = renderHook(() => useEmoji());
+      const { result } = renderHook(() => useEmoji({ vonageVideoClient }));
 
       act(() => {
         result.current.sendEmoji('❤️');
         result.current.sendEmoji('❤️');
       });
 
-      expect(mockSession.signal).toBeCalledTimes(1);
+      expect(vonageVideoClient.current?.signal).toBeCalledTimes(1);
 
       vi.advanceTimersByTime(250);
-      expect(mockSession.signal).toBeCalledTimes(1);
+      expect(vonageVideoClient.current?.signal).toBeCalledTimes(1);
 
       vi.advanceTimersByTime(251);
       act(() => {
         result.current.sendEmoji('❤️');
       });
-      expect(mockSession.signal).toBeCalledTimes(2);
+      expect(vonageVideoClient.current?.signal).toBeCalledTimes(2);
     });
   });
 
   it('adds emojis to the queue when a signal event is received and gets the correct sender name', async () => {
-    const { result } = renderHook(() => useEmoji());
+    const { result } = renderHook(() => useEmoji({ vonageVideoClient }));
 
+    // Mock receiving a signal event from another user
     act(() => {
-      // Simulate sending an emoji
-      result.current.sendEmoji('❤️');
-    });
-
-    // Mock emitting a signal event from another user's connection
-    act(() => {
-      mockSession.emit('signal', {
+      const signalEvent: SignalEvent = {
         type: 'signal:emoji',
         data: JSON.stringify({
           emoji: '❤️',
           time: Date.now(),
           connectionId: mockConnection.connectionId, // Different from the session connection
-        }),
-        from: { connectionId: '456' },
-      });
+        }) as unknown as string,
+        from: { connectionId: '456', creationTime: 1, data: 'some-data' },
+      };
+      const subscriberWrapper: SubscriberWrapper = {
+        subscriber: {
+          stream: {
+            connection: {
+              connectionId: '456',
+            },
+            name: 'John Doe',
+          },
+        },
+      } as unknown as SubscriberWrapper;
+      const subscriberWrappers = [subscriberWrapper];
+      result.current.onEmoji(signalEvent, subscriberWrappers);
     });
 
     const expectedEmojiWrapper: EmojiWrapper = {
       name: 'John Doe', // The mock connection user
       emoji: '❤️',
+      time: expect.any(Number),
+    };
+
+    // Use waitFor to check if emojiQueue contains the expected emoji
+    await waitFor(() => {
+      expect(result.current.emojiQueue).toContainEqual(expectedEmojiWrapper);
+    });
+  });
+
+  it('recognizes when a received signal event is from local user', async () => {
+    const { result } = renderHook(() => useEmoji({ vonageVideoClient }));
+
+    // Mock receiving a signal event from local user
+    act(() => {
+      const signalEvent: SignalEvent = {
+        type: 'signal:emoji',
+        data: JSON.stringify({
+          emoji: '😲',
+          time: Date.now(),
+          connectionId: mockConnection.connectionId, // Different from the session connection
+        }) as unknown as string,
+        from: { connectionId: '123', creationTime: 1, data: 'some-data' },
+      };
+      const subscriberWrapper: SubscriberWrapper = {
+        subscriber: {
+          stream: {
+            connection: {
+              connectionId: '123',
+            },
+            name: 'That be I',
+          },
+        },
+      } as unknown as SubscriberWrapper;
+      const subscriberWrappers = [subscriberWrapper];
+      result.current.onEmoji(signalEvent, subscriberWrappers);
+    });
+
+    const expectedEmojiWrapper: EmojiWrapper = {
+      name: 'You',
+      emoji: '😲',
       time: expect.any(Number),
     };
 

--- a/frontend/src/hooks/useChat.tsx
+++ b/frontend/src/hooks/useChat.tsx
@@ -1,10 +1,10 @@
-import { Session } from '@vonage/client-sdk-video';
-import { RefObject, useCallback, useState } from 'react';
+import { MutableRefObject, useCallback, useState } from 'react';
 import useUserContext from './useUserContext';
 import { ChatMessageType } from '../types/chat';
+import VonageVideoClient from '../utils/VonageVideoClient';
 
 export type UseChatProps = {
-  sessionRef: RefObject<Session | null>;
+  sessionRef: MutableRefObject<VonageVideoClient | null>;
 };
 
 export type UseChat = {
@@ -15,7 +15,7 @@ export type UseChat = {
 /**
  * React hook to store ChatMessage array in state and provider functions for sending and receiving chat messages
  * @param {UseChatProps} props - props for the hook
- *   @property {RefObject<Session | null>} sessionRef - reference to the Session object
+ *   @property {MutableRefObject<VonageVideoClient | null>} sessionRef - reference to the Session object
  * @returns {UseChat} return object
  *   @property {ChatMessageType[]} messages - array of chat messages
  *   @property {(data: string) => void} onChatMessage - new message handler

--- a/frontend/src/hooks/useCollectBrowserInformation.tsx
+++ b/frontend/src/hooks/useCollectBrowserInformation.tsx
@@ -37,7 +37,7 @@ const useCollectBrowserInformation = (): BrowserInformationType => {
       width: window.innerWidth,
       height: window.innerHeight,
     },
-    connectionId: session?.connection?.connectionId,
+    connectionId: session?.connectionId,
   };
 };
 

--- a/frontend/src/hooks/useEmoji.tsx
+++ b/frontend/src/hooks/useEmoji.tsx
@@ -1,18 +1,23 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { MutableRefObject, useCallback, useMemo, useState } from 'react';
 import { Connection } from '@vonage/client-sdk-video';
 import { throttle } from 'lodash';
-import useSessionContext from './useSessionContext';
 import { EMOJI_DISPLAY_DURATION } from '../utils/constants';
-
-type SignalEventType = {
-  type?: string;
-  data?: string;
-  from: Connection | null;
-};
+import { SignalEvent, SubscriberWrapper } from '../types/session';
+import VonageVideoClient from '../utils/VonageVideoClient';
 
 type EmojiDataType = {
   emoji: string;
   time: number;
+};
+
+export type UseEmojiProps = {
+  vonageVideoClient: MutableRefObject<VonageVideoClient | null>;
+};
+
+export type UseEmoji = {
+  sendEmoji: (emoji: string) => void;
+  emojiQueue: EmojiWrapper[];
+  onEmoji: (event: SignalEvent, subscriberWrappers: SubscriberWrapper[]) => void;
 };
 
 export type EmojiWrapper = {
@@ -21,8 +26,16 @@ export type EmojiWrapper = {
   time: number;
 };
 
-const useEmoji = () => {
-  const { session, subscriberWrappers } = useSessionContext();
+/**
+ * React hook to queue emojis into an array for display and provides functions for sending and receiving emojis.
+ * @param {UseEmojiProps}  props - props for the hook
+ *  @property {MutableRefObject<VonageVideoClient | null>} vonageVideoClient - ref for the Vonage Video Client
+ * @returns {UseEmoji} returned object
+ *  @property {(emoji: string) => void} sendEmoji - function to send emojis
+ *  @property {EmojiWrapper[]} emojiQueue - emojis to display
+ *  @property {(event: SignalEvent, subscriberWrappers: SubscriberWrapper[]) => void} onEmoji - emoji handler
+ */
+const useEmoji = ({ vonageVideoClient }: UseEmojiProps): UseEmoji => {
   const [emojiQueue, setEmojiQueue] = useState<EmojiWrapper[]>([]);
 
   /**
@@ -34,36 +47,40 @@ const useEmoji = () => {
     const throttledFunc = throttle(
       (emoji: string) => {
         const data = JSON.stringify({ emoji, time: new Date().getTime() });
-        session?.signal({ type: 'emoji', data }, () => {});
+        vonageVideoClient?.current?.signal({ type: 'emoji', data });
       },
       500,
       { leading: true, trailing: false }
     );
     return throttledFunc;
-  }, [session]);
+  }, [vonageVideoClient]);
 
   /**
    * Checks if the given connection belongs to the current user.
    * @param {Connection} sendingConnection - The connection of a user.
    * @returns {boolean} - Returns `true` if the connection is the current user's, else `false`.
    */
-  const getIsYourConnection = useCallback(
+  const isOwnConnection = useCallback(
     (sendingConnection: Connection): boolean => {
-      const yourConnection = session?.connection;
+      const yourConnectionId = vonageVideoClient?.current?.connectionId;
 
-      return sendingConnection.connectionId === yourConnection?.connectionId;
+      return sendingConnection.connectionId === yourConnectionId;
     },
-    [session?.connection]
+    [vonageVideoClient]
   );
 
   /**
    * Retrieves the user's name or `You` if you are the sender from a given Connection.
    * @param {Connection} sendingConnection - The connection object to evaluate.
+   * @param {SubscriberWrapper[]} subscriberWrappers - all subscriber wrappers in the session
    * @returns {string} The user's name, `You`, or an empty string.
    */
   const getSenderName = useCallback(
-    (sendingConnection: Connection): string | undefined => {
-      const isYou = getIsYourConnection(sendingConnection);
+    (
+      sendingConnection: Connection,
+      subscriberWrappers: SubscriberWrapper[]
+    ): string | undefined => {
+      const isYou = isOwnConnection(sendingConnection);
       if (isYou) {
         return 'You';
       }
@@ -75,21 +92,19 @@ const useEmoji = () => {
       );
       return sendingSubscriberWrapper?.subscriber.stream?.name;
     },
-    [getIsYourConnection, subscriberWrappers]
+    [isOwnConnection]
   );
 
   /**
    * Manages signals sent by users in the room. Any emojis sent by the room's users
    * are processed in a data queue to be rendered in the application.
-   * @param {SignalEventType} signalEvent - Signal event dispatched by the session.
+   * @param {SignalEvent} signalEvent - Signal event dispatched by the session.
+   * @param {SubscriberWrapper[]} subscriberWrappers - all subscriber wrappers in the session
    */
-  const emojiHandler = useCallback(
-    ({ type, data, from: sendingConnection }: SignalEventType) => {
-      if (type !== 'signal:emoji') {
-        return;
-      }
+  const onEmoji = useCallback(
+    ({ data, from: sendingConnection }: SignalEvent, subscriberWrappers: SubscriberWrapper[]) => {
       if (data && sendingConnection) {
-        const senderName = getSenderName(sendingConnection) ?? '';
+        const senderName = getSenderName(sendingConnection, subscriberWrappers) ?? '';
         const { emoji, time }: EmojiDataType = JSON.parse(data);
 
         const emojiWrapper: EmojiWrapper = {
@@ -107,15 +122,7 @@ const useEmoji = () => {
     [getSenderName]
   );
 
-  useEffect(() => {
-    session?.on('signal', emojiHandler);
-
-    return () => {
-      session?.off('signal', emojiHandler);
-    };
-  }, [emojiHandler, session]);
-
-  return { sendEmoji, emojiQueue };
+  return { sendEmoji, emojiQueue, onEmoji };
 };
 
 export default useEmoji;

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -2,7 +2,6 @@ import { useState, useRef, useCallback } from 'react';
 import { Publisher, initPublisher } from '@vonage/client-sdk-video';
 import useSessionContext from './useSessionContext';
 import useUserContext from './useUserContext';
-import { StreamCreatedEvent } from '../Context/SessionProvider/session';
 
 /**
  * @typedef {object} UseScreenShareType
@@ -46,14 +45,9 @@ const useScreenShare = (): UseScreenShareType => {
     }
   }, [session]);
 
-  const handleStreamCreated = useCallback(
-    async (event: StreamCreatedEvent) => {
-      if (event.stream.videoType === 'screen') {
-        unpublishScreenshare();
-      }
-    },
-    [unpublishScreenshare]
-  );
+  const handleStreamCreated = useCallback(async () => {
+    unpublishScreenshare();
+  }, [unpublishScreenshare]);
 
   // Using useCallback to memoize the function to avoid unnecessary re-renders
   const toggleShareScreen = useCallback(async () => {
@@ -99,10 +93,10 @@ const useScreenShare = (): UseScreenShareType => {
         // Publishing the screen sharing stream
         session.publish(screenSharingPub.current);
 
-        session?.on('streamCreated', handleStreamCreated);
+        session?.on('screenshareStreamCreated', handleStreamCreated);
       } else if (screenSharingPub.current) {
         unpublishScreenshare();
-        session?.off('streamCreated', handleStreamCreated);
+        session?.off('screenshareStreamCreated', handleStreamCreated);
       }
     }
   }, [

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -1,4 +1,4 @@
-import { Subscriber } from '@vonage/client-sdk-video';
+import { Connection, Event, Session, Stream, Subscriber } from '@vonage/client-sdk-video';
 
 /**
  * Wrapper for a subscriber, including the DOM element, the subscriber object, whether it's a screenshare subscriber and whether it has been pinned.
@@ -10,3 +10,35 @@ export type SubscriberWrapper = {
   id: string;
   isPinned: boolean;
 };
+
+/**
+ * Represents the credentials required to connect to a session.
+ * For Opentok the apiKey is the project Id
+ * For Vonage Unified the apiKey is the application Id
+ */
+export type Credential = {
+  apiKey: string;
+  sessionId: string;
+  token: string;
+};
+
+export type StreamCreatedEvent = Event<'streamCreated', Session> & {
+  stream: Stream;
+};
+
+export type VideoElementCreatedEvent = Event<'videoElementCreated', Subscriber> & {
+  element: HTMLVideoElement | HTMLObjectElement;
+};
+
+export type SignalEvent = {
+  type?: string;
+  data?: string;
+  from: Connection | null;
+};
+
+export type SignalType = {
+  type: 'emoji' | 'chat';
+  data: string;
+};
+
+export type SubscriberAudioLevelUpdatedEvent = { movingAvg: number; subscriberId: string };

--- a/frontend/src/utils/VonageVideoClient/index.ts
+++ b/frontend/src/utils/VonageVideoClient/index.ts
@@ -1,0 +1,3 @@
+import VonageVideoClient from './vonageVideoClient';
+
+export default VonageVideoClient;

--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import {
+  Connection,
+  initSession,
+  Publisher,
+  Session,
+  Stream,
+  Subscriber,
+} from '@vonage/client-sdk-video';
+import EventEmitter from 'events';
+import logOnConnect from '../logOnConnect';
+import VonageVideoClient from './vonageVideoClient';
+import { Credential, SignalEvent } from '../../types/session';
+
+vi.mock('../logOnConnect');
+vi.mock('@vonage/client-sdk-video');
+
+type TestSubscriber = Subscriber & EventEmitter;
+const mockSubscriber = Object.assign(new EventEmitter(), {
+  id: 'test-id',
+}) as unknown as TestSubscriber;
+
+const mockLogOnConnect = logOnConnect as Mock<[], void>;
+const consoleErrorSpy = vi.spyOn(console, 'error');
+const mockInitSession = vi.fn();
+const mockConnect = vi.fn();
+const mockSubscribe = vi.fn();
+const mockDisconnect = vi.fn();
+const mockPublish = vi.fn();
+type TestSession = Session & EventEmitter;
+
+const fakeCredentials: Credential = {
+  apiKey: 'api-key',
+  sessionId: 'session-id',
+  token: 'toe-ken',
+};
+
+describe('VonageVideoClient', () => {
+  let vonageVideoClient: VonageVideoClient | null;
+  let mockSession: TestSession;
+
+  beforeEach(() => {
+    mockSession = Object.assign(new EventEmitter(), {
+      connect: mockConnect,
+      subscribe: mockSubscribe,
+      disconnect: mockDisconnect,
+      forceMuteStream: vi.fn(),
+      publish: mockPublish,
+      unpublish: vi.fn(),
+    }) as unknown as TestSession;
+    mockInitSession.mockReturnValue(mockSession);
+    (initSession as Mock).mockImplementation(mockInitSession);
+    mockConnect.mockImplementation((_, callback) => {
+      callback();
+    });
+    mockSubscribe.mockReturnValue(mockSubscriber);
+
+    vonageVideoClient = new VonageVideoClient(fakeCredentials);
+  });
+
+  afterEach(() => {
+    vonageVideoClient?.disconnect();
+    vonageVideoClient = null;
+    vi.resetAllMocks();
+  });
+
+  it('constructor should initialize a session with the provided credentials', () => {
+    expect(mockInitSession).toHaveBeenCalled();
+    expect(vonageVideoClient).not.toBeUndefined();
+  });
+
+  describe('connect to session', () => {
+    it('logs on successful connection', async () => {
+      await vonageVideoClient?.connect();
+
+      expect(mockLogOnConnect).toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(vonageVideoClient).not.toBeUndefined();
+    });
+
+    it('logs to console on unsuccessful connection', async () => {
+      const fakeError = 'fake-error';
+      mockConnect.mockImplementation((_, callback) => {
+        callback(fakeError);
+      });
+      await expect(() => vonageVideoClient?.connect()).rejects.toThrowError(fakeError);
+
+      expect(mockLogOnConnect).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error connecting to session:', fakeError);
+      expect(vonageVideoClient).not.toBeUndefined();
+    });
+  });
+
+  describe('for subscriber stream created', () => {
+    it('emits an event containing a SubscriberWrapper', () =>
+      new Promise<void>((done) => {
+        const streamId = 'stream-id';
+        vonageVideoClient?.connect().then(() => {
+          vonageVideoClient?.on('subscriberVideoElementCreated', (subscriberWrapper) => {
+            expect(subscriberWrapper.id).toBe(streamId);
+            expect(subscriberWrapper).toHaveProperty('subscriber');
+            done();
+          });
+
+          mockSession.emit('streamCreated', {
+            stream: { streamId } as unknown as Stream,
+          });
+          mockSubscriber.emit('videoElementCreated', {
+            element: document.createElement('video'),
+          });
+        });
+      }));
+
+    it('emits an event for screenshare subscribers', () =>
+      new Promise<void>((done) => {
+        const streamId = 'stream-id';
+        vonageVideoClient?.connect().then(() => {
+          vonageVideoClient?.on('screenshareStreamCreated', () => {
+            done();
+          });
+
+          mockSession.emit('streamCreated', {
+            stream: { streamId, videoType: 'screen' } as unknown as Stream,
+          });
+        });
+      }));
+
+    it('emits an event containing the streamId when the stream is destroyed', async () => {
+      const streamId = 'stream-id';
+      await vonageVideoClient?.connect();
+
+      mockSession.emit('streamCreated', {
+        stream: { streamId, videoType: 'screen' } as unknown as Stream,
+      });
+
+      const subscriberDestroyedPromise = new Promise((resolve) => {
+        vonageVideoClient?.on('subscriberDestroyed', (destroyedStreamId) => {
+          expect(destroyedStreamId).toBe(streamId);
+          resolve(true);
+        });
+
+        mockSubscriber.emit('destroyed');
+      });
+
+      await subscriberDestroyedPromise;
+    });
+
+    it('emits an event when its audio level is updated', async () => {
+      await vonageVideoClient?.connect();
+      const streamId = 'stream-id';
+      mockSession.emit('streamCreated', {
+        stream: { streamId } as unknown as Stream,
+      });
+      const audioLevelUpdatedPromise = new Promise((resolve) => {
+        vonageVideoClient?.on('subscriberAudioLevelUpdated', ({ movingAvg, subscriberId }) => {
+          expect(subscriberId).toBe(streamId);
+          expect(movingAvg).toBeDefined();
+          resolve(true);
+        });
+
+        mockSubscriber.emit('audioLevelUpdated', { audioLevel: 0.5 });
+      });
+
+      await audioLevelUpdatedPromise;
+    });
+  });
+
+  it('disconnect should disconnect from the session and cleanup', async () => {
+    await vonageVideoClient?.connect();
+    vonageVideoClient?.disconnect();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('forceMuteStream should call forceMuteStream on the session', async () => {
+    const mockStream: Stream = {
+      streamId: 'stream-id',
+    } as unknown as Stream;
+
+    await vonageVideoClient?.connect();
+    vonageVideoClient?.forceMuteStream(mockStream);
+
+    expect(mockSession.forceMuteStream).toHaveBeenCalledWith(mockStream);
+  });
+
+  describe('publish', () => {
+    const mockPublisher: Publisher = {
+      id: 'publisher-id',
+    } as unknown as Publisher;
+
+    it('should publish a stream to the session', async () => {
+      await vonageVideoClient?.connect();
+      vonageVideoClient?.publish(mockPublisher);
+      expect(mockSession.publish).toHaveBeenCalledWith(mockPublisher, expect.any(Function));
+      expect(mockSession.publish).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw an error if publishing fails', async () => {
+      const error = new Error('Publishing failed');
+      error.message = 'Publishing failed';
+      error.name = 'oops';
+      mockPublish.mockImplementation((_, callback) => {
+        callback(error);
+      });
+
+      await vonageVideoClient?.connect();
+
+      expect(() => vonageVideoClient?.publish(mockPublisher)).toThrowError(
+        `${error.name}: ${error.message}`
+      );
+    });
+  });
+
+  it('unpublish should unpublish a stream from the session', async () => {
+    const mockPublisher: Publisher = {
+      id: 'publisher-id',
+    } as unknown as Publisher;
+
+    await vonageVideoClient?.connect();
+    vonageVideoClient?.publish(mockPublisher);
+    vonageVideoClient?.unpublish(mockPublisher);
+
+    expect(mockSession.unpublish).toHaveBeenCalledWith(mockPublisher);
+    expect(mockSession.unpublish).toHaveBeenCalledTimes(1);
+  });
+
+  describe('event handling', () => {
+    it('should emit archiveStarted when an archive starts', async () => {
+      const archiveId = 'archive-id';
+
+      const archiveStartedPromise = new Promise((resolve) => {
+        vonageVideoClient?.on('archiveStarted', (id) => {
+          expect(id).toBe(archiveId);
+          resolve(true);
+        });
+
+        mockSession.emit('archiveStarted', {
+          id: archiveId,
+        });
+      });
+      await archiveStartedPromise;
+    });
+
+    it('should emit archiveStopped when an archive stops', async () => {
+      const archiveStoppedPromise = new Promise((resolve) => {
+        vonageVideoClient?.on('archiveStopped', () => {
+          resolve(true);
+        });
+
+        mockSession.emit('archiveStopped');
+      });
+
+      return archiveStoppedPromise;
+    });
+
+    it('should emit sessionDisconnected when the session disconnects', async () => {
+      const sessionDisconnectedPromise = new Promise((resolve) => {
+        vonageVideoClient?.on('sessionDisconnected', () => {
+          resolve(true);
+        });
+
+        mockSession.emit('sessionDisconnected');
+      });
+      return sessionDisconnectedPromise;
+    });
+
+    it('should emit sessionReconnected when the session reconnects', async () => {
+      const sessionReconnectedPromise = new Promise((resolve) => {
+        vonageVideoClient?.on('sessionReconnected', () => {
+          resolve(true);
+        });
+
+        mockSession.emit('sessionReconnected');
+      });
+      return sessionReconnectedPromise;
+    });
+
+    it('should emit sessionReconnecting when the session is reconnecting', async () => {
+      const sessionReconnectingPromise = new Promise((resolve) => {
+        vonageVideoClient?.on('sessionReconnecting', () => {
+          resolve(true);
+        });
+
+        mockSession.emit('sessionReconnecting');
+      });
+      return sessionReconnectingPromise;
+    });
+
+    it('should emit signal:chat when a chat message is received', () => {
+      const chatSignal: SignalEvent = {
+        type: 'signal:chat',
+        data: 'Hello, world!',
+        from: {
+          connectionId: 'connection-id',
+          creationTime: 0,
+          data: 'connection-data',
+        } as unknown as Connection,
+      };
+
+      const emitChatSignalPromise = new Promise((resolve) => {
+        vonageVideoClient?.on('signal:chat', (event) => {
+          expect(event).toEqual(chatSignal);
+          resolve(true);
+        });
+
+        mockSession.emit('signal', chatSignal);
+      });
+      return emitChatSignalPromise;
+    });
+
+    it('should emit signal:emoji when an emoji is received', () => {
+      const emojiSignal: SignalEvent = {
+        type: 'signal:emoji',
+        data: '👍',
+        from: {
+          connectionId: 'connection-id',
+          creationTime: 0,
+          data: 'connection-data',
+        } as unknown as Connection,
+      };
+
+      const emitEmojiSignalPromise = new Promise((resolve) => {
+        vonageVideoClient?.on('signal:emoji', (event) => {
+          expect(event).toEqual(emojiSignal);
+          resolve(true);
+        });
+
+        mockSession.emit('signal', emojiSignal);
+      });
+      return emitEmojiSignalPromise;
+    });
+  });
+});

--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
@@ -1,0 +1,294 @@
+import {
+  initSession,
+  OTError,
+  Publisher,
+  Session,
+  Stream,
+  SubscriberProperties,
+} from '@vonage/client-sdk-video';
+import { EventEmitter } from 'events';
+import {
+  Credential,
+  StreamCreatedEvent,
+  VideoElementCreatedEvent,
+  SubscriberWrapper,
+  SignalEvent,
+  SignalType,
+  SubscriberAudioLevelUpdatedEvent,
+} from '../../types/session';
+import logOnConnect from '../logOnConnect';
+import createMovingAvgAudioLevelTracker from '../movingAverageAudioLevelTracker';
+
+type VonageVideoClientEvents = {
+  archiveStarted: [string];
+  archiveStopped: [];
+  screenshareStreamCreated: [];
+  sessionDisconnected: [];
+  sessionReconnected: [];
+  sessionReconnecting: [];
+  signal: [SignalEvent];
+  'signal:chat': [SignalEvent];
+  'signal:emoji': [SignalEvent];
+  streamPropertyChanged: [];
+  subscriberVideoElementCreated: [SubscriberWrapper];
+  subscriberDestroyed: [string];
+  subscriberAudioLevelUpdated: [SubscriberAudioLevelUpdatedEvent];
+};
+
+/**
+ * VonageVideoClient class - Manages a Vonage Video session, including subscribing to streams,
+ * handling events, and emitting custom events for session-related actions. It serves to
+ * provide a structured interface for interacting with the Vonage Video API and to separate
+ * React logic from the Vonage Video API logic, allowing for easier testing and maintenance.
+ *
+ * This class extends `EventEmitter` to provide event-driven functionality.
+ * @class VonageVideoClient
+ * @augments {EventEmitter}
+ */
+class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
+  private clientSession: Session | null;
+  private readonly credential: Credential;
+
+  /**
+   * Creates an instance of VonageVideoClient.
+   * Initializes the session and attaches event listeners.
+   * @param {Credential} credential - The API key, session ID, and token required to initialize the session.
+   */
+  constructor(credential: Credential) {
+    super();
+    this.credential = credential;
+    const { apiKey, sessionId } = this.credential;
+    this.clientSession = initSession(apiKey, sessionId);
+    this.attachEventListeners();
+  }
+
+  /**
+   * Attaches event listeners to the Vonage Video session.
+   * Handles various session events and emits corresponding custom events.
+   * @private
+   */
+  private attachEventListeners() {
+    if (!this.clientSession) {
+      return;
+    }
+    this.clientSession.on('archiveStarted', (event) => this.handleArchiveStarted(event));
+    this.clientSession.on('archiveStopped', () => this.handleArchiveStopped());
+    this.clientSession.on('sessionDisconnected', () => this.handleSessionDisconnected());
+    this.clientSession.on('sessionReconnected', () => this.handleReconnected());
+    this.clientSession.on('sessionReconnecting', () => this.handleReconnecting());
+    this.clientSession.on('signal', (event) => this.handleSignal(event));
+    this.clientSession.on('streamPropertyChanged', () => this.handleStreamPropertyChanged());
+    this.clientSession.on('streamCreated', (event) => this.handleStreamCreated(event));
+  }
+
+  /**
+   * Subscribes to a stream in a session, managing the receiving audio and video from the remote party.
+   * We are disabling the default SDK UI to have more control on the display of the subscriber
+   * Ref for Vonage Unified https://vonage.github.io/conversation-docs/video-js-reference/latest/Session.html#subscribe
+   * Ref for Opentok https://tokbox.com/developer/sdks/js/reference/Session.html#subscribe
+   * @param {StreamCreatedEvent} event - The event emitted when a stream is created
+   * @private
+   */
+  private handleStreamCreated(event: StreamCreatedEvent) {
+    if (this.clientSession === null) {
+      return;
+    }
+    const { stream } = event;
+    const { streamId, videoType } = stream;
+    const isScreenshare = videoType === 'screen';
+
+    const subscriberOptions: SubscriberProperties = {
+      insertMode: 'append',
+      width: '100%',
+      height: '100%',
+      preferredResolution: 'auto',
+      style: {
+        buttonDisplayMode: 'off',
+        nameDisplayMode: 'on',
+      },
+      insertDefaultUI: false,
+    };
+
+    const subscriber = this.clientSession.subscribe(stream, undefined, subscriberOptions);
+
+    subscriber.on('videoElementCreated', (videoElementCreatedEvent: VideoElementCreatedEvent) => {
+      const { element } = videoElementCreatedEvent;
+      const subscriberWrapper: SubscriberWrapper = {
+        // subscriber.id is refers to the targetElement id and will be undefined when insertDefaultUI is false so we use streamId to track our subscriber
+        id: streamId,
+        element,
+        isPinned: false,
+        isScreenshare,
+        subscriber,
+      };
+
+      this.emit('subscriberVideoElementCreated', subscriberWrapper);
+    });
+    subscriber.on('destroyed', () => {
+      this.emit('subscriberDestroyed', streamId);
+    });
+
+    // Create moving average tracker and add handler for subscriber audioLevelUpdated event emitted periodically with subscriber audio volume
+    // See for reference: https://developer.vonage.com/en/video/guides/ui-customization/general-customization#adjusting-user-interface-based-on-audio-levels
+    const getMovingAverageAudioLevel = createMovingAvgAudioLevelTracker();
+    subscriber.on('audioLevelUpdated', ({ audioLevel }) => {
+      const { logMovingAvg } = getMovingAverageAudioLevel(audioLevel);
+      this.emit('subscriberAudioLevelUpdated', { movingAvg: logMovingAvg, subscriberId: streamId });
+    });
+
+    if (isScreenshare) {
+      this.emit('screenshareStreamCreated');
+    }
+  }
+
+  /**
+   * Emits an event when a stream property changes.
+   * @private
+   */
+  private handleStreamPropertyChanged() {
+    this.emit('streamPropertyChanged');
+  }
+
+  /**
+   * Handles incoming signals and emits specific events based on the signal type.
+   * @param {SignalEvent} event - The signal event received from the session.
+   * @private
+   */
+  private handleSignal(event: SignalEvent) {
+    const { type } = event;
+    if (type === 'signal:chat' || type === 'signal:emoji') {
+      this.emit(type, event);
+    }
+  }
+
+  /**
+   * Emits an event when the session is reconnecting.
+   * @private
+   */
+  private handleReconnecting() {
+    this.emit('sessionReconnecting');
+  }
+
+  /**
+   * Emits an event when the session has reconnected.
+   * @private
+   */
+  private handleReconnected() {
+    this.emit('sessionReconnected');
+  }
+
+  /**
+   * Emits an event when the session is disconnected.
+   * @private
+   */
+  private handleSessionDisconnected() {
+    this.emit('sessionDisconnected');
+  }
+
+  /**
+   * Emits an event when an archive starts.
+   * @param {{ id: string }} param - The archive ID.
+   * @private
+   */
+  private handleArchiveStarted({ id }: { id: string }) {
+    this.emit('archiveStarted', id);
+  }
+
+  /**
+   * Emits an event when an archive stops.
+   * @private
+   */
+  private handleArchiveStopped() {
+    this.emit('archiveStopped');
+  }
+
+  /**
+   * Connects to the Vonage Video session using the provided credentials.
+   * @returns {Promise<void>} Resolves when the connection is successful, rejects on error.
+   */
+  async connect(): Promise<void> {
+    const { apiKey, sessionId, token } = this.credential;
+
+    await new Promise((resolve, reject) => {
+      if (!this.clientSession) {
+        reject(new Error('Session has not been initialized.'));
+      }
+      this.clientSession?.connect(token, (err?: OTError) => {
+        if (err) {
+          console.error('Error connecting to session:', err);
+          // We ignore the following lint warning because we are rejecting with an OTError object.
+          reject(err); // NOSONAR
+        } else {
+          logOnConnect(apiKey, sessionId, this.clientSession?.connection?.connectionId);
+          resolve(this.clientSession?.sessionId);
+        }
+      });
+    });
+  }
+
+  /**
+   * Disconnects from the current session and cleans up the session object.
+   */
+  disconnect() {
+    this.clientSession?.disconnect();
+    this.clientSession = null;
+  }
+
+  /**
+   * Forces a specific stream to be muted.
+   * @param {Stream} stream - The stream to be muted.
+   */
+  async forceMuteStream(stream: Stream) {
+    await this.clientSession?.forceMuteStream(stream);
+  }
+
+  /**
+   * Publishes a stream to the session.
+   * @param {Publisher} publisher - The publisher object to be published.
+   * @throws {Error} Throws an error if publishing fails.
+   */
+  publish(publisher: Publisher): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.clientSession?.publish(publisher, (error) => {
+        if (error) {
+          reject(new Error(`${error.name}: ${error.message}`));
+        }
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Sends a signal to all participants in the session.
+   * @param {SignalType} data - The signal data to be sent.
+   */
+  signal(data: SignalType) {
+    this.clientSession?.signal(data);
+  }
+
+  /**
+   * Unpublishes a stream from the session.
+   * @param {Publisher} publisher - The publisher object to be unpublished.
+   */
+  unpublish(publisher: Publisher) {
+    this.clientSession?.unpublish(publisher);
+  }
+
+  /**
+   * Gets the session ID of the current session.
+   * @returns {string | undefined} The session ID.
+   */
+  get sessionId(): string | undefined {
+    return this.clientSession?.sessionId;
+  }
+
+  /**
+   * Gets the connection ID of the current session.
+   * @returns {string | undefined} The connection ID.
+   */
+  get connectionId(): string | undefined {
+    return this.clientSession?.connection?.connectionId;
+  }
+}
+
+export default VonageVideoClient;


### PR DESCRIPTION
#### What is this PR doing?
Refactors the session context so that the Vonage Video API parts are inside a separate non-react, plain-old ~JavaScript~ TypeScript class. This will allow for easier testing in the future, e.g. captions 👀 . We talked about doing this since the [pinning PR](https://github.com/Vonage/vonage-video-react-app/pull/41/) since that was running into issues with mocking.

*note*: I force-pushed the wrong commit and had to open a new PR, some (addressed) comments are here: https://github.com/Vonage/vonage-video-react-app/pull/140

#### How should this be manually tested?
- checkout this branch
- pub/sub in a room with a few users

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3442](https://jira.vonage.com/browse/VIDCS-3442)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?