### PR TITLE
VIDSOL-125: OT Version bump to 2.30.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.4.1",
-    "@vonage/client-sdk-video": "^2.30.2",
+    "@vonage/client-sdk-video": "^2.30.5",
     "@vonage/vcr-sdk": "^1.3.0",
     "autolinker": "^4.0.0",
     "autoprefixer": "^10.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2585,10 +2585,10 @@
     "@vonage/jwt" "^1.11.0"
     debug "^4.3.4"
 
-"@vonage/client-sdk-video@^2.30.2":
-  version "2.30.2"
-  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.30.2.tgz#4dc89f28e3b78ddf4f8681b581fa0f3a713836cf"
-  integrity sha512-gdM3ZOFI7/sKnqED+cxgl6W8RgK264O5EvjRPvn2MgEW40xDnj+F1GCXCbUQbTgZ7MUgHfLBHVDMzYFflXP6Ug==
+"@vonage/client-sdk-video@^2.30.5":
+  version "2.30.5"
+  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.30.5.tgz#ad200989d6a37fd03b2f69c93728f3c914699079"
+  integrity sha512-NuEVDOeDbAN9oeUD9cPl4eb09UsqoH0+pz0AicnrAK28rf97qQ0ODTm+hjmaD9iCUyrv9KjxQdkYdrRw7fUwwA==
 
 "@vonage/conversations@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
#### What is this PR doing?

This PR bumps up the OT version to `2.30.5`.

#### How should this be manually tested?

n/a

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-125](https://jira.vonage.com/browse/VIDSOL-125)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?