### PR TITLE
VIDSOL-359: Add vscode extension recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ sauce-connect.log
 .tern-project
 
 /.vscode
+!/.vscode/extensions.json
 
 build
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "streetsidesoftware.code-spell-checker",
+        "naumovs.color-highlight",
+        "nrwl.angular-console",
+        "ms-playwright.playwright",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "github.copilot-chat",
+        "github.copilot"
+    ]
+}


### PR DESCRIPTION
#### What is this PR doing?
Adds recommended VS Code extensions to help with onboarding. When you open the project, VS Code will prompt you to install helpful extensions like ESLint, Prettier, Tailwind IntelliSense, etc.

#### How should this be manually tested?
1. Pull the branch and open in VS Code
2. You should see a notification about extension recommendations
3. Click "Show Recommendations" to see the list


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-359](https://jira.vonage.com/browse/VIDSOL-359)

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
