### PR TITLE
VIDCS-3791: Muted indicator does not promptly update when a user mutes

### DIFF
--- a/frontend/src/Context/SessionProvider/session.tsx
+++ b/frontend/src/Context/SessionProvider/session.tsx
@@ -18,6 +18,7 @@ import useRightPanel, { RightPanelActiveTab } from '../../hooks/useRightPanel';
 import {
   Credential,
   SignalEvent,
+  StreamPropertyChangedEvent,
   SubscriberAudioLevelUpdatedEvent,
   SubscriberWrapper,
 } from '../../types/session';
@@ -62,6 +63,7 @@ export type SessionContextType = {
   emojiQueue: EmojiWrapper[];
   publish: (publisher: Publisher) => Promise<void>;
   unpublish: (publisher: Publisher) => void;
+  changedStream: ChangedStreamType | null;
 };
 
 /**
@@ -93,12 +95,19 @@ export const SessionContext = createContext<SessionContextType>({
   emojiQueue: [],
   publish: async () => Promise.resolve(),
   unpublish: () => {},
+  changedStream: null,
 });
 
 export type ConnectionEventType = {
   connection: Connection;
   reason?: string;
   id?: string;
+};
+
+type ChangedStreamType = {
+  stream: Stream;
+  changedProperty: 'hasAudio' | 'hasVideo' | 'videoDimensions';
+  newValue: boolean | { width: number; height: number };
 };
 
 /**
@@ -120,7 +129,7 @@ const MAX_PIN_COUNT = isMobile() ? MAX_PIN_COUNT_MOBILE : MAX_PIN_COUNT_DESKTOP;
  * @returns {SessionContextType} a context provider for a publisher preview
  */
 const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
-  const [, forceUpdate] = useState<boolean>(false); // NOSONAR
+  const [changedStream, setChangedStream] = useState<ChangedStreamType | null>(null);
   const vonageVideoClient = useRef<null | VonageVideoClient>(null);
   const [reconnecting, setReconnecting] = useState(false);
   const [subscriberWrappers, setSubscriberWrappers] = useState<SubscriberWrapper[]>([]);
@@ -159,7 +168,7 @@ const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
     (emojiEvent: SignalEvent) => {
       setSubscriberWrappers((currentSubscriberWrappers) => {
         onEmoji(emojiEvent, currentSubscriberWrappers);
-        return currentSubscriberWrappers; // Return unchanged state
+        return [...currentSubscriberWrappers]; // Return unchanged state
       });
     },
     [onEmoji]
@@ -229,11 +238,13 @@ const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
 
   /**
    * Handles changes to stream properties. This triggers a re-render when a stream property changes
+   * @param {StreamPropertyChangedEvent} event - The event containing the stream, changed property, and new value.
    */
-  const handleStreamPropertyChanged = () => {
+  const handleStreamPropertyChanged = (event: StreamPropertyChangedEvent) => {
+    const { stream, changedProperty, newValue } = event;
     // Without a re-render during a stream change, we don't get visual indicators for a subscriber
     // muting themselves or the initials being displayed.
-    forceUpdate((prev) => !prev);
+    setChangedStream({ stream, changedProperty, newValue });
   };
 
   // handle the disconnect from session and clean up of the session object
@@ -418,6 +429,7 @@ const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
       emojiQueue,
       publish,
       unpublish,
+      changedStream, // This is used to force a re-render when a stream property changes
     }),
     [
       activeSpeakerId,
@@ -445,6 +457,7 @@ const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
       emojiQueue,
       publish,
       unpublish,
+      changedStream, // This is used to force a re-render when a stream property changes
     ]
   );
 

--- a/frontend/src/Context/SessionProvider/session.tsx
+++ b/frontend/src/Context/SessionProvider/session.tsx
@@ -63,7 +63,7 @@ export type SessionContextType = {
   emojiQueue: EmojiWrapper[];
   publish: (publisher: Publisher) => Promise<void>;
   unpublish: (publisher: Publisher) => void;
-  changedStream: ChangedStreamType | null;
+  lastStreamUpdate: StreamPropertyChangedEvent | null;
 };
 
 /**
@@ -95,19 +95,13 @@ export const SessionContext = createContext<SessionContextType>({
   emojiQueue: [],
   publish: async () => Promise.resolve(),
   unpublish: () => {},
-  changedStream: null,
+  lastStreamUpdate: null,
 });
 
 export type ConnectionEventType = {
   connection: Connection;
   reason?: string;
   id?: string;
-};
-
-type ChangedStreamType = {
-  stream: Stream;
-  changedProperty: 'hasAudio' | 'hasVideo' | 'videoDimensions';
-  newValue: boolean | { width: number; height: number };
 };
 
 /**
@@ -129,7 +123,7 @@ const MAX_PIN_COUNT = isMobile() ? MAX_PIN_COUNT_MOBILE : MAX_PIN_COUNT_DESKTOP;
  * @returns {SessionContextType} a context provider for a publisher preview
  */
 const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
-  const [changedStream, setChangedStream] = useState<ChangedStreamType | null>(null);
+  const [lastStreamUpdate, setLastStreamUpdate] = useState<StreamPropertyChangedEvent | null>(null);
   const vonageVideoClient = useRef<null | VonageVideoClient>(null);
   const [reconnecting, setReconnecting] = useState(false);
   const [subscriberWrappers, setSubscriberWrappers] = useState<SubscriberWrapper[]>([]);
