### PR TITLE
VIDSOL-149: Camera light stays on after toggling video off

### DIFF
--- a/frontend/src/components/MeetingRoom/DeviceControlButton/DeviceControlButton.spec.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceControlButton/DeviceControlButton.spec.tsx
@@ -10,6 +10,14 @@ import DeviceControlButton from './DeviceControlButton';
 
 vi.mock('../../../hooks/usePublisherContext.tsx');
 vi.mock('../../../hooks/useSpeakingDetector.tsx');
+const toggleBackgroundVideoPublisherMock = vi.fn();
+vi.mock('../../../hooks/useBackgroundPublisherContext', () => {
+  return {
+    default: () => ({
+      toggleVideo: toggleBackgroundVideoPublisherMock,
+    }),
+  };
+});
 
 const mockUsePublisherContext = usePublisherContext as Mock<[], PublisherContextType>;
 const mockUseSpeakingDetector = useSpeakingDetector as Mock<[], boolean>;
@@ -84,5 +92,26 @@ describe('DeviceControlButton', () => {
     );
     expect(screen.getByLabelText('microphone')).toBeInTheDocument();
     expect(screen.getByTestId('ArrowDropUpIcon')).toBeInTheDocument();
+  });
+
+  it('updates the main publisher and the background replacement publisher when clicked', () => {
+    const toggleVideoMock = vi.fn();
+    mockUsePublisherContext.mockImplementation(() => ({
+      ...publisherContext,
+      toggleAudio: vi.fn(),
+      toggleVideo: toggleVideoMock,
+      isAudioEnabled: true,
+      isVideoEnabled: true,
+    }));
+    render(
+      <DeviceControlButton
+        deviceType="video"
+        toggleBackgroundEffects={mockHandleToggleBackgroundEffects}
+      />
+    );
+    const cameraButton = screen.getByLabelText('camera');
+    cameraButton.click();
+    expect(toggleVideoMock).toHaveBeenCalled();
+    expect(toggleBackgroundVideoPublisherMock).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/MeetingRoom/DeviceControlButton/DeviceControlButton.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceControlButton/DeviceControlButton.tsx
@@ -9,6 +9,7 @@ import { useState, useRef, useCallback, ReactElement } from 'react';
 import MutedAlert from '../../MutedAlert';
 import usePublisherContext from '../../../hooks/usePublisherContext';
 import DeviceSettingsMenu from '../DeviceSettingsMenu';
+import useBackgroundPublisherContext from '../../../hooks/useBackgroundPublisherContext';
 
 export type DeviceControlButtonProps = {
   deviceType: 'audio' | 'video';
@@ -30,6 +31,7 @@ const DeviceControlButton = ({
   toggleBackgroundEffects,
 }: DeviceControlButtonProps): ReactElement => {
   const { isVideoEnabled, toggleAudio, toggleVideo, isAudioEnabled } = usePublisherContext();
+  const { toggleVideo: toggleBackgroundVideoPublisher } = useBackgroundPublisherContext();
   const isAudio = deviceType === 'audio';
   const [open, setOpen] = useState<boolean>(false);
   const anchorRef = useRef<HTMLInputElement | null>(null);
@@ -61,6 +63,15 @@ const DeviceControlButton = ({
     return <VideocamOffIcon className="text-red-500" />;
   };
 
+  const handleDeviceStateChange = () => {
+    if (isAudio) {
+      toggleAudio();
+    } else {
+      toggleVideo();
+      toggleBackgroundVideoPublisher();
+    }
+  };
+
   return (
     <>
       {isAudio && <MutedAlert />}
@@ -90,7 +101,7 @@ const DeviceControlButton = ({
         </IconButton>
         <Tooltip title={isAudio ? audioTitle : videoTitle} aria-label="device settings">
           <IconButton
-            onClick={isAudio ? toggleAudio : toggleVideo}
+            onClick={handleDeviceStateChange}
             edge="start"
             aria-label={isAudio ? 'microphone' : 'camera'}
             size="small"

--- a/frontend/src/components/WaitingRoom/CameraButton/CameraButton.spec.tsx
+++ b/frontend/src/components/WaitingRoom/CameraButton/CameraButton.spec.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import CameraButton from './CameraButton';
+
+let isVideoEnabled = true;
+const toggleVideoMock = vi.fn();
+const toggleBackgroundVideoMock = vi.fn();
+
+vi.mock('../../../hooks/usePreviewPublisherContext', () => {
+  return {
+    default: () => ({
+      get isVideoEnabled() {
+        return isVideoEnabled;
+      },
+      toggleVideo: toggleVideoMock,
+    }),
+  };
+});
+vi.mock('../../../hooks/useBackgroundPublisherContext', () => {
+  return {
+    default: () => ({
+      toggleVideo: toggleBackgroundVideoMock,
+    }),
+  };
+});
+
+describe('CameraButton', () => {
+  beforeEach(() => {
+    isVideoEnabled = true;
+    vi.clearAllMocks();
+  });
+
+  it('renders the video on icon when video is enabled', () => {
+    render(<CameraButton />);
+    expect(screen.getByTestId('VideocamIcon')).toBeInTheDocument();
+  });
+
+  it('renders the video off icon when video is disabled', () => {
+    isVideoEnabled = false;
+    render(<CameraButton />);
+    expect(screen.getByTestId('VideocamOffIcon')).toBeInTheDocument();
+  });
+
+  it('updates the main publisher and the background replacement publisher when clicked', () => {
+    render(<CameraButton />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(toggleVideoMock).toHaveBeenCalled();
+    expect(toggleBackgroundVideoMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/WaitingRoom/CameraButton/CameraButton.tsx
+++ b/frontend/src/components/WaitingRoom/CameraButton/CameraButton.tsx
@@ -4,6 +4,7 @@ import VideocamOffIcon from '@mui/icons-material/VideocamOff';
 import { ReactElement } from 'react';
 import usePreviewPublisherContext from '../../../hooks/usePreviewPublisherContext';
 import VideoContainerButton from '../VideoContainerButton';
+import useBackgroundPublisherContext from '../../../hooks/useBackgroundPublisherContext';
 
 /**
  * CameraButton Component
@@ -13,7 +14,13 @@ import VideoContainerButton from '../VideoContainerButton';
  */
 const CameraButton = (): ReactElement => {
   const { isVideoEnabled, toggleVideo } = usePreviewPublisherContext();
+  const { toggleVideo: toggleBackgroundVideoPublisher } = useBackgroundPublisherContext();
   const title = `Turn ${isVideoEnabled ? 'off' : 'on'} camera`;
+
+  const handleToggleVideo = () => {
+    toggleVideo();
+    toggleBackgroundVideoPublisher();
+  };
 
   return (
     <Box
@@ -31,7 +38,7 @@ const CameraButton = (): ReactElement => {
     >
       <Tooltip title={title} aria-label="toggle video">
         <VideoContainerButton
-          onClick={toggleVideo}
+          onClick={handleToggleVideo}
           sx={{
             backgroundColor: !isVideoEnabled ? 'rgb(234, 67, 53)' : '',
             '&:hover': {


### PR DESCRIPTION
#### What is this PR doing?

This PR fixes an issue where a webcam light stays on when toggling video off. This happens due to now using two different publishers, one of which was not being changed when toggling the video off.

#### How should this be manually tested?

To reproduce the issue, follow these steps:
* Checkout `develop` branch.
* Join the waiting room, turn off your camera and notice that the light on your webcam/built-in camera stays on.
* Join the meeting room, turn off your camera and notice that the light on your webcam/built-in camera stays off.

To reproduce the fix, follow the steps above on this PRs' branch and notice that the issue is no longer reproducible.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-149](https://jira.vonage.com/browse/VIDSOL-149)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
