### PR TITLE
VIDSOL-425: implement the new  makeRoomContextWrapper and migrate spec to u…

### DIFF
--- a/frontend/src/components/BackgroundEffects/BackgroundEffectsLayout/BackgroundEffectsLayout.spec.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundEffectsLayout/BackgroundEffectsLayout.spec.tsx
@@ -7,6 +7,12 @@ import BackgroundEffectsLayout from './BackgroundEffectsLayout';
 import enTranslations from '../../../locales/en.json';
 import mediaDevicesMock from '@common/test/mocks/mediaDevicesMock';
 
+const applyBackgroundFilterMock = vi.fn(() => Promise.resolve());
+
+vi.mock('../../../utils/backgroundFilter/applyBackgroundFilter/applyBackgroundFilter', () => ({
+  default: () => applyBackgroundFilterMock(),
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => {
@@ -48,6 +54,7 @@ describe('BackgroundEffectsLayout (Meeting room)', () => {
 
   beforeEach(() => {
     handleClose.mockClear();
+    applyBackgroundFilterMock.mockClear();
   });
 
   it('renders when open', async () => {
@@ -78,6 +85,7 @@ describe('BackgroundEffectsLayout (Meeting room)', () => {
     render(<BackgroundEffectsLayout mode="meeting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-effect-apply-button'));
     expect(handleClose).toHaveBeenCalled();
+    expect(applyBackgroundFilterMock).toHaveBeenCalled();
   });
 
   it('calls setBackgroundSelected when effect option none is clicked', async () => {
@@ -102,6 +110,7 @@ describe('BackgroundEffects (Waiting Room)', () => {
 
   beforeEach(() => {
     handleClose.mockClear();
+    applyBackgroundFilterMock.mockClear();
   });
 
   it('renders when open', async () => {
@@ -131,8 +140,8 @@ describe('BackgroundEffects (Waiting Room)', () => {
   it('calls handleClose and changeBackground when Apply is clicked', async () => {
     render(<BackgroundEffectsLayout mode="waiting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-effect-apply-button'));
-
     expect(handleClose).toHaveBeenCalled();
+    expect(applyBackgroundFilterMock).toHaveBeenCalled();
   });
 
   it('calls setBackgroundSelected when effect option none is clicked', async () => {

--- a/frontend/src/components/BackgroundEffects/BackgroundEffectsLayout/BackgroundEffectsLayout.spec.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundEffectsLayout/BackgroundEffectsLayout.spec.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { render as renderBase, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReactElement } from 'react';
+import { makeRoomContextWrapper } from '@test/providers';
 import BackgroundEffectsLayout from './BackgroundEffectsLayout';
 import enTranslations from '../../../locales/en.json';
-
-const mockChangeBackground = vi.fn();
+import mediaDevicesMock from '@common/test/mocks/mediaDevicesMock';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -19,52 +20,39 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-vi.mock('../../../hooks/usePublisherContext', () => ({
-  __esModule: true,
-  default: () => ({
-    publisher: {
-      getVideoFilter: vi.fn(() => undefined),
-    },
-    changeBackground: mockChangeBackground,
-    isVideoEnabled: true,
-  }),
-}));
-vi.mock('../../../hooks/usePreviewPublisherContext', () => ({
-  __esModule: true,
-  default: () => ({
-    publisher: {
-      getVideoFilter: vi.fn(() => undefined),
-    },
-    changeBackground: mockChangeBackground,
-    isVideoEnabled: true,
-  }),
-}));
-vi.mock('../../../hooks/useBackgroundPublisherContext', () => ({
-  __esModule: true,
-  default: () => ({
-    publisherVideoElement: null,
-    changeBackground: vi.fn(),
-    backgroundSelected: 'none',
-    setBackgroundSelected: vi.fn(),
-    customImages: [],
-    addCustomImage: vi.fn(),
-    deleteCustomImage: vi.fn(),
-    handleBackgroundChange: vi.fn(),
-    handleAddCustomImage: vi.fn(),
-  }),
-}));
+mediaDevicesMock.addEventListener = vi.fn();
+mediaDevicesMock.removeEventListener = vi.fn();
+mediaDevicesMock.enumerateDevices = vi.fn(() => Promise.resolve([]));
+mediaDevicesMock.getUserMedia = vi.fn(() =>
+  Promise.resolve({
+    getTracks: () => [],
+    getAudioTracks: () => [],
+    getVideoTracks: () => [],
+  } as unknown as MediaStream)
+);
+
+Object.defineProperty(global.navigator, 'mediaDevices', {
+  writable: true,
+  value: mediaDevicesMock,
+});
+
+Object.defineProperty(global.navigator, 'permissions', {
+  writable: true,
+  value: {
+    query: vi.fn(() => Promise.resolve({ state: 'granted' })),
+  },
+});
 
 describe('BackgroundEffectsLayout (Meeting room)', () => {
   const handleClose = vi.fn();
-  const renderLayout = (isOpen = true) =>
-    render(<BackgroundEffectsLayout mode="meeting" isOpen={isOpen} handleClose={handleClose} />);
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    handleClose.mockClear();
   });
 
-  it('renders when open', () => {
-    renderLayout();
+  it('renders when open', async () => {
+    render(<BackgroundEffectsLayout mode="meeting" isOpen handleClose={handleClose} />);
+    await waitFor(() => expect(screen.getByTestId('right-panel-title')).toBeInTheDocument());
     expect(screen.getByTestId('right-panel-title')).toHaveTextContent('Video effects');
     expect(screen.getByTestId('background-video-container')).toBeInTheDocument();
     expect(screen.getByTestId('background-none')).toBeInTheDocument();
@@ -73,90 +61,98 @@ describe('BackgroundEffectsLayout (Meeting room)', () => {
     expect(screen.getByTestId('background-effect-apply-button')).toBeInTheDocument();
   });
 
-  it('does not render when closed', () => {
-    const { container } = renderLayout(false);
-    expect(container).toBeEmptyDOMElement();
+  it('does not render when closed', async () => {
+    const { container } = render(
+      <BackgroundEffectsLayout mode="meeting" isOpen={false} handleClose={handleClose} />
+    );
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
   it('calls handleClose when Cancel is clicked', async () => {
-    renderLayout();
+    render(<BackgroundEffectsLayout mode="meeting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-effect-cancel-button'));
     expect(handleClose).toHaveBeenCalled();
   });
 
   it('calls handleClose and changeBackground when Apply is clicked', async () => {
-    renderLayout();
+    render(<BackgroundEffectsLayout mode="meeting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-effect-apply-button'));
-    expect(mockChangeBackground).toHaveBeenCalled();
     expect(handleClose).toHaveBeenCalled();
   });
 
   it('calls setBackgroundSelected when effect option none is clicked', async () => {
-    renderLayout();
+    render(<BackgroundEffectsLayout mode="meeting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-none'));
   });
 
   it('calls setBackgroundSelected when a background gallery option is clicked', async () => {
-    renderLayout();
+    render(<BackgroundEffectsLayout mode="meeting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-bg8'));
   });
 
-  it('displays correct English title, subtitle, cancel, and apply actions', () => {
-    renderLayout();
-    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  it('displays correct English title, subtitle, cancel, and apply actions', async () => {
+    render(<BackgroundEffectsLayout mode="meeting" isOpen handleClose={handleClose} />);
+    await waitFor(() => expect(screen.getByText('Cancel')).toBeInTheDocument());
     expect(screen.getByText('Apply')).toBeInTheDocument();
   });
 });
 
 describe('BackgroundEffects (Waiting Room)', () => {
   const handleClose = vi.fn();
-  const renderLayout = (isOpen = true) =>
-    render(<BackgroundEffectsLayout mode="waiting" isOpen={isOpen} handleClose={handleClose} />);
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    handleClose.mockClear();
   });
 
-  it('renders when open', () => {
-    renderLayout();
-    expect(screen.getByTestId('background-video-container')).toBeInTheDocument();
+  it('renders when open', async () => {
+    render(<BackgroundEffectsLayout mode="waiting" isOpen handleClose={handleClose} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('background-video-container')).toBeInTheDocument()
+    );
     expect(screen.getByTestId('background-none')).toBeInTheDocument();
     expect(screen.getByTestId('background-bg1')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Apply/i })).toBeInTheDocument();
   });
 
-  it('does not render when closed', () => {
-    const { container } = renderLayout(false);
-    expect(container).toBeEmptyDOMElement();
+  it('does not render when closed', async () => {
+    const { container } = render(
+      <BackgroundEffectsLayout mode="waiting" isOpen={false} handleClose={handleClose} />
+    );
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
   it('calls handleClose when Cancel is clicked', async () => {
-    renderLayout();
+    render(<BackgroundEffectsLayout mode="waiting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-effect-cancel-button'));
     expect(handleClose).toHaveBeenCalled();
   });
 
   it('calls handleClose and changeBackground when Apply is clicked', async () => {
-    renderLayout();
+    render(<BackgroundEffectsLayout mode="waiting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-effect-apply-button'));
-    expect(mockChangeBackground).toHaveBeenCalled();
+
     expect(handleClose).toHaveBeenCalled();
   });
 
   it('calls setBackgroundSelected when effect option none is clicked', async () => {
-    renderLayout();
+    render(<BackgroundEffectsLayout mode="waiting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-none'));
   });
 
   it('calls setBackgroundSelected when a background gallery option is clicked', async () => {
-    renderLayout();
+    render(<BackgroundEffectsLayout mode="waiting" isOpen handleClose={handleClose} />);
     await userEvent.click(screen.getByTestId('background-bg8'));
   });
 
-  it('displays correct English title, subtitle, cancel, and apply actions', () => {
-    renderLayout();
-    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  it('displays correct English title, subtitle, cancel, and apply actions', async () => {
+    render(<BackgroundEffectsLayout mode="waiting" isOpen handleClose={handleClose} />);
+    await waitFor(() => expect(screen.getByText('Cancel')).toBeInTheDocument());
     expect(screen.getByText('Apply')).toBeInTheDocument();
   });
 });
+
+function render(ui: ReactElement) {
+  const { RoomProviderWrapper } = makeRoomContextWrapper();
+  return renderBase(ui, { wrapper: RoomProviderWrapper });
+}

--- a/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.spec.tsx
+++ b/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.spec.tsx
@@ -1,14 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { cleanup, screen, render as renderBase } from '@testing-library/react';
-import { ReactElement } from 'react';
+import { ComponentType, ReactElement, ReactNode } from 'react';
 import useDevices from '@hooks/useDevices';
 import { AllMediaDevices } from '@app-types/room';
 import { allMediaDevices } from '@utils/mockData/device';
-import { AppConfigProviderWrapperOptions, makeAppConfigProviderWrapper } from '@test/providers';
+import { makeRoomContextWrapper, type RoomContextWrapperOptions } from '@test/providers';
 import backgroundEffectsDialog$ from '@Context/BackgroundEffectsDialog';
 import precallNetworkTestDialog$ from '@Context/PrecallNetworkTestDialog';
 import ControlPanel from '.';
 import composeProviders from '@utils/composeProviders';
+import mediaDevicesMock from '@common/test/mocks/mediaDevicesMock';
 
 vi.mock('@hooks/useDevices.tsx');
 
@@ -22,6 +23,22 @@ describe('ControlPanel', () => {
     mockUseDevices.mockReturnValue({
       getAllMediaDevices: vi.fn(),
       allMediaDevices,
+    });
+
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      writable: true,
+      value: mediaDevicesMock,
+    });
+
+    vi.spyOn(mediaDevicesMock, 'addEventListener').mockImplementation(() => {});
+    vi.spyOn(mediaDevicesMock, 'removeEventListener').mockImplementation(() => {});
+    vi.spyOn(mediaDevicesMock, 'enumerateDevices').mockResolvedValue([]);
+
+    Object.defineProperty(global.navigator, 'permissions', {
+      writable: true,
+      value: {
+        query: vi.fn().mockResolvedValue({ state: 'granted' }),
+      },
     });
   });
 
@@ -141,13 +158,13 @@ describe('ControlPanel', () => {
 function render(
   ui: ReactElement,
   options?: {
-    appConfigOptions?: AppConfigProviderWrapperOptions;
+    roomContextOptions?: RoomContextWrapperOptions;
   }
 ) {
-  const { AppConfigWrapper } = makeAppConfigProviderWrapper(options?.appConfigOptions);
+  const { RoomProviderWrapper } = makeRoomContextWrapper(options?.roomContextOptions);
 
   const wrapper = composeProviders(
-    AppConfigWrapper,
+    RoomProviderWrapper as ComponentType<{ children: ReactNode }>,
     backgroundEffectsDialog$.Provider,
     precallNetworkTestDialog$.Provider
   );

--- a/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.spec.tsx
+++ b/frontend/src/components/WaitingRoom/ControlPanel/ControlPanel.spec.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { cleanup, screen, render as renderBase } from '@testing-library/react';
-import { ComponentType, ReactElement, ReactNode } from 'react';
+import { ReactElement } from 'react';
 import useDevices from '@hooks/useDevices';
 import { AllMediaDevices } from '@app-types/room';
 import { allMediaDevices } from '@utils/mockData/device';
@@ -164,7 +164,7 @@ function render(
   const { RoomProviderWrapper } = makeRoomContextWrapper(options?.roomContextOptions);
 
   const wrapper = composeProviders(
-    RoomProviderWrapper as ComponentType<{ children: ReactNode }>,
+    RoomProviderWrapper,
     backgroundEffectsDialog$.Provider,
     precallNetworkTestDialog$.Provider
   );

--- a/frontend/src/test/providers/index.ts
+++ b/frontend/src/test/providers/index.ts
@@ -13,14 +13,6 @@ export {
   type UserProviderWrapperOptions,
 } from './makeUserProviderWrapper';
 
-/**
- * TODO: We still need to create provider wrappers for the following contexts:
- *
- * RoomProvider
- *
- * Right now we are mocking all those context which downgrades the quality of our tests.
- */
-
 export {
   default as makeAudioOutputProviderWrapper,
   type AudioOutputProviderWrapperOptions,
@@ -40,3 +32,8 @@ export {
   default as makeBackgroundPublisherProviderWrapper,
   type BackgroundPublisherProviderWrapperOptions,
 } from './makeBackgroundPublisherProviderWrapper';
+
+export {
+  default as makeRoomContextWrapper,
+  type RoomContextWrapperOptions,
+} from './makeRoomContextWrapper';

--- a/frontend/src/test/providers/makeRoomContextWrapper.ts
+++ b/frontend/src/test/providers/makeRoomContextWrapper.ts
@@ -4,6 +4,10 @@ import makeUserProviderWrapper from './makeUserProviderWrapper';
 import makeBackgroundPublisherProviderWrapper from './makeBackgroundPublisherProviderWrapper';
 import makeAudioOutputProviderWrapper from './makeAudioOutputProviderWrapper';
 import makePreviewPublisherProviderWrapper from './makePreviewPublisherProviderWrapper';
+import type { PublisherProviderWrapperOptions } from './makePublisherProviderWrapper';
+import type { SessionProviderWrapperOptions } from './makeSessionProviderWrapper';
+import type { UserProviderWrapperOptions } from './makeUserProviderWrapper';
+import type { AppConfigProviderWrapperOptions } from './makeAppConfigProviderWrapper';
 
 export type RoomContextWrapperOptions = {
   publisherContext?: PublisherProviderWrapperOptions['publisherContext'];

--- a/frontend/src/test/providers/makeRoomContextWrapper.ts
+++ b/frontend/src/test/providers/makeRoomContextWrapper.ts
@@ -1,0 +1,49 @@
+import composeProviders from '@utils/composeProviders';
+import makeAppConfigProviderWrapper from './makeAppConfigProviderWrapper';
+import makeUserProviderWrapper from './makeUserProviderWrapper';
+import makeBackgroundPublisherProviderWrapper from './makeBackgroundPublisherProviderWrapper';
+import makeAudioOutputProviderWrapper from './makeAudioOutputProviderWrapper';
+import makePreviewPublisherProviderWrapper from './makePreviewPublisherProviderWrapper';
+
+export type RoomContextWrapperOptions = Record<string, never>;
+
+/**
+ * Creates wrapper for RoomContext which composes multiple providers.
+ * This mirrors the structure of RoomContext component:
+ * - AppConfig
+ * - User
+ * - BackgroundPublisher (which includes Publisher, Session)
+ * - PreviewPublisher
+ * - AudioOutput
+ *
+ * @param {object} _options - The wrapper options (reserved for future use).
+ * @returns The composed RoomContext wrapper and all context getters.
+ */
+function makeRoomContextWrapper(_options: RoomContextWrapperOptions = {}) {
+  const { AppConfigWrapper, ...appConfigContext } = makeAppConfigProviderWrapper();
+  const { UserProviderWrapper, ...userContext } = makeUserProviderWrapper();
+  const { BackgroundPublisherProviderWrapper, ...backgroundPublisherContext } =
+    makeBackgroundPublisherProviderWrapper();
+  const { PreviewPublisherProviderWrapper, ...previewPublisherContext } =
+    makePreviewPublisherProviderWrapper();
+  const { AudioOutputProviderWrapper, ...audioOutputContext } = makeAudioOutputProviderWrapper();
+
+  const RoomProviderWrapper = composeProviders(
+    AppConfigWrapper,
+    UserProviderWrapper,
+    BackgroundPublisherProviderWrapper,
+    PreviewPublisherProviderWrapper,
+    AudioOutputProviderWrapper
+  );
+
+  return {
+    RoomProviderWrapper,
+    ...appConfigContext,
+    ...userContext,
+    ...backgroundPublisherContext,
+    ...previewPublisherContext,
+    ...audioOutputContext,
+  };
+}
+
+export default makeRoomContextWrapper;

--- a/frontend/src/test/providers/makeRoomContextWrapper.ts
+++ b/frontend/src/test/providers/makeRoomContextWrapper.ts
@@ -5,7 +5,12 @@ import makeBackgroundPublisherProviderWrapper from './makeBackgroundPublisherPro
 import makeAudioOutputProviderWrapper from './makeAudioOutputProviderWrapper';
 import makePreviewPublisherProviderWrapper from './makePreviewPublisherProviderWrapper';
 
-export type RoomContextWrapperOptions = Record<string, never>;
+export type RoomContextWrapperOptions = {
+  publisherContext?: PublisherProviderWrapperOptions['publisherContext'];
+  sessionContext?: SessionProviderWrapperOptions['sessionOptions'];
+  userOptions?: UserProviderWrapperOptions['userOptions'];
+  appConfigOptions?: AppConfigProviderWrapperOptions;
+};
 
 /**
  * Creates wrapper for RoomContext which composes multiple providers.


### PR DESCRIPTION
#### What is this PR doing?
Implemented `makeRoomContextWrapper`  to compose all room-related providers for testing.
Replace mocked context hooks with real providers in `ControlPanel` and `BackgroundEffectsLayout` specs.  

#### How should this be manually tested?
Run the ` yarn vitest run frontend` 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-425](https://jira.vonage.com/browse/VIDSOL-425)

#### Checklist
[ x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
