### PR TITLE
VIDCS-3893: vonage/client-sdk-video version bump

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.4.1",
-    "@vonage/client-sdk-video": "^2.29.4",
+    "@vonage/client-sdk-video": "^2.30.2",
     "@vonage/vcr-sdk": "^1.3.0",
     "autolinker": "^4.0.0",
     "autoprefixer": "^10.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2585,10 +2585,10 @@
     "@vonage/jwt" "^1.11.0"
     debug "^4.3.4"
 
-"@vonage/client-sdk-video@^2.29.4":
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.29.4.tgz#80f9905aa465656df485acbee976c2bc139688e3"
-  integrity sha512-pXSCj3xcJsViPkEEtIe1Ox0nH/IpDlZUkfZCFSXvOxrBzmQwseBiPcZp6NCc1DM7TI3hnmFlT2rY5rx2HlhNyw==
+"@vonage/client-sdk-video@^2.30.2":
+  version "2.30.2"
+  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.30.2.tgz#4dc89f28e3b78ddf4f8681b581fa0f3a713836cf"
+  integrity sha512-gdM3ZOFI7/sKnqED+cxgl6W8RgK264O5EvjRPvn2MgEW40xDnj+F1GCXCbUQbTgZ7MUgHfLBHVDMzYFflXP6Ug==
 
 "@vonage/conversations@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
#### What is this PR doing?

This PR bumps up the version of `vonage/client-sdk-video` to the latest currently-available one.

#### How should this be manually tested?

n/a

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-3893](https://jira.vonage.com/browse/VIDCS-3893)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?