### PR TITLE
VIDSOL-81: Remove web credentials

### DIFF
--- a/backend/routes/wellKnown.ts
+++ b/backend/routes/wellKnown.ts
@@ -47,9 +47,6 @@ wellKnownRouter.get('/apple-app-site-association', (_req: Request, res: Response
         },
       ],
     },
-    webcredentials: {
-      apps: ['PR6C39UQ38.com.vonage.VERA'],
-    },
   });
 });
 

--- a/backend/tests/apple-app-site-association.test.ts
+++ b/backend/tests/apple-app-site-association.test.ts
@@ -53,9 +53,6 @@ describe('GET /.well-known/apple-app-site-association', () => {
             }),
           ]),
         }),
-        webcredentials: expect.objectContaining({
-          apps: expect.arrayContaining(['PR6C39UQ38.com.vonage.VERA']),
-        }),
       })
     );
   });

--- a/customWordList.txt
+++ b/customWordList.txt
@@ -9,4 +9,3 @@ NOSONAR
 jiraiOSComponentId
 supportedLngs
 applinks
-webcredentials


### PR DESCRIPTION
#### What is this PR doing?
Removes the webcredentials key and values from the apple-app-site-association file

#### How should this be manually tested?
Should not longer be served in 
https://meet.vonagenetworks.net/.well-known/apple-app-site-association

#### What are the relevant tickets?

Resolves [VIDSOL-81](https://jira.vonage.com/browse/VIDSOL-81)

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
