### PR TITLE
VIDCS-3880: Add animation effect to Right Panel open

### DIFF
--- a/frontend/src/components/MeetingRoom/RightPanel/RightPanel.tsx
+++ b/frontend/src/components/MeetingRoom/RightPanel/RightPanel.tsx
@@ -26,7 +26,13 @@ const RightPanel = ({ activeTab, handleClose }: RightPanelProps): ReactElement =
   const height = isSmallViewport
     ? '@apply h-[calc(100dvh_-_80px)]'
     : '@apply h-[calc(100dvh_-_96px)]';
-  const className = `${height} absolute top-0 ${margins} ${width} overflow-hidden rounded bg-white transition-[right] ${activeTab === 'closed' ? 'right-[-380px] hidden' : 'right-0'}`;
+
+  const isOpen = activeTab !== 'closed';
+  const className = `
+      ${height} absolute top-0 ${margins} ${width} overflow-hidden rounded bg-white
+      transition-all duration-300 ease-in-out
+      ${isOpen ? 'right-0 opacity-100 pointer-events-auto' : 'right-[-380px] opacity-0 pointer-events-none'}
+    `;
 
   return (
     <div data-testid="right-panel" className={className}>


### PR DESCRIPTION
#### What is this PR doing?

This PR adds an animation effect whenever a user toggles one of the Right Panel buttons (Chat, Report issue - if enabled, and Participant List).

#### How should this be manually tested?

To reproduce the "issue":

* Checkout the `develop` branch.
* Run the app, join a meeting room.
* Click one of the buttons on the bottom right in the Toolbar (chat/report/issue/participant list).
* Notice that they show up very abruptly on the screen.

To reproduce the improvement:
* follow the steps above, notice that it shows up with an animation that is a better UX/UI. 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3880](https://jira.vonage.com/browse/VIDCS-3880)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?