### PR TITLE
VIDSOL-450: Devices name are truncated 

### DIFF
--- a/frontend/src/components/MeetingRoom/InputAudioDevices/InputAudioDevices.tsx
+++ b/frontend/src/components/MeetingRoom/InputAudioDevices/InputAudioDevices.tsx
@@ -12,6 +12,7 @@ import useDevices from '@hooks/useDevices';
 import usePublisherContext from '@hooks/usePublisherContext';
 import { setStorageItem, STORAGE_KEYS } from '@utils/storage';
 import cleanAndDedupeDeviceLabels from '@utils/cleanAndDedupeDeviceLabels';
+import Tooltip from '@ui/Tooltip';
 
 export type InputAudioDevicesProps = {
   handleToggle: () => void;
@@ -114,9 +115,11 @@ const InputAudioDevices = ({ handleToggle }: InputAudioDevicesProps): ReactEleme
                       />
                     </Box>
                   ) : (
-                    <Box sx={{ minWidth: 36 }} /> // Placeholder when CheckIcon is not displayed
+                    <Box sx={{ minWidth: 36 }} />
                   )}
-                  <Typography noWrap>{option}</Typography>
+                  <Tooltip title={option} placement="right" arrow>
+                    <Typography noWrap>{option}</Typography>
+                  </Tooltip>
                 </Box>
               </MenuItem>
             );

--- a/frontend/src/components/MeetingRoom/InputAudioDevices/InputAudioDevices.tsx
+++ b/frontend/src/components/MeetingRoom/InputAudioDevices/InputAudioDevices.tsx
@@ -118,7 +118,9 @@ const InputAudioDevices = ({ handleToggle }: InputAudioDevicesProps): ReactEleme
                     <Box sx={{ minWidth: 36 }} />
                   )}
                   <Tooltip title={option} placement="right" arrow>
-                    <Typography noWrap>{option}</Typography>
+                    <Typography component="span" noWrap>
+                      {option}
+                    </Typography>
                   </Tooltip>
                 </Box>
               </MenuItem>

--- a/frontend/src/components/MeetingRoom/OutputAudioDevices/OutputAudioDevices.tsx
+++ b/frontend/src/components/MeetingRoom/OutputAudioDevices/OutputAudioDevices.tsx
@@ -127,7 +127,9 @@ const OutputAudioDevices = ({ handleToggle }: OutputAudioDevicesProps): ReactEle
                     <Box sx={{ minWidth: 36 }} />
                   )}
                   <Tooltip title={device.label} placement="right" arrow>
-                    <Typography noWrap>{device.label}</Typography>
+                    <Typography component="span" noWrap>
+                      {device.label}
+                    </Typography>
                   </Tooltip>
                 </Box>
               </MenuItem>

--- a/frontend/src/components/MeetingRoom/OutputAudioDevices/OutputAudioDevices.tsx
+++ b/frontend/src/components/MeetingRoom/OutputAudioDevices/OutputAudioDevices.tsx
@@ -13,6 +13,7 @@ import Typography from '@ui/Typography';
 import MenuList from '@ui/MenuList';
 import MenuItem from '@ui/MenuItem';
 import VividIcon from '@components/VividIcon';
+import Tooltip from '@ui/Tooltip';
 
 export type OutputAudioDevicesProps = {
   handleToggle: () => void;
@@ -123,9 +124,11 @@ const OutputAudioDevices = ({ handleToggle }: OutputAudioDevicesProps): ReactEle
                       />
                     </Box>
                   ) : (
-                    <Box sx={{ minWidth: 36 }} /> // Placeholder when CheckIcon is not displayed
+                    <Box sx={{ minWidth: 36 }} />
                   )}
-                  <Typography noWrap>{device.label}</Typography>
+                  <Tooltip title={device.label} placement="right" arrow>
+                    <Typography noWrap>{device.label}</Typography>
+                  </Tooltip>
                 </Box>
               </MenuItem>
             );

--- a/frontend/src/components/MeetingRoom/VideoDevices/VideoDevices.tsx
+++ b/frontend/src/components/MeetingRoom/VideoDevices/VideoDevices.tsx
@@ -127,7 +127,9 @@ const VideoDevices = ({ handleToggle }: VideoDevicesProps): ReactElement | false
                     <Box sx={{ minWidth: 36 }} /> // Placeholder when CheckIcon is not displayed
                   )}
                   <Tooltip title={option.label} placement="right" arrow>
-                    <Typography noWrap>{option.label}</Typography>
+                    <Typography component="span" noWrap>
+                      {option.label}
+                    </Typography>
                   </Tooltip>
                 </Box>
               </MenuItem>

--- a/frontend/src/components/MeetingRoom/VideoDevices/VideoDevices.tsx
+++ b/frontend/src/components/MeetingRoom/VideoDevices/VideoDevices.tsx
@@ -12,6 +12,7 @@ import Typography from '@ui/Typography';
 import MenuList from '@ui/MenuList';
 import MenuItem from '@ui/MenuItem';
 import VividIcon from '@components/VividIcon';
+import Tooltip from '@ui/Tooltip';
 
 export type VideoDevicesProps = {
   handleToggle: () => void;
@@ -125,7 +126,9 @@ const VideoDevices = ({ handleToggle }: VideoDevicesProps): ReactElement | false
                   ) : (
                     <Box sx={{ minWidth: 36 }} /> // Placeholder when CheckIcon is not displayed
                   )}
-                  <Typography noWrap>{option.label}</Typography>
+                  <Tooltip title={option.label} placement="right" arrow>
+                    <Typography noWrap>{option.label}</Typography>
+                  </Tooltip>
                 </Box>
               </MenuItem>
             );


### PR DESCRIPTION
#### What is this PR doing?
Add tooltip to display device labels in audio and video device components to see the full text.

#### How should this be manually tested?
Check a tooltip is displayed in audio and video device components.
<img width="682" height="453" alt="Screenshot 2026-01-22 at 12 06 20" src="https://github.com/user-attachments/assets/00c08331-23d0-4d02-b782-b16dedf7236c" />

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-450](https://jira.vonage.com/browse/VIDSOL-450)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
