### PR TITLE
VIDSOL-192: Bump up OT version to 2.31.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.4.1",
-    "@vonage/client-sdk-video": "^2.30.5",
+    "@vonage/client-sdk-video": "^2.31.0",
     "@vonage/vcr-sdk": "^1.3.0",
     "autolinker": "^4.0.0",
     "autoprefixer": "^10.4.19",

--- a/frontend/src/components/MeetingRoom/AudioIndicator/AudioIndicator.spec.tsx
+++ b/frontend/src/components/MeetingRoom/AudioIndicator/AudioIndicator.spec.tsx
@@ -19,6 +19,7 @@ describe('AudioIndicator', () => {
     videoType: 'camera',
     frameRate: 1,
     initials: 'JD',
+    hasCaptions: false,
   };
 
   const defaultProps: AudioIndicatorProps = {

--- a/frontend/src/components/MeetingRoom/MutingDialog/MutingDialog.spec.tsx
+++ b/frontend/src/components/MeetingRoom/MutingDialog/MutingDialog.spec.tsx
@@ -20,6 +20,7 @@ describe('ParticipantListAudioIndicator', () => {
     videoType: 'camera',
     frameRate: 1,
     initials: 'JD',
+    hasCaptions: false,
   };
 
   const defaultProps: MutingDialogProps = {

--- a/frontend/src/components/MeetingRoom/ParticipantListItem/ParticipantListItem.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ParticipantListItem/ParticipantListItem.spec.tsx
@@ -24,6 +24,7 @@ describe('ParticipantListItem', () => {
     videoType: 'camera',
     frameRate: 1,
     initials: 'JD',
+    hasCaptions: false,
   };
   const defaultProps: ParticipantListItemProps = {
     audioLevel: 50,

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -47,7 +47,7 @@ export type LocalCaptionReceived = { streamId: string; caption: string; isFinal:
 
 export type StreamPropertyChangedEvent = {
   stream: Stream;
-  changedProperty: 'hasAudio' | 'hasVideo' | 'videoDimensions';
+  changedProperty: 'hasAudio' | 'hasVideo' | 'hasCaptions' | 'videoDimensions';
   oldValue: boolean | { width: number; height: number };
   newValue: boolean | { width: number; height: number };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2618,10 +2618,10 @@
     "@vonage/jwt" "^1.11.0"
     debug "^4.3.4"
 
-"@vonage/client-sdk-video@^2.30.5":
-  version "2.30.5"
-  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.30.5.tgz#ad200989d6a37fd03b2f69c93728f3c914699079"
-  integrity sha512-NuEVDOeDbAN9oeUD9cPl4eb09UsqoH0+pz0AicnrAK28rf97qQ0ODTm+hjmaD9iCUyrv9KjxQdkYdrRw7fUwwA==
+"@vonage/client-sdk-video@^2.31.0":
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.31.0.tgz#eb718485b2a7f7aec156c6dff9929dcc0550cd0e"
+  integrity sha512-tIpI2RfgC2sc5HtwIVipMlUPhDVAHt9LH5L7enpaSHFAwlQ7Mqucbr93z62dDrbtdJiNQDrTLssFhSdk0+mL/A==
 
 "@vonage/conversations@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
#### What is this PR doing?

This PR bumps up @vonage/client-sdk-video version to `2.31.0`

#### How should this be manually tested?

n/a, CI passes

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-192](https://jira.vonage.com/browse/VIDSOL-192)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
