### PR TITLE
VIDSOL-50: Update check-pull-request-title job to check for latest jira project

### DIFF
--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -18,17 +18,17 @@ jobs:
           set -e
 
           # Regex to check following:
-          # Starts with "VIDCS-" followed by digits
+          # Starts with "VIDSOL-" followed by digits
           # A colon (:) followed by exactly one space
           # followed by the actual PR title text
-          regex="^VIDCS-[0-9]+: [^ ].*$"
+          regex="^VIDSOL-[0-9]+: [^ ].*$"
 
           if echo "$PR_NAME" | grep -Eq "$regex"; then
             echo "Acceptable title"
             exit 0
           else
             echo "Rejected title"
-            echo "Reason: The PR title must start with 'VIDCS-' followed by digits, a colon (:), and exactly one space, with the rest of the title immediately after the space."
+            echo "Reason: The PR title must start with 'VIDSOL-' followed by digits, a colon (:), and exactly one space, with the rest of the title immediately after the space."
             exit 1
           fi
         shell: bash


### PR DESCRIPTION
#### What is this PR doing?

The PR title needs to be prefixed with `VIDSOL-` now. 

#### How should this be manually tested?

n/a, CI should be green for the `check-pull-request-title` job in particular.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDCS-](https://jira.vonage.com/browse/VIDCS-)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?