### PR TITLE
VIDSOL-25: Record meeting shows incorrect option for the user who has not started the recording

### DIFF
--- a/frontend/src/components/MeetingRoom/ArchivingButton/ArchivingButton.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ArchivingButton/ArchivingButton.spec.tsx
@@ -1,14 +1,12 @@
 import { describe, expect, it, vi, beforeEach, Mock } from 'vitest';
 import { render, screen, act, waitFor } from '@testing-library/react';
-import { startArchiving } from '../../../api/archiving';
+import { startArchiving, stopArchiving } from '../../../api/archiving';
 import ArchivingButton from './ArchivingButton';
 import useRoomName from '../../../hooks/useRoomName';
+import useSessionContext from '../../../hooks/useSessionContext';
+import { SessionContextType } from '../../../Context/SessionProvider/session';
 
-vi.mock('../../../hooks/useSessionContext', () => ({
-  default: () => ({
-    subscriberWrappers: [],
-  }),
-}));
+vi.mock('../../../hooks/useSessionContext');
 vi.mock('../../../hooks/useRoomName');
 
 vi.mock('../../../api/archiving', () => ({
@@ -19,10 +17,20 @@ vi.mock('../../../api/archiving', () => ({
 describe('ArchivingButton', () => {
   const mockHandleCloseMenu = vi.fn();
   const mockedRoomName = 'test-room-name';
+  let sessionContext: SessionContextType;
+
+  const mockUseSessionContext = useSessionContext as Mock<[], SessionContextType>;
+  const testArchiveId = 'test-archive-id';
 
   beforeEach(() => {
     vi.clearAllMocks();
     (useRoomName as Mock).mockReturnValue(mockedRoomName);
+    sessionContext = {
+      subscriberWrappers: [],
+      archiveId: null,
+    } as unknown as SessionContextType;
+
+    mockUseSessionContext.mockReturnValue(sessionContext as unknown as SessionContextType);
   });
 
   it('renders the button correctly', () => {
@@ -47,6 +55,35 @@ describe('ArchivingButton', () => {
     act(() => screen.getByTestId('popup-dialog-primary-button').click());
     await waitFor(() => {
       expect(startArchiving).toHaveBeenCalledWith(mockedRoomName);
+    });
+  });
+
+  it('shows stop recording dialog when archiving is active', () => {
+    mockUseSessionContext.mockReturnValue({
+      subscriberWrappers: [],
+      archiveId: 'test-archive-id',
+    } as unknown as SessionContextType);
+
+    render(<ArchivingButton handleClick={mockHandleCloseMenu} />);
+    act(() => screen.getByTestId('archiving-button').click());
+    expect(screen.getByText('Stop Recording?')).toBeInTheDocument();
+  });
+
+  it('triggers stop archiving when recording is active', async () => {
+    mockUseSessionContext.mockReturnValue({
+      subscriberWrappers: [],
+      archiveId: testArchiveId,
+    } as unknown as SessionContextType);
+
+    render(<ArchivingButton handleClick={mockHandleCloseMenu} />);
+
+    act(() => screen.getByTestId('archiving-button').click());
+    expect(screen.getByText('Stop Recording?')).toBeInTheDocument();
+
+    // click the button to stop archiving
+    act(() => screen.getByTestId('popup-dialog-primary-button').click());
+    await waitFor(() => {
+      expect(stopArchiving).toHaveBeenCalledWith(mockedRoomName, testArchiveId);
     });
   });
 });

--- a/frontend/src/components/MeetingRoom/ArchivingButton/ArchivingButton.tsx
+++ b/frontend/src/components/MeetingRoom/ArchivingButton/ArchivingButton.tsx
@@ -51,7 +51,7 @@ const ArchivingButton = ({
     secondaryActionText: 'Cancel',
   };
 
-  const [actionText, setActionText] = useState<DialogTexts>(startRecordingText);
+  const actionText = isRecording ? stopRecordingText : startRecordingText;
 
   const handleClose = () => {
     setIsModalOpen(false);
@@ -66,14 +66,12 @@ const ArchivingButton = ({
     if (action === 'start') {
       if (!archiveId && roomName) {
         try {
-          setActionText(stopRecordingText);
           await startArchiving(roomName);
         } catch (err) {
           console.log(err);
         }
       }
     } else if (archiveId && roomName) {
-      setActionText(startRecordingText);
       stopArchiving(roomName, archiveId);
     }
   };


### PR DESCRIPTION
#### What is this PR doing?

This PR fixes an issue where `Record meeting shows incorrect option for the user who has not started the recording` 

#### How should this be manually tested?

Steps to reproduce:
* Checkout the `develop` branch.
* Join a meeting from 2 tabs
* On tab 1 start recording
* On tab 2 notice the red recording indicator.
* On tab 2 Click on the Stop recording button
* Notice we get a Start recording card, instead of the stop recording one

To check the fix:
* Checkout this branch.
* Follow steps above, notice that correct messages are being displayed. 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-25](https://jira.vonage.com/browse/VIDSOL-25)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
