### PR TITLE
VIDSOL-51: Incorrect running instructions for ngrok

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,19 +169,33 @@ The Vonage Video API Reference App for React is currently supported on the lates
 
 ## Testing on Multiple Devices
 
-To test the video API across multiple devices on your local network, you can use **ngrok** to expose your frontend publicly.
+To test the video API across multiple devices on your local network, you can use **ngrok** to expose your frontend and backend publicly.
 
-1. Create an account at [ngrok](https://dashboard.ngrok.com/signup) if you haven’t already.
+1. Create an account at [ngrok](https://dashboard.ngrok.com/signup) if you haven't already.
 
 2. Follow the [Setup and Installation instructions](https://dashboard.ngrok.com/get-started/setup/) for your operating system to install and configure ngrok.
 
-3. Create a secure tunnel to your frontend using:
+3. **Start the application locally first:**
 
+    ``` bash
+    yarn dev
+    ```
+
+    Make sure both the backend server (port 3345) and frontend dev server (port 5173) are running before proceeding to the next step.
+
+4. Create secure tunnels for both frontend and backend:
+
+    **Frontend tunnel:**
     ``` bash
     yarn forward:frontend
     ```
 
-    This command creates a publicly accessible HTTPS URL for your frontend. It will appear in your terminal, similar to the image below:
+    **Backend tunnel (in a separate terminal):**
+    ``` bash
+    yarn forward:backend
+    ```
+
+    Both commands will create publicly accessible HTTPS URLs. The output will appear in your terminals, similar to the image below:
 
     <details close>
     <summary>ngrok output example</summary>
@@ -190,18 +204,20 @@ To test the video API across multiple devices on your local network, you can use
 
     </br>
 
-4. Copy the domain from the output and update your **frontend/.env** file:
+5. Copy the domains from both outputs and update your **frontend/.env** file:
 
     ``` ini
-    # example
-    VITE_TUNNEL_DOMAIN=GENERIC_DOMAIN
+    # Frontend tunnel domain
+    VITE_TUNNEL_DOMAIN=your-frontend-domain.ngrok.io
+    # Backend tunnel domain  
+    VITE_API_URL=https://your-backend-domain.ngrok.io
     ```
 
-    **Note:** ngrok assigns a temporary domain. You’ll need to update your environment variable each time the domain changes.
+    **Note:** ngrok assigns temporary domains. You'll need to update your environment variables each time the domains change.
 
   </br>
 
-5. Open the provided **Forwarding** URL in your browser. This exposes your Vite app publicly. However, keep in mind that the backend server is still local, so the devices accessing the app must be on the same local network.
+6. Open the provided frontend **Forwarding** URL in your browser. This exposes your entire application publicly, allowing devices on any network to access both the frontend and backend.
 
 </br>
 

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -3,9 +3,9 @@ import isReportIssueEnabled from './isReportIssueEnabled/isReportIssueEnabled';
 /**
  * @constant {string} API_URL - The base URL determined by the current environment.
  */
-export const API_URL = window.location.origin.includes('localhost')
-  ? 'http://localhost:3345'
-  : window.location.origin;
+export const API_URL =
+  import.meta.env.VITE_API_URL ||
+  (window.location.origin.includes('localhost') ? 'http://localhost:3345' : window.location.origin);
 
 /**
  * @constant {object} DEVICE_ACCESS_STATUS - An object representing various states for device access.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "debug:backend": "yarn workspace backend debug",
     "start:frontend": "yarn workspace frontend dev",
     "forward:frontend": "npx ngrok http 5173",
+    "forward:backend": "npx ngrok http 3345",
     "test": "yarn test:backend && yarn test:frontend",
     "test:backend": "yarn workspace backend test",
     "test:backend:watch": "yarn workspace backend test:watch",


### PR DESCRIPTION
#### What is this PR doing?

This PR fixes an issue where if one follows the instructions in README.md on how to test the app via `ngrok`, one won't have any luck with it. 

#### How should this be manually tested?

To reproduce the issue: 
* Checkout the `develop` branch.
* Follow the steps in README.md that show how to do `Testing on Multiple Devices`.
* Notice that you're getting a token error when joining the meeting room. 😢 

To reproduce the fix: 
* Checkout this branch.
* Follow the steps in the README.md that show how to do `Testing on Multiple Devices`.
* Notice that you are able to do so. 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-51](https://jira.vonage.com/browse/VIDSOL-51)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
