### PR TITLE
VIDSOL-283: Fixing regression after changes on cloud-runtime-cli

### DIFF
--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -28,8 +28,10 @@ jobs:
           cache: npm
 
       - name: Install VCR CLI
+        shell: bash
         run: |
-          sudo curl -L https://raw.githubusercontent.com/Vonage/cloud-runtime-cli/main/script/install.sh | sudo sh
+          set -euo pipefail
+          curl -fsSL https://raw.githubusercontent.com/Vonage/cloud-runtime-cli/main/script/install.sh | sudo bash
           vcr -v
 
       - name: Deploy vcr


### PR DESCRIPTION
#### What is this PR doing?
There was some changes introduced on [cloud-runtime-cli](https://github.com/Vonage/cloud-runtime-cli/commits/main/script/install.sh) on the past days, we are using all the time the last version of the file and it looks like that version may have cause some issues when running it with **Dash**.

VCR install script changed on Oct 31 and added Bash-only syntax (<<<). Ubuntu runners use dash by default, which doesn’t support that, so the command broke. Fixed by forcing the step to run with Bash instead.

#### How should this be manually tested?
No need.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-283](https://jira.vonage.com/browse/VIDSOL-283)

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
