### PR TITLE
VIDSOL-101: Bump actions to v4 to remove deprecated save-state warnings

### DIFF
--- a/.github/workflows/auto-set-base.yml
+++ b/.github/workflows/auto-set-base.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check and Update Base Branch
         env:

--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.4
           cache: npm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout
         if: steps.check-skip-ci.outputs.result == 'false'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -87,7 +87,7 @@ jobs:
 
       - name: Setup node
         if: steps.check-skip-ci.outputs.result == 'false'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -85,13 +85,13 @@ jobs:
 
       - name: Checkout
         if: steps.check-update-screenshots.outputs.result == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
       - name: Setup node
         if: steps.check-update-screenshots.outputs.result == 'true'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
#### What is this PR doing?
- Updated `actions/checkout` from v3.0.2 to `v4`
- Updated `actions/setup-node` from v3 to `v4`

These changes should resolve the warning:
[The `save-state` command is deprecated and will be disabled soon.](https://github.com/Vonage/vonage-video-react-app/actions/runs/16036062577)

#### How should this be manually tested?
n/a

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-101](https://jira.vonage.com/browse/VIDSOL-101)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?