### PR TITLE
VIDSOL-122: VERA version bump to 1.2.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Express-based backend with authenticated routes.",
   "main": "index.js",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "private": true,
   "description": "React reference application for the Vonage Video web client SDK.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "build": "vite build && yarn cp-build",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-tests",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "integration test workspace for vonage video react app",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vonage-video-react-app",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "React reference application for the Vonage Video web client SDK.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
#### What is this PR doing?

This PR bumps up the VERA version to `1.2.1`.

#### How should this be manually tested?

n/a

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-122](https://jira.vonage.com/browse/VIDSOL-122)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?