### PR TITLE
VIDSOL-496: enable microphone toggle after joining with mic off

### DIFF
--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.spec.tsx
@@ -8,6 +8,7 @@ import {
 } from '@vonage/client-sdk-video';
 import EventEmitter from 'events';
 import usePublisher from './usePublisher';
+import { setStorageItem, STORAGE_KEYS } from '@utils/storage';
 import { makeTestProvider, ProviderOptions, providers } from '@test/providers';
 import SuspenseBoundary from '@common/components/SuspenseBoundary';
 import composeProviders from '@common/helpers/composeProviders';
@@ -121,6 +122,39 @@ describe('usePublisher', () => {
       await waitFor(() => {
         expect(result.current.publisher).toBeNull();
       });
+    });
+
+    it('should apply storage preference and mute audio when user joins with mic off', async () => {
+      setStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED, 'false');
+      try {
+        mockedInitPublisher.mockReturnValue(mockPublisher);
+        const { result } = renderHook(() => usePublisher(), {
+          userContext: {
+            value: {
+              defaultSettings: {
+                publishAudio: true,
+                publishVideo: false,
+                name: '',
+                noiseSuppression: true,
+                publishCaptions: false,
+              },
+            },
+          },
+        });
+
+        act(() => {
+          result.current.initializeLocalPublisher({});
+          // @ts-expect-error We simulate allowing camera and microphone permissions in a browser.
+          mockPublisher.emit('accessAllowed');
+        });
+
+        await waitFor(() => {
+          expect(publishAudioSpy).toHaveBeenCalledWith(false);
+          expect(result.current.isAudioEnabled).toBe(false);
+        });
+      } finally {
+        setStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED, 'true');
+      }
     });
   });
 

--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
@@ -16,6 +16,9 @@ import useSessionContext from '../../../hooks/useSessionContext';
 import applyBackgroundFilter from '../../../utils/backgroundFilter/applyBackgroundFilter/applyBackgroundFilter';
 import idempotentCallbackWithRetry from '@common/execution/idempotentCallbackWithRetry';
 
+const getUserPrefersAudioOn = (): boolean =>
+  getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false';
+
 type PublisherStreamCreatedEvent = Event<'streamCreated', Publisher> & {
   stream: Stream;
 };
@@ -154,10 +157,7 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
     }
 
     setIsVideoEnabled(!!publisherOptions.publishVideo);
-    const wantsAudioOn =
-      publisherOptions.publishAudio &&
-      getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false';
-    setIsAudioEnabled(!!wantsAudioOn);
+    setIsAudioEnabled(!!(publisherOptions.publishAudio && getUserPrefersAudioOn()));
   }, [publisherOptions]);
 
   reconnectingRef.current = reconnecting === true;
@@ -168,8 +168,7 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
       microphone: true,
       camera: true,
     });
-    const wantsAudioOn = getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false';
-    if (!wantsAudioOn && publisherRef.current) {
+    if (!getUserPrefersAudioOn() && publisherRef.current) {
       publisherRef.current.publishAudio(false);
       setIsAudioEnabled(false);
     }

--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
@@ -8,7 +8,7 @@ import OT, {
   PublisherProperties,
 } from '@vonage/client-sdk-video';
 import { useTranslation } from 'react-i18next';
-import { setStorageItem, STORAGE_KEYS } from '@utils/storage';
+import { getStorageItem, setStorageItem, STORAGE_KEYS } from '@utils/storage';
 import usePublisherQuality, { NetworkQuality } from '../usePublisherQuality/usePublisherQuality';
 import useSyncPublisherDevices from './hooks/useSyncPublisherDevices/useSyncPublisherDevices';
 import usePublisherOptions from '../usePublisherOptions';
@@ -154,7 +154,10 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
     }
 
     setIsVideoEnabled(!!publisherOptions.publishVideo);
-    setIsAudioEnabled(!!publisherOptions.publishAudio);
+    const wantsAudioOn =
+      publisherOptions.publishAudio &&
+      getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false';
+    setIsAudioEnabled(!!wantsAudioOn);
   }, [publisherOptions]);
 
   reconnectingRef.current = reconnecting === true;
@@ -165,6 +168,11 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
       microphone: true,
       camera: true,
     });
