### PR TITLE
VIDSOL-283: fixing pipilene type errors removing ts-check

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "version": "1.3.0",
   "type": "module",
   "scripts": {
-    "build": "yarn  --silent ts-check && vite build && yarn cp-build",
+    "build": "vite build && yarn cp-build",
     "cp-build": "mkdir -p ../backend/dist && cp -r dist ../backend",
     "dev": "concurrently 'yarn --silent ts-check:watch' 'vite --host'",
     "docs": "typedoc",


### PR DESCRIPTION
#### What is this PR doing?
Removing ts-check from the build script... The VRC deploy pipeline fails when running it due to a lack of some TypeScript dependencies. However, the error seems environment-related, and I haven’t been able to reproduce it locally to fix it. For now, we can disable it to unlock the deployment.

#### How should this be manually tested?
pipiline should work

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-](https://jira.vonage.com/browse/VIDSOL-)

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
