### PR TITLE
VIDSOL-309: Full Clickable Zoom

### DIFF
--- a/frontend/src/components/HiddenParticipantsTile/HiddenParticipantsTile.tsx
+++ b/frontend/src/components/HiddenParticipantsTile/HiddenParticipantsTile.tsx
@@ -40,7 +40,6 @@ const HiddenParticipantsTile = ({
       data-testid="hidden-participants"
       sx={{
         position: 'absolute',
-        margin: 1,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
+++ b/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
@@ -62,11 +62,13 @@ const ZoomIndicator = ({
         right: 8,
         display: 'flex',
         alignItems: 'center',
-        gap: 1,
+        gap: isZoomed ? 1 : 0,
         borderRadius: theme.shapes.borderRadiusLarge,
         backgroundColor: theme.colors.darkGreyOpacity,
         p: 0.75,
+        cursor: isZoomed ? 'default' : 'pointer',
       }}
+      onClick={!isZoomed ? handleMainClick : undefined}
     >
       {/* Main zoom indicator button */}
       <Tooltip
@@ -81,7 +83,7 @@ const ZoomIndicator = ({
           data-testid="zoom-indicator-button"
           onMouseLeave={() => setTooltipOpen(false)}
           sx={{
-            ml: isZoomed ? 0 : 1,
+            p: isZoomed ? undefined : 0.75,
           }}
         >
           {isZoomed ? (
@@ -101,61 +103,63 @@ const ZoomIndicator = ({
       </Tooltip>
 
       {/* Zoom controls */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0 }}>
-        {isZoomed && (
-          <>
-            <Tooltip arrow title={t('zoom.out')}>
-              <Box component="span">
-                <IconButton
-                  onClick={zoomOut}
-                  disabled={!canZoomOut}
-                  data-testid="zoom-out-button"
-                  sx={{
-                    p: 0.5,
-                    color: theme.colors.onDarkGrey,
-                    '&:disabled': {
-                      color: theme.colors.disabled,
-                    },
-                  }}
-                >
-                  <VividIcon customSize={-6} name="minus-solid" />
-                </IconButton>
-              </Box>
-            </Tooltip>
-
-            {/* Zoom percentage display */}
-            {isZoomed && (
-              <Tooltip arrow title={t('zoom.current')}>
-                <Typography
-                  component="span"
-                  sx={{ mx: 1, cursor: 'default', color: theme.colors.onDarkGrey }}
-                  data-testid="zoom-level"
-                >
-                  {Math.round(zoomLevel * 100)}%
-                </Typography>
+      {isZoomed && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0 }}>
+          {isZoomed && (
+            <>
+              <Tooltip arrow title={t('zoom.out')}>
+                <Box component="span">
+                  <IconButton
+                    onClick={zoomOut}
+                    disabled={!canZoomOut}
+                    data-testid="zoom-out-button"
+                    sx={{
+                      p: 0.5,
+                      color: theme.colors.onDarkGrey,
+                      '&:disabled': {
+                        color: theme.colors.disabled,
+                      },
+                    }}
+                  >
+                    <VividIcon customSize={-6} name="minus-solid" />
+                  </IconButton>
+                </Box>
               </Tooltip>
-            )}
-            <Tooltip arrow title={t('zoom.in')}>
-              <Box component="span">
-                <IconButton
-                  onClick={zoomIn}
-                  disabled={!canZoomIn}
-                  data-testid="zoom-in-button"
-                  sx={{
-                    p: 0.5,
-                    color: theme.colors.onDarkGrey,
-                    '&:disabled': {
-                      color: theme.colors.disabled,
-                    },
-                  }}
-                >
-                  <VividIcon customSize={-6} name="plus-solid" />
-                </IconButton>
-              </Box>
-            </Tooltip>
-          </>
-        )}
-      </Box>
+
+              {/* Zoom percentage display */}
+              {isZoomed && (
+                <Tooltip arrow title={t('zoom.current')}>
+                  <Typography
+                    component="span"
+                    sx={{ mx: 1, cursor: 'default', color: theme.colors.onDarkGrey }}
+                    data-testid="zoom-level"
+                  >
+                    {Math.round(zoomLevel * 100)}%
+                  </Typography>
+                </Tooltip>
+              )}
+              <Tooltip arrow title={t('zoom.in')}>
+                <Box component="span">
+                  <IconButton
+                    onClick={zoomIn}
+                    disabled={!canZoomIn}
+                    data-testid="zoom-in-button"
+                    sx={{
+                      p: 0.5,
+                      color: theme.colors.onDarkGrey,
+                      '&:disabled': {
+                        color: theme.colors.disabled,
+                      },
+                    }}
+                  >
+                    <VividIcon customSize={-6} name="plus-solid" />
+                  </IconButton>
+                </Box>
+              </Tooltip>
+            </>
+          )}
+        </Box>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
+++ b/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
@@ -79,7 +79,7 @@ const ZoomIndicator = ({
         onClose={() => setTooltipOpen(false)}
       >
         <IconButton
-          onClick={handleMainClick}
+          onClick={isZoomed ? handleMainClick : undefined}
           data-testid="zoom-indicator-button"
           onMouseLeave={() => setTooltipOpen(false)}
           sx={{

--- a/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
+++ b/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
@@ -68,7 +68,7 @@ const ZoomIndicator = ({
         p: 0.75,
         cursor: isZoomed ? 'default' : 'pointer',
       }}
-      onClick={!isZoomed ? handleMainClick : undefined}
+      onClick={isZoomed ? undefined : handleMainClick}
     >
       {/* Main zoom indicator button */}
       <Tooltip
@@ -105,59 +105,57 @@ const ZoomIndicator = ({
       {/* Zoom controls */}
       {isZoomed && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0 }}>
-          {isZoomed && (
-            <>
-              <Tooltip arrow title={t('zoom.out')}>
-                <Box component="span">
-                  <IconButton
-                    onClick={zoomOut}
-                    disabled={!canZoomOut}
-                    data-testid="zoom-out-button"
-                    sx={{
-                      p: 0.5,
-                      color: theme.colors.onDarkGrey,
-                      '&:disabled': {
-                        color: theme.colors.disabled,
-                      },
-                    }}
-                  >
-                    <VividIcon customSize={-6} name="minus-solid" />
-                  </IconButton>
-                </Box>
-              </Tooltip>
+          <>
+            <Tooltip arrow title={t('zoom.out')}>
+              <Box component="span">
+                <IconButton
+                  onClick={zoomOut}
+                  disabled={!canZoomOut}
+                  data-testid="zoom-out-button"
+                  sx={{
+                    p: 0.5,
+                    color: theme.colors.onDarkGrey,
+                    '&:disabled': {
+                      color: theme.colors.disabled,
+                    },
+                  }}
+                >
+                  <VividIcon customSize={-6} name="minus-solid" />
+                </IconButton>
+              </Box>
+            </Tooltip>
 
-              {/* Zoom percentage display */}
-              {isZoomed && (
-                <Tooltip arrow title={t('zoom.current')}>
-                  <Typography
-                    component="span"
-                    sx={{ mx: 1, cursor: 'default', color: theme.colors.onDarkGrey }}
-                    data-testid="zoom-level"
-                  >
-                    {Math.round(zoomLevel * 100)}%
-                  </Typography>
-                </Tooltip>
-              )}
-              <Tooltip arrow title={t('zoom.in')}>
-                <Box component="span">
-                  <IconButton
-                    onClick={zoomIn}
-                    disabled={!canZoomIn}
-                    data-testid="zoom-in-button"
-                    sx={{
-                      p: 0.5,
-                      color: theme.colors.onDarkGrey,
-                      '&:disabled': {
-                        color: theme.colors.disabled,
-                      },
-                    }}
-                  >
-                    <VividIcon customSize={-6} name="plus-solid" />
-                  </IconButton>
-                </Box>
+            {/* Zoom percentage display */}
+            {isZoomed && (
+              <Tooltip arrow title={t('zoom.current')}>
+                <Typography
+                  component="span"
+                  sx={{ mx: 1, cursor: 'default', color: theme.colors.onDarkGrey }}
+                  data-testid="zoom-level"
+                >
+                  {Math.round(zoomLevel * 100)}%
+                </Typography>
               </Tooltip>
-            </>
-          )}
+            )}
+            <Tooltip arrow title={t('zoom.in')}>
+              <Box component="span">
+                <IconButton
+                  onClick={zoomIn}
+                  disabled={!canZoomIn}
+                  data-testid="zoom-in-button"
+                  sx={{
+                    p: 0.5,
+                    color: theme.colors.onDarkGrey,
+                    '&:disabled': {
+                      color: theme.colors.disabled,
+                    },
+                  }}
+                >
+                  <VividIcon customSize={-6} name="plus-solid" />
+                </IconButton>
+              </Box>
+            </Tooltip>
+          </>
         </Box>
       )}
     </Box>

--- a/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
+++ b/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
@@ -54,6 +54,9 @@ const ZoomIndicator = ({
     }
   };
 
+  const outerClickHandler = isZoomed ? undefined : handleMainClick;
+  const innerClickHandler = outerClickHandler ? undefined : handleMainClick;
+
   return (
     <Box
       sx={{
@@ -68,7 +71,7 @@ const ZoomIndicator = ({
         p: 0.75,
         cursor: isZoomed ? 'default' : 'pointer',
       }}
-      onClick={isZoomed ? undefined : handleMainClick}
+      onClick={outerClickHandler}
     >
       {/* Main zoom indicator button */}
       <Tooltip
@@ -79,7 +82,7 @@ const ZoomIndicator = ({
         onClose={() => setTooltipOpen(false)}
       >
         <IconButton
-          onClick={isZoomed ? handleMainClick : undefined}
+          onClick={innerClickHandler}
           data-testid="zoom-indicator-button"
           onMouseLeave={() => setTooltipOpen(false)}
           sx={{


### PR DESCRIPTION
#### What is this PR doing?
While trying to zoom in on the shared screen, whole button was not clickable. The whole grey thing should be clickable.

#### How should this be manually tested?
Check that Zoom Button is fully clickable when no zoom (100%).
If you have some zoom (e.g 125% or 75%), only icons will be clickable.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-309](https://jira.vonage.com/browse/VIDSOL-309)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