+    const wantsAudioOn = getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false';
+    if (!wantsAudioOn && publisherRef.current) {
+      publisherRef.current.publishAudio(false);
+      setIsAudioEnabled(false);
+    }
   }, []);
 
   const handleDestroyed = useCallback(() => {

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.spec.tsx
@@ -186,7 +186,7 @@ describe('usePublisherOptions', () => {
     });
   });
 
-  it('should disable audio and video from storage options', async () => {
+  it('should always request audio when allowed (storage mute applied in usePublisher)', async () => {
     vi.spyOn(OT, 'hasMediaProcessorSupport').mockReturnValue(true);
     setStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED, 'false');
     setStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED, 'true');
@@ -212,7 +212,7 @@ describe('usePublisherOptions', () => {
     });
 
     await waitFor(() => {
-      expect(result.current?.publishAudio).toBe(false);
+      expect(result.current?.publishAudio).toBe(true);
       expect(result.current?.publishVideo).toBe(true);
     });
   });

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
@@ -37,6 +37,11 @@ const usePublisherOptions = (): PublisherProperties | null => {
   const videoSource = useDeviceId('videoinput');
   const audioSource = useDeviceId('audioinput');
 
+  // Read storage outside getOptions so these values are in the dependency array.
+  // When user toggles audio/video, storage updates and triggers re-render; options must recompute.
+  const isAudioDisabled = getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) === 'false';
+  const isVideoDisabled = getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) === 'false';
+
   const getOptions = useStableCallback(() => {
     const initials = getInitials(name);
 
@@ -47,8 +52,6 @@ const usePublisherOptions = (): PublisherProperties | null => {
 
     const videoFilter: VideoFilter | undefined =
       backgroundFilter && hasMediaProcessorSupport() ? backgroundFilter : undefined;
-
-    const isVideoDisabled = getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) === 'false';
 
     // Audio: always request when allowed. The SDK does not acquire microphone when publishAudio is
     // false, so publishAudio(true) later would fail. The initial mute is applied in usePublisher
@@ -89,6 +92,8 @@ const usePublisherOptions = (): PublisherProperties | null => {
       publishCaptions,
       publishVideo,
       videoSource,
+      isAudioDisabled,
+      isVideoDisabled,
     ]
   );
 };

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
@@ -50,6 +50,11 @@ const usePublisherOptions = (): PublisherProperties | null => {
 
     const isVideoDisabled = getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) === 'false';
 
+    // Audio: always request when allowed. The SDK does not acquire microphone when publishAudio is
+    // false, so publishAudio(true) later would fail. The initial mute is applied in usePublisher
+    // after accessAllowed.
+    // Video: can use storage here. The SDK still acquires the camera when publishVideo is false
+    // (videoSource is provided), so publishVideo(true) works when toggling later.
     const options = {
       audioFallback: { publisher: true },
       audioFilter,

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
@@ -48,7 +48,6 @@ const usePublisherOptions = (): PublisherProperties | null => {
     const videoFilter: VideoFilter | undefined =
       backgroundFilter && hasMediaProcessorSupport() ? backgroundFilter : undefined;
 
-    const isAudioDisabled = getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) === 'false';
     const isVideoDisabled = getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) === 'false';
 
     const options = {
@@ -58,7 +57,7 @@ const usePublisherOptions = (): PublisherProperties | null => {
       initials,
       insertDefaultUI: false,
       name,
-      publishAudio: allowAudioOnJoin && publishAudio && !isAudioDisabled,
+      publishAudio: allowAudioOnJoin && publishAudio,
       publishCaptions,
       publishVideo: allowVideoOnJoin && publishVideo && !isVideoDisabled,
       resolution: defaultResolution,


### PR DESCRIPTION
#### What is this PR doing?

#### Root cause
When joining with camera on and microphone off, the Vonage SDK was
initialized with publishAudio: false. In that case, the SDK does not
request microphone access via getUserMedia, so the publisher never gets
an audio track.
Later, when the user turns the mic on, publishAudio(true) is called,
but the publisher has no audio source, so nothing is published.
#### Fix
- Always request audio in init when allowAudioOnJoin is true so the SDK
  acquires the microphone track
- Apply the stored preference in handleAccessAllowed by calling
  publishAudio(false) when the user chose mic off
- Persist storage-based preference ([VIDSOL-269](https://github.com/Vonage/vonage-video-react-app/pull/220)) unchanged


#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-496](https://jira.vonage.com/browse/VIDSOL-496)

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
