### PR TITLE
VIDCS-3699: Implement server-side controls of captions 

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,8 @@
     "express": "^4.21.2",
     "form-data": "^4.0.1",
     "opentok": "^2.16.0",
-    "tsx": "^4.10.5"
+    "tsx": "^4.10.5",
+    "opentok-jwt": "^0.1.5"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/backend/routes/session.ts
+++ b/backend/routes/session.ts
@@ -91,15 +91,11 @@ sessionRouter.post(
       const { room: roomName } = req.params;
       const sessionId = await sessionService.getSession(roomName);
       if (sessionId) {
-        if (videoService.enableCaptions) {
-          const captions = await videoService.enableCaptions(sessionId);
-          res.json({
-            captions,
-            status: 200,
-          });
-        } else {
-          res.status(500).json({ message: 'Captions service is unavailable' });
-        }
+        const captions = await videoService.enableCaptions(sessionId);
+        res.json({
+          captions,
+          status: 200,
+        });
       } else {
         res.status(404).json({ message: 'Room not found' });
       }
@@ -115,17 +111,11 @@ sessionRouter.post(
   async (req: Request<{ room: string; captionId: string }>, res: Response) => {
     try {
       const { captionId } = req.params;
-      if (captionId) {
-        if (videoService.disableCaptions) {
-          const responseCaptionId = await videoService.disableCaptions(captionId);
-          res.json({
-            captionId: responseCaptionId,
-            status: 200,
-          });
-        } else {
-          res.status(500).json({ message: 'Captions service is unavailable' });
-        }
-      }
+      const responseCaptionId = await videoService.disableCaptions(captionId);
+      res.json({
+        captionId: responseCaptionId,
+        status: 200,
+      });
     } catch (error: unknown) {
       res.status(500).send({ message: (error as Error).message ?? error });
     }

--- a/backend/routes/session.ts
+++ b/backend/routes/session.ts
@@ -84,4 +84,52 @@ sessionRouter.get('/:room/archives', async (req: Request<{ room: string }>, res:
   }
 });
 
+sessionRouter.post(
+  '/:room/enableCaptions',
+  async (req: Request<{ room: string }>, res: Response) => {
+    try {
+      const { room: roomName } = req.params;
+      const sessionId = await sessionService.getSession(roomName);
+      if (sessionId) {
+        if (videoService.enableCaptions) {
+          const captions = await videoService.enableCaptions(sessionId);
+          res.json({
+            captions,
+            status: 200,
+          });
+        } else {
+          res.status(500).json({ message: 'Captions service is unavailable' });
+        }
+      } else {
+        res.status(404).json({ message: 'Room not found' });
+      }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+      res.status(500).json({ message: errorMessage });
+    }
+  }
+);
+
+sessionRouter.post(
+  '/:room/:captionId/disableCaptions',
+  async (req: Request<{ room: string; captionId: string }>, res: Response) => {
+    try {
+      const { captionId } = req.params;
+      if (captionId) {
+        if (videoService.disableCaptions) {
+          const responseCaptionId = await videoService.disableCaptions(captionId);
+          res.json({
+            captionId: responseCaptionId,
+            status: 200,
+          });
+        } else {
+          res.status(500).json({ message: 'Captions service is unavailable' });
+        }
+      }
+    } catch (error: unknown) {
+      res.status(500).send({ message: (error as Error).message ?? error });
+    }
+  }
+);
+
 export default sessionRouter;

--- a/backend/tests/session.test.ts
+++ b/backend/tests/session.test.ts
@@ -22,6 +22,8 @@ await jest.unstable_mockModule('../videoService/opentokVideoService.ts', () => {
       return {
         startArchive: jest.fn<() => Promise<string>>().mockResolvedValue('archiveId'),
         stopArchive: jest.fn<() => Promise<string>>().mockRejectedValue('invalid archive'),
+        enableCaptions: jest.fn<() => Promise<string>>().mockResolvedValue('captionId'),
+        disableCaptions: jest.fn<() => Promise<string>>().mockResolvedValue('invalid caption'),
         generateToken: jest
           .fn<() => Promise<{ token: string; apiKey: string }>>()
           .mockResolvedValue({
@@ -70,28 +72,47 @@ describe.each([
   });
 
   describe('POST requests', () => {
-    it('returns a 200 when starting an archive in a room', async () => {
-      const res = await request(server)
-        .post(`/session/${roomName}/startArchive`)
-        .set('Content-Type', 'application/json');
-      expect(res.statusCode).toEqual(200);
+    describe('archiving', () => {
+      it('returns a 200 when starting an archive in a room', async () => {
+        const res = await request(server)
+          .post(`/session/${roomName}/startArchive`)
+          .set('Content-Type', 'application/json');
+        expect(res.statusCode).toEqual(200);
+      });
+
+      it('returns a 404 when starting an archive in a non-existent room', async () => {
+        const invalidRoomName = 'nonExistingRoomName';
+        const res = await request(server)
+          .post(`/session/${invalidRoomName}/startArchive`)
+          .set('Content-Type', 'application/json');
+        expect(res.statusCode).toEqual(404);
+      });
+
+      it('returns a 500 when stopping an invalid archive in a room', async () => {
+        const archiveId = 'b8-c9-d10';
+        const res = await request(server)
+          .post(`/session/${roomName}/${archiveId}/stopArchive`)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json');
+        expect(res.statusCode).toEqual(500);
+      });
     });
 
-    it('returns a 404 when starting an archive in a non-existent room', async () => {
-      const invalidRoomName = 'nonExistingRoomName';
-      const res = await request(server)
-        .post(`/session/${invalidRoomName}/startArchive`)
-        .set('Content-Type', 'application/json');
-      expect(res.statusCode).toEqual(404);
-    });
+    describe('captions', () => {
+      it('returns a 200 when enabling captions in a room', async () => {
+        const res = await request(server)
+          .post(`/session/${roomName}/enableCaptions`)
+          .set('Content-Type', 'application/json');
+        expect(res.statusCode).toEqual(200);
+      });
 
-    it('returns a 500 when stopping an invalid archive in a room', async () => {
-      const archiveId = 'b8-c9-d10';
-      const res = await request(server)
-        .post(`/session/${roomName}/${archiveId}/stopArchive`)
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json');
-      expect(res.statusCode).toEqual(500);
+      it('returns a 200 when disabling captions in a room', async () => {
+        const captionId = 'someCaptionId';
+        const res = await request(server)
+          .post(`/session/${roomName}/${captionId}/disableCaptions`)
+          .set('Content-Type', 'application/json');
+        expect(res.statusCode).toEqual(200);
+      });
     });
   });
 });

--- a/backend/tests/session.test.ts
+++ b/backend/tests/session.test.ts
@@ -122,7 +122,7 @@ describe.each([
         expect(res.statusCode).toEqual(404);
       });
 
-      it('returns a 500 when stopping an invalid captions in a room', async () => {
+      it('returns an invalid caption message when stopping an invalid captions in a room', async () => {
         const invalidCaptionId = 'wrongCaptionId';
         const res = await request(server)
           .post(`/session/${roomName}/${invalidCaptionId}/disableCaptions`)

--- a/backend/tests/session.test.ts
+++ b/backend/tests/session.test.ts
@@ -113,6 +113,25 @@ describe.each([
           .set('Content-Type', 'application/json');
         expect(res.statusCode).toEqual(200);
       });
+
+      it('returns a 404 when starting captions in a non-existent room', async () => {
+        const invalidRoomName = 'randomRoomName';
+        const res = await request(server)
+          .post(`/session/${invalidRoomName}/enableCaptions`)
+          .set('Content-Type', 'application/json');
+        expect(res.statusCode).toEqual(404);
+      });
+
+      it('returns a 500 when stopping an invalid captions in a room', async () => {
+        const invalidCaptionId = 'wrongCaptionId';
+        const res = await request(server)
+          .post(`/session/${roomName}/${invalidCaptionId}/disableCaptions`)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json');
+
+        const responseBody = JSON.parse(res.text);
+        expect(responseBody.captionId).toEqual('invalid caption');
+      });
     });
   });
 });

--- a/backend/types/opentok-jwt-d.ts
+++ b/backend/types/opentok-jwt-d.ts
@@ -1,0 +1,4 @@
+declare module 'opentok-jwt' {
+  // eslint-disable-next-line import/prefer-default-export
+  export function projectToken(apiKey: string, apiSecret: string, expire?: number): string;
+}

--- a/backend/videoService/opentokVideoService.ts
+++ b/backend/videoService/opentokVideoService.ts
@@ -1,6 +1,12 @@
 import OpenTok, { Archive, Role } from 'opentok';
+import axios from 'axios';
+import { projectToken } from 'opentok-jwt';
 import { VideoService } from './videoServiceInterface';
 import { OpentokConfig } from '../types/config';
+
+export type EnableCaptionResponse = {
+  captionsId: string;
+};
 
 class OpenTokVideoService implements VideoService {
   private readonly opentok: OpenTok;
@@ -86,6 +92,60 @@ class OpenTokVideoService implements VideoService {
         }
       });
     });
+  }
+
+  // The OpenTok API does not support enabling captions directly through the OpenTok SDK.
+  // Instead, we need to make a direct HTTP request to the OpenTok API endpoint to enable captions.
+  // This is not the case for Vonage Video Node SDK, which has a built-in method for enabling captions.
+  readonly API_URL = 'https://api.opentok.com/v2/project';
+
+  async enableCaptions(sessionId: string): Promise<EnableCaptionResponse> {
+    const expires = Math.floor(new Date().getTime() / 1000) + 24 * 60 * 60;
+    // Note that the project token is different from the session token.
+    // The project token is used to authenticate the request to the OpenTok API.
+    const projectJWT = projectToken(this.config.apiKey, this.config.apiSecret, expires);
+    const captionURL = `${this.API_URL}/${this.config.apiKey}/captions`;
+
+    const requestToken = this.generateToken(sessionId);
+    const { token } = requestToken;
+    const captionAxiosPostBody = {
+      sessionId,
+      token,
+      languageCode: 'en-US',
+      maxDuration: 1800,
+      partialCaptions: true,
+    };
+
+    const response = await axios.post(captionURL, captionAxiosPostBody, {
+      headers: {
+        'X-OPENTOK-AUTH': projectJWT,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const responseData: EnableCaptionResponse = {
+      captionsId: response.data.captionsId,
+    };
+    return responseData;
+  }
+
+  async disableCaptions(captionId: string): Promise<string> {
+    const expires = Math.floor(new Date().getTime() / 1000) + 24 * 60 * 60;
+    // Note that the project token is different from the session token.
+    // The project token is used to authenticate the request to the OpenTok API.
+    const projectJWT = projectToken(this.config.apiKey, this.config.apiSecret, expires);
+    const captionURL = `${this.API_URL}/${this.config.apiKey}/captions/${captionId}/stop`;
+    await axios.post(
+      captionURL,
+      {},
+      {
+        headers: {
+          'X-OPENTOK-AUTH': projectJWT,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    return 'Captions stopped successfully';
   }
 }
 

--- a/backend/videoService/opentokVideoService.ts
+++ b/backend/videoService/opentokVideoService.ts
@@ -107,10 +107,10 @@ class OpenTokVideoService implements VideoService {
     const captionURL = `${this.API_URL}/${this.config.apiKey}/captions`;
 
     const { token } = this.generateToken(sessionId);
-    const captionAxiosPostBody = {
-      sessionId,
-      token,
+    const captionOptions = {
+      // The following language codes are supported: en-US, en-AU, en-GB, fr-FR, fr-CA, de-DE, hi-IN, it-IT, pt-BR, ja-JP, ko-KR, zh-CN, zh-TW
       languageCode: 'en-US',
+      // The maximum duration of the captions in seconds. The default is 14,400 seconds (4 hours).
       maxDuration: 1800,
       // Enabling partial captions allows for more frequent updates to the captions.
       // This is useful for real-time applications where the captions need to be updated frequently.
@@ -118,15 +118,26 @@ class OpenTokVideoService implements VideoService {
       partialCaptions: true,
     };
 
-    const {
-      data: { captionsId },
-    } = await axios.post(captionURL, captionAxiosPostBody, {
-      headers: {
-        'X-OPENTOK-AUTH': projectJWT,
-        'Content-Type': 'application/json',
-      },
-    });
-    return { captionsId };
+    const captionAxiosPostBody = {
+      sessionId,
+      token,
+      ...captionOptions,
+    };
+
+    try {
+      const {
+        data: { captionsId },
+      } = await axios.post(captionURL, captionAxiosPostBody, {
+        headers: {
+          'X-OPENTOK-AUTH': projectJWT,
+          'Content-Type': 'application/json',
+        },
+      });
+      return { captionsId };
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+      throw new Error(`Failed to enable captions: ${errorMessage}`);
+    }
   }
 
   async disableCaptions(captionId: string): Promise<string> {

--- a/backend/videoService/opentokVideoService.ts
+++ b/backend/videoService/opentokVideoService.ts
@@ -130,22 +130,28 @@ class OpenTokVideoService implements VideoService {
   }
 
   async disableCaptions(captionId: string): Promise<string> {
-    const expires = Math.floor(new Date().getTime() / 1000) + 24 * 60 * 60;
-    // Note that the project token is different from the session token.
-    // The project token is used to authenticate the request to the OpenTok API.
-    const projectJWT = projectToken(this.config.apiKey, this.config.apiSecret, expires);
-    const captionURL = `${this.API_URL}/${this.config.apiKey}/captions/${captionId}/stop`;
-    await axios.post(
-      captionURL,
-      {},
-      {
-        headers: {
-          'X-OPENTOK-AUTH': projectJWT,
-          'Content-Type': 'application/json',
-        },
-      }
-    );
-    return 'Captions stopped successfully';
+    try {
+      const expires = Math.floor(new Date().getTime() / 1000) + 24 * 60 * 60;
+      // Note that the project token is different from the session token.
+      // The project token is used to authenticate the request to the OpenTok API.
+      const projectJWT = projectToken(this.config.apiKey, this.config.apiSecret, expires);
+      const captionURL = `${this.API_URL}/${this.config.apiKey}/captions/${captionId}/stop`;
+
+      await axios.post(
+        captionURL,
+        {},
+        {
+          headers: {
+            'X-OPENTOK-AUTH': projectJWT,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      return 'Captions stopped successfully';
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+      throw new Error(`Failed to disable captions: ${errorMessage}`);
+    }
   }
 }
 

--- a/backend/videoService/tests/opentokVideoService.test.ts
+++ b/backend/videoService/tests/opentokVideoService.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+const mockSessionId = 'mockSessionId';
+const mockToken = 'mockToken';
+const mockApiKey = 'mockApplicationId';
+const mockArchiveId = 'mockArchiveId';
+const mockRoomName = 'awesomeRoomName';
+const mockCaptionId = 'mockCaptionId';
+const mockApiSecret = 'mockApiSecret';
+
+await jest.unstable_mockModule('opentok', () => ({
+  default: jest.fn().mockImplementation(() => ({
+    createSession: jest.fn(
+      (_options: unknown, callback: (err: unknown, session: { sessionId: string }) => void) => {
+        callback(null, { sessionId: mockSessionId });
+      }
+    ),
+    generateToken: jest.fn<() => { token: string; apiKey: string }>().mockReturnValue({
+      token: mockToken,
+      apiKey: mockApiKey,
+    }),
+    startArchive: jest.fn(
+      (
+        _sessionId: string,
+        _options: unknown,
+        callback: (
+          err: unknown,
+          session: {
+            archive: {
+              id: string;
+            };
+          }
+        ) => void
+      ) => {
+        callback(null, {
+          archive: {
+            id: mockArchiveId,
+          },
+        });
+      }
+    ),
+    stopArchive: jest.fn(
+      (_archiveId: string, callback: (err: unknown, archive: { archiveId: string }) => void) => {
+        callback(null, { archiveId: mockArchiveId });
+      }
+    ),
+    listArchives: jest.fn(
+      (_options: unknown, callback: (err: unknown, archives: [{ archiveId: string }]) => void) => {
+        callback(null, [{ archiveId: mockArchiveId }]);
+      }
+    ),
+  })),
+  mediaMode: 'routed',
+}));
+
+await jest.unstable_mockModule('axios', () => ({
+  default: {
+    post: jest.fn<() => Promise<{ data: { captionsId: string } }>>().mockResolvedValue({
+      data: { captionsId: mockCaptionId },
+    }),
+  },
+}));
+
+const { default: OpenTokVideoService } = await import('../opentokVideoService');
+
+describe('OpentokVideoService', () => {
+  let opentokVideoService: typeof OpenTokVideoService.prototype;
+
+  beforeEach(() => {
+    opentokVideoService = new OpenTokVideoService({
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+      provider: 'opentok',
+    });
+  });
+
+  it('creates a session', async () => {
+    const session = await opentokVideoService.createSession();
+    expect(session).toBe(mockSessionId);
+  });
+
+  it('generates a token', () => {
+    const result = opentokVideoService.generateToken(mockSessionId);
+    expect(result.token).toEqual({
+      apiKey: mockApiKey,
+      token: mockToken,
+    });
+  });
+
+  it('starts an archive', async () => {
+    const response = await opentokVideoService.startArchive(mockRoomName, mockSessionId);
+    expect(response).toMatchObject({
+      archive: {
+        id: mockArchiveId,
+      },
+    });
+  });
+
+  it('stops an archive', async () => {
+    const archiveResponse = await opentokVideoService.stopArchive(mockArchiveId);
+    expect(archiveResponse).toBe(mockArchiveId);
+  });
+
+  it('generates a list of archives', async () => {
+    const archiveResponse = await opentokVideoService.listArchives(mockSessionId);
+    expect(archiveResponse).toEqual([{ archiveId: mockArchiveId }]);
+  });
+
+  it('enables captions', async () => {
+    const captionResponse = await opentokVideoService.enableCaptions(mockSessionId);
+    expect(captionResponse.captionsId).toBe(mockCaptionId);
+  });
+
+  it('disables captions', async () => {
+    const captionResponse = await opentokVideoService.disableCaptions(mockCaptionId);
+    expect(captionResponse).toBe('Captions stopped successfully');
+  });
+});

--- a/backend/videoService/tests/vonageVideoService.test.ts
+++ b/backend/videoService/tests/vonageVideoService.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@vonage/auth');
+
+await jest.unstable_mockModule('@vonage/video', () => {
+  return {
+    Video: jest.fn().mockImplementation(() => ({
+      createSession: jest.fn<() => Promise<{ sessionId: string }>>().mockResolvedValue({
+        sessionId: '12345',
+      }),
+    })),
+    LayoutType: {
+      BEST_FIT: 'bestFit',
+      HORIZONTAL_PRESENTATION: 'horizontalPresentation',
+      CUSTOM: 'custom',
+    },
+    MediaMode: {
+      ROUTED: 'routed',
+    },
+    Resolution: {
+      FHD_LANDSCAPE: '1920x1080',
+    },
+  };
+});
+
+const { default: VonageVideoService } = await import('../vonageVideoService');
+
+describe('VonageVideoService', () => {
+  let vonageVideoService: typeof VonageVideoService.prototype;
+
+  beforeEach(() => {
+    vonageVideoService = new VonageVideoService({
+      applicationId: 'abcd-1234',
+      privateKey: 'blah-blah-blah',
+      provider: 'vonage',
+    });
+  });
+
+  it('can create a session', async () => {
+    const session = await vonageVideoService.createSession();
+    expect(session).toBe('12345');
+  });
+});

--- a/backend/videoService/tests/vonageVideoService.test.ts
+++ b/backend/videoService/tests/vonageVideoService.test.ts
@@ -2,11 +2,35 @@ import { describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('@vonage/auth');
 
+const mockSessionId = 'mockSessionId';
+const mockToken = 'mockToken';
+const mockApplicationId = 'mockApplicationId';
+const mockArchiveId = 'mockArchiveId';
+const mockRoomName = 'awesomeRoomName';
+const mockCaptionId = 'mockCaptionId';
+const mockPrivateKey = 'mockPrivateKey';
+
 await jest.unstable_mockModule('@vonage/video', () => {
   return {
     Video: jest.fn().mockImplementation(() => ({
       createSession: jest.fn<() => Promise<{ sessionId: string }>>().mockResolvedValue({
-        sessionId: '12345',
+        sessionId: mockSessionId,
+      }),
+      generateClientToken: jest.fn<() => { token: string; apiKey: string }>().mockReturnValue({
+        token: mockToken,
+        apiKey: mockApplicationId,
+      }),
+      startArchive: jest.fn<() => Promise<{ id: string }>>().mockResolvedValue({
+        id: mockArchiveId,
+      }),
+      stopArchive: jest.fn<() => Promise<{ status: number }>>().mockResolvedValue({
+        status: 200,
+      }),
+      enableCaptions: jest.fn<() => Promise<{ captionsId: string }>>().mockResolvedValue({
+        captionsId: mockCaptionId,
+      }),
+      disableCaptions: jest.fn<() => Promise<{ status: number }>>().mockResolvedValue({
+        status: 200,
       }),
     })),
     LayoutType: {
@@ -30,14 +54,42 @@ describe('VonageVideoService', () => {
 
   beforeEach(() => {
     vonageVideoService = new VonageVideoService({
-      applicationId: 'abcd-1234',
-      privateKey: 'blah-blah-blah',
+      applicationId: mockApplicationId,
+      privateKey: mockPrivateKey,
       provider: 'vonage',
     });
   });
 
-  it('can create a session', async () => {
+  it('creates a session', async () => {
     const session = await vonageVideoService.createSession();
-    expect(session).toBe('12345');
+    expect(session).toBe(mockSessionId);
+  });
+
+  it('generates a token', () => {
+    const result = vonageVideoService.generateToken(mockSessionId);
+    expect(result.token).toEqual({
+      apiKey: mockApplicationId,
+      token: mockToken,
+    });
+  });
+
+  it('starts an archive', async () => {
+    const archive = await vonageVideoService.startArchive(mockRoomName, mockSessionId);
+    expect(archive.id).toBe(mockArchiveId);
+  });
+
+  it('stops an archive', async () => {
+    const archiveResponse = await vonageVideoService.stopArchive(mockArchiveId);
+    expect(archiveResponse).toBe('Archive stopped successfully');
+  });
+
+  it('enables captions', async () => {
+    const captionResponse = await vonageVideoService.enableCaptions(mockSessionId);
+    expect(captionResponse.captionsId).toBe(mockCaptionId);
+  });
+
+  it('disables captions', async () => {
+    const captionResponse = await vonageVideoService.disableCaptions(mockCaptionId);
+    expect(captionResponse).toBe('Captions stopped successfully');
   });
 });

--- a/backend/videoService/videoServiceInterface.ts
+++ b/backend/videoService/videoServiceInterface.ts
@@ -1,4 +1,4 @@
-import { SingleArchiveResponse } from '@vonage/video';
+import { SingleArchiveResponse, EnableCaptionResponse } from '@vonage/video';
 import { Archive } from 'opentok';
 
 export interface VideoService {
@@ -7,4 +7,6 @@ export interface VideoService {
   startArchive(roomName: string, sessionId: string): Promise<Archive | SingleArchiveResponse>;
   stopArchive(archiveId: string): Promise<string>;
   listArchives(sessionId: string): Promise<Archive[] | SingleArchiveResponse[] | undefined>;
+  enableCaptions(sessionId: string): Promise<EnableCaptionResponse | string | undefined>;
+  disableCaptions(captionId: string): Promise<string>;
 }

--- a/backend/videoService/videoServiceInterface.ts
+++ b/backend/videoService/videoServiceInterface.ts
@@ -7,6 +7,6 @@ export interface VideoService {
   startArchive(roomName: string, sessionId: string): Promise<Archive | SingleArchiveResponse>;
   stopArchive(archiveId: string): Promise<string>;
   listArchives(sessionId: string): Promise<Archive[] | SingleArchiveResponse[] | undefined>;
-  enableCaptions(sessionId: string): Promise<EnableCaptionResponse | string | undefined>;
+  enableCaptions(sessionId: string): Promise<EnableCaptionResponse>;
   disableCaptions(captionId: string): Promise<string>;
 }

--- a/backend/videoService/vonageVideoService.ts
+++ b/backend/videoService/vonageVideoService.ts
@@ -7,6 +7,7 @@ import {
   SingleArchiveResponse,
   Video,
   EnableCaptionResponse,
+  CaptionOptions,
 } from '@vonage/video';
 import { VideoService } from './videoServiceInterface';
 import { VonageConfig } from '../types/config';
@@ -70,8 +71,29 @@ class VonageVideoService implements VideoService {
   async enableCaptions(sessionId: string): Promise<EnableCaptionResponse> {
     const requestToken = this.generateToken(sessionId);
     const { token } = requestToken;
-    return this.vonageVideo.enableCaptions(sessionId, token);
+
+    try {
+      const captionOptions: CaptionOptions = {
+        // The maximum duration of the captions in seconds. The default is 14,400 seconds (4 hours).
+        maxDuration: 1800,
+        // Enabling partial captions allows for more frequent updates to the captions.
+        // This is useful for real-time applications where the captions need to be updated frequently.
+        // However, it may also increase the number of inaccuracies in the captions.
+        partialCaptions: 'true',
+      };
+      const captionsId = await this.vonageVideo.enableCaptions(sessionId, token, captionOptions);
+      return captionsId;
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+      throw new Error(`Failed to enable captions: ${errorMessage}`);
+    }
   }
+
+  // async enableCaptions(sessionId: string): Promise<EnableCaptionResponse> {
+  //   const requestToken = this.generateToken(sessionId);
+  //   const { token } = requestToken;
+  //   return this.vonageVideo.enableCaptions(sessionId, token);
+  // }
 
   async disableCaptions(captionId: string): Promise<string> {
     try {

--- a/backend/videoService/vonageVideoService.ts
+++ b/backend/videoService/vonageVideoService.ts
@@ -74,8 +74,13 @@ class VonageVideoService implements VideoService {
   }
 
   async disableCaptions(captionId: string): Promise<string> {
-    await this.vonageVideo.disableCaptions(captionId);
-    return 'Captions stopped successfully';
+    try {
+      await this.vonageVideo.disableCaptions(captionId);
+      return 'Captions stopped successfully';
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+      throw new Error(`Failed to disable captions: ${errorMessage}`);
+    }
   }
 }
 

--- a/backend/videoService/vonageVideoService.ts
+++ b/backend/videoService/vonageVideoService.ts
@@ -89,12 +89,6 @@ class VonageVideoService implements VideoService {
     }
   }
 
-  // async enableCaptions(sessionId: string): Promise<EnableCaptionResponse> {
-  //   const requestToken = this.generateToken(sessionId);
-  //   const { token } = requestToken;
-  //   return this.vonageVideo.enableCaptions(sessionId, token);
-  // }
-
   async disableCaptions(captionId: string): Promise<string> {
     try {
       await this.vonageVideo.disableCaptions(captionId);

--- a/backend/videoService/vonageVideoService.ts
+++ b/backend/videoService/vonageVideoService.ts
@@ -1,6 +1,13 @@
 /* eslint-disable no-underscore-dangle */
 import { Auth } from '@vonage/auth';
-import { LayoutType, MediaMode, Resolution, SingleArchiveResponse, Video } from '@vonage/video';
+import {
+  LayoutType,
+  MediaMode,
+  Resolution,
+  SingleArchiveResponse,
+  Video,
+  EnableCaptionResponse,
+} from '@vonage/video';
 import { VideoService } from './videoServiceInterface';
 import { VonageConfig } from '../types/config';
 
@@ -58,6 +65,17 @@ class VonageVideoService implements VideoService {
   async stopArchive(archiveId: string): Promise<string> {
     await this.vonageVideo.stopArchive(archiveId);
     return 'Archive stopped successfully';
+  }
+
+  async enableCaptions(sessionId: string): Promise<EnableCaptionResponse> {
+    const requestToken = this.generateToken(sessionId);
+    const { token } = requestToken;
+    return this.vonageVideo.enableCaptions(sessionId, token);
+  }
+
+  async disableCaptions(captionId: string): Promise<string> {
+    await this.vonageVideo.disableCaptions(captionId);
+    return 'Captions stopped successfully';
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6890,6 +6890,13 @@ oniguruma-to-js@0.4.3:
   dependencies:
     regex "^4.3.2"
 
+opentok-jwt@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/opentok-jwt/-/opentok-jwt-0.1.5.tgz#c7c84724fc4d287f3a08f4264f97935cbbdb624e"
+  integrity sha512-Ub3iQEYava3oHK9Xp+UePFw9mratzp98LuDx46qtfkAFzsIKePlwBbj6UZ4pGuJDXZ28BJWpnXZyRWMJK9IW6w==
+  dependencies:
+    jsonwebtoken "^9.0.0"
+
 opentok-layout-js@^5.4.0:
   version "5.4.0"
   resolved "https://registry.npmjs.org/opentok-layout-js/-/opentok-layout-js-5.4.0.tgz"


### PR DESCRIPTION
#### What is this PR doing?

This PR implements server-side controls of captions. 

#### How should this be manually tested?

This needs to be tested with both `vonage` and `opentok` as `VIDEO_SERVICE_PROVIDER`s in your `.env` file in the backend. For that, you'll need to have both Vonage applicationId and OpenTok API key.

To test this, you will also need to have Postman installed. 
Once that is done, run the app by doing `yarn dev`.
In Postman, make a `GET` request to `localhost:3345/session/<room_name_of_your_choice>` (notice no trailing slash) - this is going to create a room for you - captions cannot be enabled unless a room has already been created. 
After that, make a `POST` request to `localhost:3345/session/<room_name_of_your_choice>/enableCaptions`.
Notice that you are getting a return that looks something like this:

```
{
    "captions": {
        "captionsId": "3f9ed25c-a12c-4ff4-abe9-428f4371dae2"
    },
    "status": 200
}
```
Copy-paste the `captionsId` you got back and make a `POST` request to `localhost:3345/session/<room_name_of_your_choice>/<captionsId_here>/disableCaptions`. 
If using the example above, `<captionsId_here>` would be `3f9ed25c-a12c-4ff4-abe9-428f4371dae2`. 


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3699](https://jira.vonage.com/browse/VIDCS-3699)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?