### PR TITLE
VIDCS-3810: Error when components have maxWidth or width with NaN value

### DIFF
--- a/frontend/src/components/MeetingRoom/NameDisplay/NameDisplay.tsx
+++ b/frontend/src/components/MeetingRoom/NameDisplay/NameDisplay.tsx
@@ -16,11 +16,13 @@ export type NameDisplayProps = {
  * @returns {ReactElement} The NameDisplay component.
  */
 const NameDisplay = ({ name, containerWidth }: NameDisplayProps): ReactElement => {
+  const safeMaxWidth =
+    typeof containerWidth === 'number' && !Number.isNaN(containerWidth) ? containerWidth : 0;
   return (
     <div
       className={`absolute bottom-[10px] left-[10px] truncate text-sm text-white ${TEXT_SHADOW}`}
       style={{
-        maxWidth: containerWidth - 32,
+        maxWidth: Math.max(0, safeMaxWidth - 32),
       }}
     >
       <span>{name}</span>

--- a/frontend/src/components/MeetingRoom/NameDisplay/NameDisplay.tsx
+++ b/frontend/src/components/MeetingRoom/NameDisplay/NameDisplay.tsx
@@ -17,7 +17,7 @@ export type NameDisplayProps = {
  */
 const NameDisplay = ({ name, containerWidth }: NameDisplayProps): ReactElement => {
   const safeMaxWidth =
-    typeof containerWidth === 'number' && !Number.isNaN(containerWidth) ? containerWidth : 0;
+    typeof containerWidth === 'number' && Number.isFinite(containerWidth) ? containerWidth : 0;
   return (
     <div
       className={`absolute bottom-[10px] left-[10px] truncate text-sm text-white ${TEXT_SHADOW}`}

--- a/frontend/src/components/ScreenShareNameDisplay/ScreenShareNameDisplay.tsx
+++ b/frontend/src/components/ScreenShareNameDisplay/ScreenShareNameDisplay.tsx
@@ -15,6 +15,7 @@ export type ScreenShareNameDisplayProps = {
  * @returns {ReactElement} The ScreenShareNameDisplay component.
  */
 const ScreenShareNameDisplay = ({ name, box }: ScreenShareNameDisplayProps): ReactElement => {
+  const safeMaxWidth = typeof box.width === 'number' && !Number.isNaN(box.width) ? box.width : 0;
   return (
     <Chip
       label={name}
@@ -22,7 +23,7 @@ const ScreenShareNameDisplay = ({ name, box }: ScreenShareNameDisplayProps): Rea
       sx={{
         color: 'white',
         backgroundColor: 'rgba(60, 64, 67, 0.55)',
-        maxWidth: box.width - 32,
+        maxWidth: Math.max(0, safeMaxWidth - 32),
       }}
       className="absolute bottom-[10px] left-[10px] truncate text-sm md:text-lg"
     />

--- a/frontend/src/components/ScreenShareNameDisplay/ScreenShareNameDisplay.tsx
+++ b/frontend/src/components/ScreenShareNameDisplay/ScreenShareNameDisplay.tsx
@@ -15,7 +15,7 @@ export type ScreenShareNameDisplayProps = {
  * @returns {ReactElement} The ScreenShareNameDisplay component.
  */
 const ScreenShareNameDisplay = ({ name, box }: ScreenShareNameDisplayProps): ReactElement => {
-  const safeMaxWidth = typeof box.width === 'number' && !Number.isNaN(box.width) ? box.width : 0;
+  const safeMaxWidth = typeof box.width === 'number' && Number.isFinite(box.width) ? box.width : 0;
   return (
     <Chip
       label={name}

--- a/frontend/src/utils/helpers/getBoxStyle.ts
+++ b/frontend/src/utils/helpers/getBoxStyle.ts
@@ -16,8 +16,14 @@ const getBoxStyle = (box: Box | undefined, isScreenShare?: boolean): CSSProperti
     left: box.left,
     top: box.top,
     // We subtract the margins from width and height
-    width: box.width - VIDEO_TILE_MARGIN - (isScreenShare ? 0 : 6),
-    height: box.height - VIDEO_TILE_MARGIN,
+    width:
+      typeof box.width === 'number' && !Number.isNaN(box.width)
+        ? box.width - VIDEO_TILE_MARGIN - (isScreenShare ? 0 : 6)
+        : 0,
+    height:
+      typeof box.height === 'number' && !Number.isNaN(box.height)
+        ? box.height - VIDEO_TILE_MARGIN
+        : 0,
     aspectRatio: '16 / 9',
   };
 

--- a/frontend/src/utils/helpers/getBoxStyle.ts
+++ b/frontend/src/utils/helpers/getBoxStyle.ts
@@ -17,11 +17,11 @@ const getBoxStyle = (box: Box | undefined, isScreenShare?: boolean): CSSProperti
     top: box.top,
     // We subtract the margins from width and height
     width:
-      typeof box.width === 'number' && !Number.isNaN(box.width)
+      typeof box.width === 'number' && Number.isFinite(box.width)
         ? box.width - VIDEO_TILE_MARGIN - (isScreenShare ? 0 : 6)
         : 0,
     height:
-      typeof box.height === 'number' && !Number.isNaN(box.height)
+      typeof box.height === 'number' && Number.isFinite(box.height)
         ? box.height - VIDEO_TILE_MARGIN
         : 0,
     aspectRatio: '16 / 9',


### PR DESCRIPTION
#### What is this PR doing?
This PR is protecting unsafe values on width/height and maxWidth. 
Values such as `NaN` were throwing a CSS error.

#### How should this be manually tested?
Check that no errors are being thrown in developer console. 
1- Open participants
2- Make screen small
3- You should not see any error:
<img width="775" alt="Screenshot 2025-06-06 at 16 41 30" src="https://github.com/user-attachments/assets/7dad9cd5-3a2c-4eea-9fe2-699d64d78519" />

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3810](https://jira.vonage.com/browse/VIDCS-3810)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?