### PR TITLE
VIDSOL-433: Add padding to the active speaker and screenshare

### DIFF
--- a/frontend/src/components/MeetingRoom/ReportIssue/FeedbackForm/FeedbackForm.tsx
+++ b/frontend/src/components/MeetingRoom/ReportIssue/FeedbackForm/FeedbackForm.tsx
@@ -73,7 +73,7 @@ const FeedbackForm = ({
   // 208px = 64px panel header + 80px toolbar if small viewport + (40px submit button + 24px submit button margin)
   const height = isSmallViewport ? 'calc(100dvh - 208px)' : 'calc(100dvh - 224px)';
   // For small viewports: width = 100dvw - 50px of margin
-  // For desktop viewports: 310px = SMALL_RIGHT_PANEL_WIDTH RightPanel - 50px margin
+  // For desktop viewports: 310px = 350px RightPanel - 50px margin
   const width = isSmallViewport ? 'calc(100dvw - 50px)' : '300px';
 
   const getColorStyle = (value: string, maxLength: number) => {

--- a/frontend/src/components/MeetingRoom/ReportIssue/FeedbackForm/FeedbackForm.tsx
+++ b/frontend/src/components/MeetingRoom/ReportIssue/FeedbackForm/FeedbackForm.tsx
@@ -73,8 +73,8 @@ const FeedbackForm = ({
   // 208px = 64px panel header + 80px toolbar if small viewport + (40px submit button + 24px submit button margin)
   const height = isSmallViewport ? 'calc(100dvh - 208px)' : 'calc(100dvh - 224px)';
   // For small viewports: width = 100dvw - 50px of margin
-  // For desktop viewports: 310px = 360px RightPanel - 50px margin
-  const width = isSmallViewport ? 'calc(100dvw - 50px)' : '310px';
+  // For desktop viewports: 310px = SMALL_RIGHT_PANEL_WIDTH RightPanel - 50px margin
+  const width = isSmallViewport ? 'calc(100dvw - 50px)' : '300px';
 
   const getColorStyle = (value: string, maxLength: number) => {
     return value.length >= maxLength || value.length === 0 ? theme.colors.error : 'inherit';

--- a/frontend/src/components/MeetingRoom/RightPanel/RightPanel.tsx
+++ b/frontend/src/components/MeetingRoom/RightPanel/RightPanel.tsx
@@ -7,6 +7,7 @@ import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 import BackgroundEffectsLayout from '../../BackgroundEffects/BackgroundEffectsLayout';
 import Box from '@ui/Box';
 import useTheme from '@ui/theme';
+import { SMALL_RIGHT_PANEL_WIDTH } from '@utils/constants';
 
 export type RightPanelProps = {
   handleClose: () => void;
@@ -38,7 +39,7 @@ const RightPanel = ({ activeTab, handleClose }: RightPanelProps): ReactElement =
         bgcolor: theme.colors.surface,
         transition: 'right 0.3s',
         borderRadius: 2,
-        width: isSmallViewport ? '100dvw' : '360px',
+        width: isSmallViewport ? '100dvw' : SMALL_RIGHT_PANEL_WIDTH,
         height: isSmallViewport ? 'calc(100dvh - 80px)' : 'calc(100dvh - 96px)',
         mr: isSmallViewport ? 0 : 2,
         mt: isSmallViewport ? 0 : 2,

--- a/frontend/src/components/MeetingRoom/RightPanel/RightPanel.tsx
+++ b/frontend/src/components/MeetingRoom/RightPanel/RightPanel.tsx
@@ -3,16 +3,16 @@ import ParticipantList from '../ParticipantList/ParticipantList';
 import Chat from '../Chat';
 import ReportIssue from '../ReportIssue';
 import type { RightPanelActiveTab } from '../../../hooks/useRightPanel';
-import useIsSmallViewport from '../../../hooks/useIsSmallViewport';
 import BackgroundEffectsLayout from '../../BackgroundEffects/BackgroundEffectsLayout';
-import Box from '@ui/Box';
+import Box, { BoxProps } from '@ui/Box';
 import useTheme from '@ui/theme';
-import { SMALL_RIGHT_PANEL_WIDTH } from '@utils/constants';
+import classNames from 'classnames';
+import { twMerge } from 'tailwind-merge';
 
 export type RightPanelProps = {
   handleClose: () => void;
   activeTab: RightPanelActiveTab;
-};
+} & BoxProps;
 
 /**
  * RightPanel Component
@@ -23,13 +23,25 @@ export type RightPanelProps = {
  *   @property {Function} handleClose - click handler to close the panel
  * @returns {ReactElement} RightPanel Component
  */
-const RightPanel = ({ activeTab, handleClose }: RightPanelProps): ReactElement => {
-  const isSmallViewport = useIsSmallViewport();
+const RightPanel = ({
+  activeTab,
+  handleClose,
+  className,
+  ...boxProps
+}: RightPanelProps): ReactElement => {
   const theme = useTheme();
 
   return (
     <Box
       data-testid="right-panel"
+      className={twMerge(
+        classNames([
+          'w-[100dvw] vera-desktop:w-[350px]',
+          'h-[calc(100dvh-80px)] vera-desktop:h-[calc(100dvh-96px)]',
+          'mr-0 vera-desktop:mr-4 mt-0 vera-desktop:mt-4',
+          className,
+        ])
+      )}
       sx={{
         position: 'absolute',
         top: 0,
@@ -39,11 +51,8 @@ const RightPanel = ({ activeTab, handleClose }: RightPanelProps): ReactElement =
         bgcolor: theme.colors.surface,
         transition: 'right 0.3s',
         borderRadius: 2,
-        width: isSmallViewport ? '100dvw' : SMALL_RIGHT_PANEL_WIDTH,
-        height: isSmallViewport ? 'calc(100dvh - 80px)' : 'calc(100dvh - 96px)',
-        mr: isSmallViewport ? 0 : 2,
-        mt: isSmallViewport ? 0 : 2,
       }}
+      {...boxProps}
     >
       <ParticipantList handleClose={handleClose} isOpen={activeTab === 'participant-list'} />
       <BackgroundEffectsLayout

--- a/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.spec.tsx
@@ -309,7 +309,7 @@ describe('ScreenshareVideoTile', () => {
       const tile = screen.getByTestId('screenshare-tile');
       expect(tile).toHaveStyle({
         position: 'absolute',
-        margin: '8px',
+        margin: '0px',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.spec.tsx
@@ -307,13 +307,8 @@ describe('ScreenshareVideoTile', () => {
       render(<ScreenshareVideoTile {...defaultProps} />);
 
       const tile = screen.getByTestId('screenshare-tile');
-      expect(tile).toHaveStyle({
-        position: 'absolute',
-        margin: '0px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      });
+      expect(tile).toHaveStyle({ position: 'absolute' });
+      expect(tile).toHaveStyle({ display: 'flex' });
     });
 
     it('has correct id attribute', () => {

--- a/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.tsx
@@ -168,7 +168,6 @@ const ScreenshareVideoTile = forwardRef(
         data-testid={dataTestId}
         sx={{
           position: 'absolute',
-          m: 1,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -191,7 +190,7 @@ const ScreenshareVideoTile = forwardRef(
           sx={{
             position: 'relative',
             left: 0,
-            top: 0,
+            top: '-4px',
             width: '100%',
             height: '100%',
             overflow: 'hidden',

--- a/frontend/src/components/MeetingRoom/VideoTile/VideoTile.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTile/VideoTile.tsx
@@ -75,11 +75,11 @@ const VideoTile = forwardRef(
           sx={{
             position: 'relative',
             left: 0,
-            top: 0,
+            top: '-4px',
             width: '100%',
             height: '100%',
             overflow: 'hidden',
-            borderRadius: 3,
+            borderRadius: theme.shapes.borderRadiusLarge,
             backgroundColor: theme.colors.darkGrey,
             display: hasVideo ? 'block' : 'none',
             ...(isTalking && {
@@ -95,7 +95,7 @@ const VideoTile = forwardRef(
             width: '100%',
             height: '100%',
             overflow: 'hidden',
-            borderRadius: 3,
+            borderRadius: theme.shapes.borderRadiusLarge,
             backgroundColor: theme.colors.darkGrey,
             display: hasVideo ? 'none' : 'block',
             ...(isTalking && {

--- a/frontend/src/components/MeetingRoom/VideoTile/VideoTile.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTile/VideoTile.tsx
@@ -74,8 +74,8 @@ const VideoTile = forwardRef(
           ref={ref}
           sx={{
             position: 'relative',
-            left: 0,
-            top: '-4px',
+            left: isScreenshare ? 0 : '4px',
+            top: isScreenshare ? 0 : '4px',
             width: '100%',
             height: '100%',
             overflow: 'hidden',
@@ -90,8 +90,8 @@ const VideoTile = forwardRef(
         <Box
           sx={{
             position: 'relative',
-            left: 0,
-            top: 0,
+            left: isScreenshare ? 0 : '4px',
+            top: isScreenshare ? 0 : '4px',
             width: '100%',
             height: '100%',
             overflow: 'hidden',

--- a/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
+++ b/frontend/src/components/MeetingRoom/ZoomIndicator/ZoomIndicator.tsx
@@ -61,7 +61,7 @@ const ZoomIndicator = ({
     <Box
       sx={{
         position: 'absolute',
-        bottom: 4,
+        bottom: 8,
         right: 8,
         display: 'flex',
         alignItems: 'center',

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -177,3 +177,8 @@ export const MAX_ZOOM = 5;
  * This value determines how much the zoom level changes with each zoom action (e.g., mouse wheel event).
  */
 export const ZOOM_STEP = 0.25;
+
+/**
+ * @constant {number} SMALL_RIGHT_PANEL_WIDTH - The width in pixels of the right panel on small viewports.
+ */
+export const SMALL_RIGHT_PANEL_WIDTH = 350;

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -177,8 +177,3 @@ export const MAX_ZOOM = 5;
  * This value determines how much the zoom level changes with each zoom action (e.g., mouse wheel event).
  */
 export const ZOOM_STEP = 0.25;
-
-/**
- * @constant {number} SMALL_RIGHT_PANEL_WIDTH - The width in pixels of the right panel on small viewports.
- */
-export const SMALL_RIGHT_PANEL_WIDTH = 350;

--- a/frontend/src/utils/helpers/getBoxStyle.ts
+++ b/frontend/src/utils/helpers/getBoxStyle.ts
@@ -15,14 +15,15 @@ const getBoxStyle = (box: Box | undefined, isScreenShare?: boolean): CSSProperti
   box && {
     left: box.left,
     top: box.top,
-    // We subtract the margins from width and height
+    // We subtract the margins from width and height.
+    // Screenshare tiles do not apply the default outer margin.
     width:
       typeof box.width === 'number' && Number.isFinite(box.width)
-        ? box.width - VIDEO_TILE_MARGIN - (isScreenShare ? 0 : 6)
+        ? box.width - (isScreenShare ? 0 : VIDEO_TILE_MARGIN) - (isScreenShare ? 0 : 6)
         : 0,
     height:
       typeof box.height === 'number' && Number.isFinite(box.height)
-        ? box.height - VIDEO_TILE_MARGIN
+        ? box.height - (isScreenShare ? 0 : VIDEO_TILE_MARGIN)
         : 0,
     aspectRatio: '16 / 9',
   };


### PR DESCRIPTION
#### What is this PR doing?
Add padding to the active speaker and screen share.

#### How should this be manually tested?
Check the content is always visible, when you publish and subscribe, even if screen sharing or not.
The minimum margin is 4px: 
<img width="2278" height="1478" alt="image" src="https://github.com/user-attachments/assets/6d0cf658-4a76-4840-b202-1a989a6c67f9" />


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-433](https://jira.vonage.com/browse/VIDSOL-433)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
