### PR TITLE
VIDSOL-323: vcr fixes node version config

### DIFF
--- a/.github/workflows/deploy-to-vcr.yml
+++ b/.github/workflows/deploy-to-vcr.yml
@@ -24,8 +24,13 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: yarn
+
+      - name: Verify Node & Yarn versions
+        run: |
+          node -v
+          yarn -v
 
       - name: Building artefact
         run: |


### PR DESCRIPTION
#### What is this PR doing?
forcing node version to be 22.12 >

#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-](https://jira.vonage.com/browse/VIDSOL-)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