@@ -241,10 +235,10 @@ const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
    * @param {StreamPropertyChangedEvent} event - The event containing the stream, changed property, and new value.
    */
   const handleStreamPropertyChanged = (event: StreamPropertyChangedEvent) => {
-    const { stream, changedProperty, newValue } = event;
+    const { stream, changedProperty, newValue, oldValue } = event;
     // Without a re-render during a stream change, we don't get visual indicators for a subscriber
     // muting themselves or the initials being displayed.
-    setChangedStream({ stream, changedProperty, newValue });
+    setLastStreamUpdate({ stream, changedProperty, newValue, oldValue });
   };
 
   // handle the disconnect from session and clean up of the session object
@@ -429,7 +423,7 @@ const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
       emojiQueue,
       publish,
       unpublish,
-      changedStream, // This is used to force a re-render when a stream property changes
+      lastStreamUpdate,
     }),
     [
       activeSpeakerId,
@@ -457,7 +451,7 @@ const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
       emojiQueue,
       publish,
       unpublish,
-      changedStream, // This is used to force a re-render when a stream property changes
+      lastStreamUpdate,
     ]
   );
 

--- a/frontend/src/Context/SessionProvider/session.tsx
+++ b/frontend/src/Context/SessionProvider/session.tsx
@@ -232,7 +232,7 @@ const SessionProvider = ({ children }: SessionProviderProps): ReactElement => {
 
   /**
    * Handles changes to stream properties. This triggers a re-render when a stream property changes
-   * @param {StreamPropertyChangedEvent} event - The event containing the stream, changed property, and new value.
+   * @param {StreamPropertyChangedEvent} event - The event containing the stream, changed property, new value, and old value.
    */
   const handleStreamPropertyChanged = (event: StreamPropertyChangedEvent) => {
     const { stream, changedProperty, newValue, oldValue } = event;

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -42,3 +42,10 @@ export type SignalType = {
 };
 
 export type SubscriberAudioLevelUpdatedEvent = { movingAvg: number; subscriberId: string };
+
+export type StreamPropertyChangedEvent = {
+  stream: Stream;
+  changedProperty: 'hasAudio' | 'hasVideo' | 'videoDimensions';
+  oldValue: boolean | { width: number; height: number };
+  newValue: boolean | { width: number; height: number };
+};

--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
@@ -146,7 +146,8 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
 
   /**
    * Emits an event when a stream property changes.
-   * @param event
+   * @param {StreamPropertyChangedEvent} event - The event containing the stream and the changed property.
+   * The event includes the stream, the changed property, and the old and new values.
    * @private
    */
   private handleStreamPropertyChanged = (event: StreamPropertyChangedEvent) => {

--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
@@ -15,6 +15,7 @@ import {
   SignalEvent,
   SignalType,
   SubscriberAudioLevelUpdatedEvent,
+  StreamPropertyChangedEvent,
 } from '../../types/session';
 import logOnConnect from '../logOnConnect';
 import createMovingAvgAudioLevelTracker from '../movingAverageAudioLevelTracker';
@@ -29,7 +30,7 @@ type VonageVideoClientEvents = {
   signal: [SignalEvent];
   'signal:chat': [SignalEvent];
   'signal:emoji': [SignalEvent];
-  streamPropertyChanged: [];
+  streamPropertyChanged: [StreamPropertyChangedEvent];
   subscriberVideoElementCreated: [SubscriberWrapper];
   subscriberDestroyed: [string];
   subscriberAudioLevelUpdated: [SubscriberAudioLevelUpdatedEvent];
@@ -77,7 +78,9 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
     this.clientSession.on('sessionReconnected', () => this.handleReconnected());
     this.clientSession.on('sessionReconnecting', () => this.handleReconnecting());
     this.clientSession.on('signal', (event) => this.handleSignal(event));
-    this.clientSession.on('streamPropertyChanged', () => this.handleStreamPropertyChanged());
+    this.clientSession.on('streamPropertyChanged', (event) =>
+      this.handleStreamPropertyChanged(event)
+    );
     this.clientSession.on('streamCreated', (event) => this.handleStreamCreated(event));
   };
 
@@ -143,10 +146,11 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
 
   /**
    * Emits an event when a stream property changes.
+   * @param event
    * @private
    */
-  private handleStreamPropertyChanged = () => {
-    this.emit('streamPropertyChanged');
+  private handleStreamPropertyChanged = (event: StreamPropertyChangedEvent) => {
+    this.emit('streamPropertyChanged', event);
   };
 
   /**


### PR DESCRIPTION
#### What is this PR doing?
Fixes an issue where the muted indicator was not being updated.

#### How should this be manually tested?
##### Repro'ing the issue
- go to deployed app
- create a room with two participants
- mute the audio for one participant
- notice the other tab does not reflect the changes in the muted indicator

##### Verifying the fix
- checkout this branch
- create a room with two participants
- mute the audio for one participant
- notice the audio muted state change is reflected in the other tab

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3791](https://jira.vonage.com/browse/VIDCS-3791)

#### Checklist
[✅] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?