### PR TITLE
VIDSOL-305: Remove ts check hotfix

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Express-based backend with authenticated routes.",
   "main": "index.js",
   "type": "module",
   "scripts": {
     "dev": "nodemon --watch . --ext ts,tsx,json --ignore dist --exec \"sh -c 'yarn ts-check && node --import tsx index.ts'\"",
-    "start": "yarn ts-check && node --import tsx index.ts",
+    "start": "node --import tsx index.ts",
     "debug": "nodemon --watch . --ext ts,tsx,json --ignore dist --exec \"sh -c 'yarn ts-check && node --inspect --import tsx index.ts'\"",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest --maxWorkers=1 --coverage",
     "test:watch": "yarn test --watch",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,10 +2,10 @@
   "name": "frontend",
   "private": true,
   "description": "React reference application for the Vonage Video web client SDK.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
-    "build": "yarn  --silent ts-check && vite build && yarn cp-build",
+    "build": "vite build && yarn cp-build",
     "cp-build": "mkdir -p ../backend/dist && cp -r dist ../backend",
     "dev": "concurrently 'yarn --silent ts-check:watch' 'vite --host'",
     "docs": "typedoc",
@@ -54,7 +54,8 @@
     "ua-parser-js": "^1.0.37",
     "uuid": "^9.0.1",
     "vite": "^5.4.19",
-    "vitest": "^1.6"
+    "vitest": "^1.6",
+    "vite-plugin-checker": "^0.11.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.1",
@@ -65,7 +66,6 @@
     "@types/uuid": "^9.0.8",
     "@vitest/coverage-v8": "^1.3.0",
     "@vitest/ui": "^1.3",
-    "jsdom": "^22.1.0",
-    "vite-plugin-checker": "^0.11.0"
+    "jsdom": "^22.1.0"
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -29,6 +29,7 @@ const vitestConfig: VitestUserConfigInterface = defineVitestConfig({
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
+  const isDevelopment = mode === 'development';
 
   return mergeConfig(vitestConfig, {
     server: {
@@ -44,10 +45,14 @@ export default defineConfig(({ mode }) => {
         'process.env.CI': process.env.CI,
         preventAssignment: true,
       }),
-      checker({
-        typescript: true,
-        terminal: true,
-      }),
+      ...(isDevelopment
+        ? [
+            checker({
+              typescript: true,
+              terminal: true,
+            }),
+          ]
+        : []),
     ],
     resolve: {
       alias: {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-tests",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "integration test workspace for vonage video react app",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vonage-video-react-app",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "React reference application for the Vonage Video web client SDK.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
#### What is this PR doing?
- we are removing the ts-check from the build scripts in the package json
- we made now consume vite-plugin-checker only on dev mode
- vite-plugin-checker was added as a dev instead of dev dependency to avoid compilation errors

#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-305](https://jira.vonage.com/browse/VIDSOL-)

#### Checklist
[ ] Branch is based on `develop` (not `main`).*THIS IS A HOT FIX FOR MAIN*
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
