### PR TITLE
VIDSOL-10: VERA does not display special characters properly in Participant List, Muted Video Publisher

### DIFF
--- a/frontend/src/utils/getInitials/getInitials.spec.tsx
+++ b/frontend/src/utils/getInitials/getInitials.spec.tsx
@@ -74,7 +74,7 @@ describe('getInitials', () => {
     });
   });
 
-  it('returns initials for a simgle character first name', () => {
+  it('returns initials for a single character first name', () => {
     const username = 'l';
 
     const initials = getInitials(username);
@@ -82,7 +82,7 @@ describe('getInitials', () => {
     expect(initials).toBe('L');
   });
 
-  it('returns initials for a simgle character last name', () => {
+  it('returns initials for a single character last name', () => {
     const username = 'Daniel Michael B';
 
     const initials = getInitials(username);
@@ -90,11 +90,57 @@ describe('getInitials', () => {
     expect(initials).toBe('DB');
   });
 
-  it('returns initials for a simgle character first and last name', () => {
+  it('returns initials for a single character first and last name', () => {
     const username = 's d';
 
     const initials = getInitials(username);
 
     expect(initials).toBe('SD');
+  });
+
+  it('handles Unicode characters with accents', () => {
+    const username = 'Òscar';
+
+    const initials = getInitials(username);
+
+    expect(initials).toBe('Ò');
+  });
+
+  it('handles Unicode characters in multiple names', () => {
+    const username = 'José María';
+
+    const initials = getInitials(username);
+
+    expect(initials).toBe('JM');
+  });
+
+  it('handles various accented characters', () => {
+    const testCases = [
+      { username: 'François Müller', expected: 'FM' },
+      { username: 'Åse Björk', expected: 'ÅB' },
+      { username: 'Zürich', expected: 'Z' },
+      { username: 'Naïve Café', expected: 'NC' },
+      { username: 'Señor López', expected: 'SL' },
+    ];
+
+    testCases.forEach(({ username, expected }) => {
+      const initials = getInitials(username);
+      expect(initials).toBe(expected);
+    });
+  });
+
+  it('handles hyphenated names with accents', () => {
+    const username = 'José-María González';
+
+    const initials = getInitials(username);
+
+    expect(initials).toBe('JG');
+  });
+
+  it('handles combining diacritical marks', () => {
+    const username = 'André Müller';
+    const initials = getInitials(username);
+
+    expect(initials).toBe('AM');
   });
 });

--- a/frontend/src/utils/getInitials/getInitials.tsx
+++ b/frontend/src/utils/getInitials/getInitials.tsx
@@ -9,7 +9,7 @@ const getInitialFromName = (name: string): string => {
  */
 export default (username: string): string => {
   // Matches any names, including hyphenated names.
-  const names = username.match(/(\w+(-\w+)?)/gm);
+  const names = username.match(/[\p{L}\p{M}]+([-][\p{L}\p{M}]+)*/gu);
   let lastInitial = '';
 
   if (!names) {


### PR DESCRIPTION
#### What is this PR doing?

This PR fixes an issue where VERA does not display special characters properly in Participant List, Muted Video Publisher.

#### How should this be manually tested?

To reproduce the issue, run the app on the `develop` branch.
Join the waiting room and try using a name that involves a special character for username, such as `Òscar` followed by a last name of your choice.
Mute your video in the waiting room and notice that the initial displayed is only for the "last name" part of it. 
Join the meeting room, add another tab. 
Mute video on the tab A.
From tab B, notice that the initials displayed only contain the "last name" part of the user A. 
Notice that the little image in the participant list of user A in the user B tab shows as only having the "last name" part of it.

To reproduce the fix, checkout this branch.
Perform the steps above and notice that special character is used as part of the intitials. 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-10](https://jira.vonage.com/browse/VIDSOL-10)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
