### PR TITLE
VIDSOL-488: firefox-video-preview

### DIFF
--- a/.github/workflows/vcr-deploy-on-comment.yml
+++ b/.github/workflows/vcr-deploy-on-comment.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 env:
@@ -103,6 +103,19 @@ jobs:
           api-secret: ${{ secrets.VCR_API_SECRET }}
           filename: vcr-dev.yml
 
+      - name: Comment PR on success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.number }},
+              body: `## ✅ Deployed to VCR\n\n**URL:** ${{ steps.deploy.outputs.instance-url }}\n\n**Commit:** \`${{ steps.pr.outputs.head_sha }}\`\n\n[View build logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`
+            });
+        continue-on-error: true
+
       - name: Slack notification on success
         uses: ./.github/actions/slack-notify
         with:
@@ -110,6 +123,19 @@ jobs:
           color: '28a745'
           message: "Vera pull request *<https://github.com/Vonage/vonage-video-react-app/pull/${{ steps.pr.outputs.number }}|${{ steps.pr.outputs.title }}>* \n with commit hash: ${{ steps.pr.outputs.head_sha }} \n is deployed to VCR \nURL: ${{ steps.deploy.outputs.instance-url }} \n*<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Click here to go to build logs>* \n :large_green_circle: :large_green_circle: :large_green_circle: :large_green_circle:"
         if: success()
+        continue-on-error: true
+
+      - name: Comment PR on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.number }},
+              body: `## ❌ Deployment to VCR Failed\n\n**Commit:** \`${{ steps.pr.outputs.head_sha }}\`\n\n[View build logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`
+            });
         continue-on-error: true
 
       - name: Slack notification on failure

--- a/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
+++ b/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
@@ -19,6 +19,7 @@ import mediaDevices$ from '@core/stores/devices';
 import useSyncPublisherDevices from '@Context/PublisherProvider/usePublisher/hooks/useSyncPublisherDevices';
 import { getStorageItem, STORAGE_KEYS } from '@utils/storage';
 import attempt from '@common/execution/attempt/attempt';
+import { useMountEffect } from '@web/hooks';
 
 export type BackgroundPublisherContextType = {
   isPublishing: boolean;
@@ -308,6 +309,12 @@ const useBackgroundPublisher = (
     },
     [addCustomImage, handleBackgroundChange]
   );
+
+  useMountEffect(() => {
+    return () => {
+      destroyBackgroundPublisher();
+    };
+  });
 
   return {
     initBackgroundLocalPublisher,

--- a/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
+++ b/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
@@ -17,6 +17,8 @@ import getInitialBackgroundFilter from '../../../utils/backgroundFilter/getIniti
 import handlePublisherAccessDenied from '../../../utils/publisher/handlePublisherAccessDenied';
 import mediaDevices$ from '@core/stores/devices';
 import useSyncPublisherDevices from '@Context/PublisherProvider/usePublisher/hooks/useSyncPublisherDevices';
+import { getStorageItem, STORAGE_KEYS } from '@utils/storage';
+import attempt from '@common/execution/attempt/attempt';
 
 export type BackgroundPublisherContextType = {
   isPublishing: boolean;
@@ -97,7 +99,7 @@ const useBackgroundPublisher = (
   );
 
   const [isVideoEnabled, setIsVideoEnabled] = useState<boolean>(
-    initialValue?.isVideoEnabled ?? true
+    initialValue?.isVideoEnabled ?? getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) !== 'false'
   );
 
   const [localVideoSource, setLocalVideoSource] = useState<string | undefined>(
@@ -178,10 +180,20 @@ const useBackgroundPublisher = (
     [handleBackgroundAccessDenied, setAccessStatus]
   );
 
+  /**
+   * Destroys the background publisher
+   * @returns {void}
+   */
+  const destroyBackgroundPublisher = useCallback(() => {
+    attempt(() => {
+      backgroundPublisherRef.current?.destroy();
+    });
+
+    backgroundPublisherRef.current = null;
+  }, []);
+
   const initBackgroundLocalPublisher = useCallback(() => {
-    if (backgroundPublisherRef.current) {
-      return;
-    }
+    if (backgroundPublisherRef.current) return;
 
     // Set videoFilter based on user's selected background
     let videoFilter: VideoFilter | undefined;
@@ -208,19 +220,6 @@ const useBackgroundPublisher = (
     });
     addPublisherListeners(backgroundPublisherRef.current);
   }, [addPublisherListeners, isVideoEnabled]);
-
-  /**
-   * Destroys the background publisher
-   * @returns {void}
-   */
-  const destroyBackgroundPublisher = useCallback(() => {
-    if (backgroundPublisherRef.current) {
-      backgroundPublisherRef.current.destroy();
-      backgroundPublisherRef.current = null;
-    } else {
-      console.warn('pub not destroyed');
-    }
-  }, []);
 
   /**
    * Turns the camera on and off

--- a/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
+++ b/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
@@ -21,6 +21,7 @@ import mediaDevices$ from '@core/stores/devices';
 import useSyncPublisherDevices from '@Context/PublisherProvider/usePublisher/hooks/useSyncPublisherDevices/useSyncPublisherDevices';
 import waitUntilPlaying from '@utils/waitUntilPlaying';
 import { attempt } from '@common/execution';
+import { useMountEffect } from '@web/hooks';
 
 type PublisherVideoElementCreatedEvent = Event<'videoElementCreated', Publisher> & {
   element: HTMLVideoElement | HTMLObjectElement;
@@ -319,6 +320,12 @@ const usePreviewPublisher = (
       }));
     }
   };
+
+  useMountEffect(() => {
+    return () => {
+      destroyPublisher();
+    };
+  });
 
   return {
     isAudioEnabled,

--- a/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
+++ b/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
@@ -13,13 +13,14 @@ import useUserContext from '../../../hooks/useUserContext';
 import { DEVICE_ACCESS_STATUS } from '../../../utils/constants';
 import { UserType } from '../../user';
 import { AccessDeniedEvent } from '../../PublisherProvider/usePublisher/usePublisher';
-import { setStorageItem, STORAGE_KEYS } from '../../../utils/storage';
+import { setStorageItem, getStorageItem, STORAGE_KEYS } from '../../../utils/storage';
 import applyBackgroundFilter from '../../../utils/backgroundFilter/applyBackgroundFilter/applyBackgroundFilter';
 import handlePublisherAccessDenied from '../../../utils/publisher/handlePublisherAccessDenied';
 import useStableCallback from '@web/hooks/useStableCallback';
 import mediaDevices$ from '@core/stores/devices';
 import useSyncPublisherDevices from '@Context/PublisherProvider/usePublisher/hooks/useSyncPublisherDevices/useSyncPublisherDevices';
 import waitUntilPlaying from '@utils/waitUntilPlaying';
+import { attempt } from '@common/execution';
 
 type PublisherVideoElementCreatedEvent = Event<'videoElementCreated', Publisher> & {
   element: HTMLVideoElement | HTMLObjectElement;
@@ -104,11 +105,15 @@ const usePreviewPublisher = (
     () => initialValue?.backgroundFilter ?? user.defaultSettings.backgroundFilter
   );
   const [isVideoEnabled, setIsVideoEnabled] = useState<boolean>(
-    initialValue?.isVideoEnabled ?? true
+    () =>
+      initialValue?.isVideoEnabled ?? getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) !== 'false'
   );
+
   const [isAudioEnabled, setIsAudioEnabled] = useState<boolean>(
-    initialValue?.isAudioEnabled ?? true
+    () =>
+      initialValue?.isAudioEnabled ?? getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false'
   );
+
   const handlePreviewDestroyed = () => {
     publisherRef.current = null;
   };
@@ -229,9 +234,6 @@ const usePreviewPublisher = (
     if (publisherRef.current) {
       return;
     }
-    // We reset user preferences as we want to start with both devices enabled
-    setStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED, 'true');
-    setStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED, 'true');
 
     // Set videoFilter based on user's selected background
     let videoFilter: VideoFilter | undefined;
@@ -243,6 +245,8 @@ const usePreviewPublisher = (
       insertDefaultUI: false,
       videoFilter,
       resolution: defaultResolution,
+      publishAudio: isAudioEnabled,
+      publishVideo: isVideoEnabled,
       audioSource: audioSourceId,
       videoSource: videoSourceId,
     };
@@ -264,11 +268,13 @@ const usePreviewPublisher = (
    */
   const destroyPublisher = useCallback(() => {
     if (publisherRef.current) {
-      publisherRef.current.destroy();
-      publisherRef.current = null;
-    } else {
-      console.warn('pub not destroyed');
+      attempt(() => {
+        // There is a known race condition in Firefox during navigation where the DOM elements are destroyed before the publisher is destroyed, causing OT to throw an error.
+        publisherRef.current?.destroy();
+      });
     }
+
+    publisherRef.current = null;
   }, []);
 
   /**

--- a/frontend/src/Context/PublisherProvider/usePublisher/hooks/useSyncPublisherDevices/useSyncPublisherDevices.ts
+++ b/frontend/src/Context/PublisherProvider/usePublisher/hooks/useSyncPublisherDevices/useSyncPublisherDevices.ts
@@ -21,9 +21,14 @@ const useSyncPublisherDevices = (
       args.setIsVideoEnabled
         ? mediaDevices$.subscribe(
             ({ videoinput }) => videoinput,
-            (input) => {
+            async (input) => {
               const didChanged = publisherRef.current?.getVideoSource()?.deviceId !== input;
               if (didChanged) attempt(() => publisherRef.current?.setVideoSource(input!));
+
+              const { permissionsRequests } = mediaDevices$.getMetadata();
+              if (permissionsRequests.status === 'pending') {
+                await permissionsRequests;
+              }
 
               if (hasDevices('videoinput')) return;
               args.setIsVideoEnabled?.(false);
@@ -37,9 +42,14 @@ const useSyncPublisherDevices = (
       args?.setIsAudioEnabled
         ? mediaDevices$.subscribe(
             ({ audioinput }) => audioinput,
-            (input) => {
+            async (input) => {
               const didChanged = publisherRef.current?.getAudioSource()?.id !== input;
               if (didChanged) attempt(() => publisherRef.current?.setAudioSource(input!));
+
+              const { permissionsRequests } = mediaDevices$.getMetadata();
+              if (permissionsRequests.status === 'pending') {
+                await permissionsRequests;
+              }
 
               if (hasDevices('audioinput')) return;
               args.setIsAudioEnabled?.(false);

--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
@@ -8,7 +8,7 @@ import OT, {
   PublisherProperties,
 } from '@vonage/client-sdk-video';
 import { useTranslation } from 'react-i18next';
-import { setStorageItem, STORAGE_KEYS } from '@utils/storage';
+import { getStorageItem, setStorageItem, STORAGE_KEYS } from '@utils/storage';
 import usePublisherQuality, { NetworkQuality } from '../usePublisherQuality/usePublisherQuality';
 import useSyncPublisherDevices from './hooks/useSyncPublisherDevices/useSyncPublisherDevices';
 import usePublisherOptions from '../usePublisherOptions';
@@ -105,12 +105,15 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
 
   const publisherOptions = usePublisherOptions();
   const [isForceMuted, setIsForceMuted] = useState<boolean>(initialValue?.isForceMuted ?? false);
+
   const [isVideoEnabled, setIsVideoEnabled] = useState<boolean>(
-    initialValue?.isVideoEnabled ?? false
+    initialValue?.isVideoEnabled ?? getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) !== 'false'
   );
+
   const [isAudioEnabled, setIsAudioEnabled] = useState<boolean>(
-    initialValue?.isAudioEnabled ?? false
+    initialValue?.isAudioEnabled ?? getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false'
   );
+
   const [stream, setStream] = useState<Stream | null>(initialValue?.stream ?? null);
 
   const [publishingError, setPublishingError] = useState<PublishingErrorType>(

--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
@@ -54,6 +54,7 @@ export type PublisherContextType = {
   toggleVideo: () => void;
   changeBackground: (backgroundSelected: string) => void;
   unpublish: () => void;
+  publisherOptions: PublisherProperties;
 };
 
 export type PublisherContextInitialValue = Partial<
@@ -552,6 +553,7 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
     toggleVideo,
     changeBackground,
     unpublish,
+    publisherOptions,
   };
 };
 export default usePublisher;

--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
@@ -104,7 +104,6 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
 
   const [isPublishing, setIsPublishing] = useState(initialValue?.isPublishing ?? false);
 
-  const publisherOptions = usePublisherOptions();
   const [isForceMuted, setIsForceMuted] = useState<boolean>(initialValue?.isForceMuted ?? false);
 
   const [isVideoEnabled, setIsVideoEnabled] = useState<boolean>(
@@ -114,6 +113,8 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
   const [isAudioEnabled, setIsAudioEnabled] = useState<boolean>(
     initialValue?.isAudioEnabled ?? getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false'
   );
+
+  const publisherOptions = usePublisherOptions({ isAudioEnabled, isVideoEnabled });
 
   const [stream, setStream] = useState<Stream | null>(initialValue?.stream ?? null);
 
@@ -151,15 +152,6 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
       setPublishingError(accessDeniedError);
     }
   }, [deviceAccess, t]);
-
-  useEffect(() => {
-    if (!publisherOptions) {
-      return;
-    }
-
-    setIsVideoEnabled(!!publisherOptions.publishVideo);
-    setIsAudioEnabled(!!publisherOptions.publishAudio);
-  }, [publisherOptions]);
 
   reconnectingRef.current = reconnecting === true;
 

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.spec.tsx
@@ -3,7 +3,6 @@ import { renderHook as renderHookBase, waitFor } from '@testing-library/react';
 import OT from '@vonage/client-sdk-video';
 import localStorageMock from '@utils/mockData/localStorageMock';
 import mediaDevices$ from '@core/stores/devices';
-import { setStorageItem, STORAGE_KEYS } from '@utils/storage';
 import { makeTestProvider, providers, ProviderOptions } from '@test/providers';
 import makeMediaDeviceInfos from '@web-test/fixtures/makeMediaDeviceInfos';
 import { setupWindowNavigatorMock } from '@web-test/fixtures';
@@ -47,7 +46,9 @@ describe('usePublisherOptions', () => {
 
   it('should use default settings', async () => {
     vi.spyOn(OT, 'hasMediaProcessorSupport').mockReturnValue(true);
-    const { result } = renderHook(() => usePublisherOptions());
+    const { result } = renderHook(() =>
+      usePublisherOptions({ isAudioEnabled: false, isVideoEnabled: false })
+    );
     await waitFor(() => {
       expect(result.current).toEqual({
         resolution: '1280x720',
@@ -72,7 +73,9 @@ describe('usePublisherOptions', () => {
 
   it('should not have advanced noise suppression if not supported by browser', async () => {
     vi.spyOn(OT, 'hasMediaProcessorSupport').mockReturnValue(false);
-    const { result } = renderHook(() => usePublisherOptions());
+    const { result } = renderHook(() =>
+      usePublisherOptions({ isAudioEnabled: true, isVideoEnabled: true })
+    );
 
     await waitFor(() => {
       expect(result.current?.audioFilter).toBe(undefined);
@@ -93,25 +96,28 @@ describe('usePublisherOptions', () => {
       videoinput: videoDevice.deviceId,
     }));
 
-    const { result } = renderHook(() => usePublisherOptions(), {
-      userContext: {
-        value: {
-          defaultSettings: {
-            publishAudio: true,
-            publishVideo: true,
-            name: 'Foo Bar',
-            backgroundFilter: {
-              type: 'backgroundBlur',
-              blurStrength: 'high',
+    const { result } = renderHook(
+      () => usePublisherOptions({ isAudioEnabled: true, isVideoEnabled: true }),
+      {
+        userContext: {
+          value: {
+            defaultSettings: {
+              publishAudio: true,
+              publishVideo: true,
+              name: 'Foo Bar',
+              backgroundFilter: {
+                type: 'backgroundBlur',
+                blurStrength: 'high',
+              },
+              noiseSuppression: false,
+              audioSource: audioDevice.deviceId,
+              videoSource: videoDevice.deviceId,
+              publishCaptions: true,
             },
-            noiseSuppression: false,
-            audioSource: audioDevice.deviceId,
-            videoSource: videoDevice.deviceId,
-            publishCaptions: true,
           },
         },
-      },
-    });
+      }
+    );
 
     await waitFor(() => {
       expect(result.current).toEqual({
@@ -138,15 +144,18 @@ describe('usePublisherOptions', () => {
 
   describe('configurable features', () => {
     it('should disable audio publishing when allowAudioOnJoin is false', async () => {
-      const { result } = renderHook(() => usePublisherOptions(), {
-        appConfigContext: {
-          value: {
-            audioSettings: {
-              allowAudioOnJoin: false,
+      const { result } = renderHook(
+        () => usePublisherOptions({ isAudioEnabled: true, isVideoEnabled: true }),
+        {
+          appConfigContext: {
+            value: {
+              audioSettings: {
+                allowAudioOnJoin: false,
+              },
             },
           },
-        },
-      });
+        }
+      );
 
       await waitFor(() => {
         expect(result.current?.publishAudio).toBe(false);
@@ -154,15 +163,18 @@ describe('usePublisherOptions', () => {
     });
 
     it('should disable video publishing when allowVideoOnJoin is false', async () => {
-      const { result } = renderHook(() => usePublisherOptions(), {
-        appConfigContext: {
-          value: {
-            audioSettings: {
-              allowAudioOnJoin: false,
+      const { result } = renderHook(
+        () => usePublisherOptions({ isAudioEnabled: true, isVideoEnabled: true }),
+        {
+          appConfigContext: {
+            value: {
+              videoSettings: {
+                allowVideoOnJoin: false,
+              },
             },
           },
-        },
-      });
+        }
+      );
 
       await waitFor(() => {
         expect(result.current?.publishVideo).toBe(false);
@@ -170,15 +182,18 @@ describe('usePublisherOptions', () => {
     });
 
     it('should configure resolution from config', async () => {
-      const { result } = renderHook(() => usePublisherOptions(), {
-        appConfigContext: {
-          value: {
-            videoSettings: {
-              defaultResolution: '640x480',
+      const { result } = renderHook(
+        () => usePublisherOptions({ isAudioEnabled: true, isVideoEnabled: true }),
+        {
+          appConfigContext: {
+            value: {
+              videoSettings: {
+                defaultResolution: '640x480',
+              },
             },
           },
-        },
-      });
+        }
+      );
 
       await waitFor(() => {
         expect(result.current?.resolution).toBe('640x480');
@@ -186,30 +201,31 @@ describe('usePublisherOptions', () => {
     });
   });
 
-  it('should disable audio and video from storage options', async () => {
+  it('should disable audio and video based on isAudioEnabled and isVideoEnabled params', async () => {
     vi.spyOn(OT, 'hasMediaProcessorSupport').mockReturnValue(true);
-    setStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED, 'false');
-    setStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED, 'true');
 
-    const { result } = renderHook(() => usePublisherOptions(), {
-      userContext: {
-        value: {
-          defaultSettings: {
-            publishAudio: true,
-            publishVideo: true,
-            name: 'Foo Bar',
-            backgroundFilter: {
-              type: 'backgroundBlur',
-              blurStrength: 'high',
+    const { result } = renderHook(
+      () => usePublisherOptions({ isAudioEnabled: false, isVideoEnabled: true }),
+      {
+        userContext: {
+          value: {
+            defaultSettings: {
+              publishAudio: true,
+              publishVideo: true,
+              name: 'Foo Bar',
+              backgroundFilter: {
+                type: 'backgroundBlur',
+                blurStrength: 'high',
+              },
+              noiseSuppression: false,
+              audioSource: audioDevice.deviceId,
+              videoSource: videoDevice.deviceId,
+              publishCaptions: true,
             },
-            noiseSuppression: false,
-            audioSource: audioDevice.deviceId,
-            videoSource: videoDevice.deviceId,
-            publishCaptions: true,
           },
         },
-      },
-    });
+      }
+    );
 
     await waitFor(() => {
       expect(result.current?.publishAudio).toBe(false);

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
@@ -8,7 +8,6 @@ import {
 import appConfig$ from '@stores/appConfig';
 import useUserContext from '@hooks/useUserContext';
 import getInitials from '@utils/getInitials';
-import { getStorageItem, STORAGE_KEYS } from '@utils/storage';
 import { useDeviceId } from '@core/stores/devices/hooks';
 import useStableCallback from '@web/hooks/useStableCallback';
 
@@ -17,7 +16,13 @@ import useStableCallback from '@web/hooks/useStableCallback';
  * @returns {PublisherProperties | null} publisher properties object
  */
 
-const usePublisherOptions = (): PublisherProperties => {
+const usePublisherOptions = ({
+  isAudioEnabled,
+  isVideoEnabled,
+}: {
+  isAudioEnabled: boolean;
+  isVideoEnabled: boolean;
+}): PublisherProperties => {
   const { user } = useUserContext();
 
   const defaultResolution = appConfig$.use.select(
@@ -36,9 +41,6 @@ const usePublisherOptions = (): PublisherProperties => {
 
   const videoSource = useDeviceId('videoinput');
   const audioSource = useDeviceId('audioinput');
-
-  const isAudioEnabled = getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false';
-  const isVideoEnabled = getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) !== 'false';
 
   const getOptions = useStableCallback(() => {
     const initials = getInitials(name);

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
@@ -37,6 +37,9 @@ const usePublisherOptions = (): PublisherProperties | null => {
   const videoSource = useDeviceId('videoinput');
   const audioSource = useDeviceId('audioinput');
 
+  const isAudioEnabled = getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) !== 'false';
+  const isVideoEnabled = getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) !== 'false';
+
   const getOptions = useStableCallback(() => {
     const initials = getInitials(name);
 
@@ -48,9 +51,6 @@ const usePublisherOptions = (): PublisherProperties | null => {
     const videoFilter: VideoFilter | undefined =
       backgroundFilter && hasMediaProcessorSupport() ? backgroundFilter : undefined;
 
-    const isAudioDisabled = getStorageItem(STORAGE_KEYS.AUDIO_SOURCE_ENABLED) === 'false';
-    const isVideoDisabled = getStorageItem(STORAGE_KEYS.VIDEO_SOURCE_ENABLED) === 'false';
-
     const options = {
       audioFallback: { publisher: true },
       audioFilter,
@@ -58,9 +58,9 @@ const usePublisherOptions = (): PublisherProperties | null => {
       initials,
       insertDefaultUI: false,
       name,
-      publishAudio: allowAudioOnJoin && publishAudio && !isAudioDisabled,
+      publishAudio: allowAudioOnJoin && publishAudio && isAudioEnabled,
       publishCaptions,
-      publishVideo: allowVideoOnJoin && publishVideo && !isVideoDisabled,
+      publishVideo: allowVideoOnJoin && publishVideo && isVideoEnabled,
       resolution: defaultResolution,
       videoFilter,
       videoSource,
@@ -85,6 +85,8 @@ const usePublisherOptions = (): PublisherProperties | null => {
       publishCaptions,
       publishVideo,
       videoSource,
+      isAudioEnabled,
+      isVideoEnabled,
     ]
   );
 };

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
@@ -17,7 +17,7 @@ import useStableCallback from '@web/hooks/useStableCallback';
  * @returns {PublisherProperties | null} publisher properties object
  */
 
-const usePublisherOptions = (): PublisherProperties | null => {
+const usePublisherOptions = (): PublisherProperties => {
   const { user } = useUserContext();
 
   const defaultResolution = appConfig$.use.select(

--- a/frontend/src/pages/MeetingRoom/MeetingRoom.tsx
+++ b/frontend/src/pages/MeetingRoom/MeetingRoom.tsx
@@ -14,7 +14,6 @@ import EmojisOrigin from '../../components/MeetingRoom/EmojisOrigin';
 import RightPanel from '../../components/MeetingRoom/RightPanel';
 import useRoomName from '../../hooks/useRoomName';
 import isValidRoomName from '../../utils/isValidRoomName';
-import usePublisherOptions from '../../Context/PublisherProvider/usePublisherOptions';
 import CaptionsBox from '../../components/MeetingRoom/CaptionsButton/CaptionsBox';
 import useIsSmallViewport from '../../hooks/useIsSmallViewport';
 import CaptionsError from '../../components/MeetingRoom/CaptionsError';
@@ -46,8 +45,15 @@ const MeetingRoom = (): ReactElement => {
       defaultSettings: { name },
     },
   } = useUserContext();
-  const { publisher, publish, quality, initializeLocalPublisher, publishingError, isVideoEnabled } =
-    usePublisherContext();
+  const {
+    publisher,
+    publish,
+    quality,
+    initializeLocalPublisher,
+    publishingError,
+    isVideoEnabled,
+    publisherOptions,
+  } = usePublisherContext();
 
   const {
     initBackgroundLocalPublisher,
@@ -72,7 +78,6 @@ const MeetingRoom = (): ReactElement => {
   } = useSessionContext();
   const { isSharingScreen, screensharingPublisher, screenshareVideoElement, toggleShareScreen } =
     useScreenShare();
-  const publisherOptions = usePublisherOptions();
   const isSmallViewport = useIsSmallViewport();
 
   const [isUserCaptionsEnabled, setIsUserCaptionsEnabled] = useState<boolean>(false);

--- a/frontend/src/utils/SpeakingDetector/speakingDetector.spec.ts
+++ b/frontend/src/utils/SpeakingDetector/speakingDetector.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SpeakingDetector from './speakingDetector';
 import { waitForEvent } from '../async';
 import { setupWindowNavigatorMock } from '@web-test/fixtures';
+import { mediaDevices$ } from '@core/stores';
 
 const mockCreateMediaStreamSource = vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() }));
 
@@ -42,8 +43,11 @@ beforeEach(() => {
           groupId: 'group1',
         } as MediaDeviceInfo,
       ]),
+      addEventListener: vi.fn(),
     },
   });
+
+  mediaDevices$.reset();
 });
 
 describe('SpeakingDetector', () => {

--- a/integration-tests/fixtures/testWithLogging.ts
+++ b/integration-tests/fixtures/testWithLogging.ts
@@ -30,6 +30,13 @@ const addLogger = (page: Page, context: BrowserContext) => {
 
 const test = (() => {
   return baseTest.extend({
+    context: async ({ context }, use) => {
+      // Clear localStorage on every page load to ensure consistent initial state
+      await context.addInitScript(() => {
+        localStorage.clear();
+      });
+      await use(context);
+    },
     page: async ({ page, context }, use) => {
       const loggedPage = addLogger(page, context);
       await use(loggedPage);

--- a/integration-tests/tests/meetingroom.spec.ts
+++ b/integration-tests/tests/meetingroom.spec.ts
@@ -6,13 +6,15 @@ import { openMeetingRoomWithSettings, waitUntilReady } from './utils';
 test.describe('meeting room', () => {
   test('should allow a user to mute another participant', async ({
     page: pageOne,
-    context,
+    browser,
     browserName,
     isMobile,
   }) => {
     const roomName = randomBytes(5).toString('hex');
 
-    const pageTwo = await context.newPage();
+    // Use a separate context for User Two to avoid localStorage pollution
+    const contextTwo = await browser.newContext();
+    const pageTwo = await contextTwo.newPage();
 
     await openMeetingRoomWithSettings({
       page: pageOne,
@@ -33,6 +35,10 @@ test.describe('meeting room', () => {
     });
     await expect(pageTwo.getByTestId('MicNoneIcon')).toBeVisible();
 
+    // Wait for User Two's subscriber tile to appear on pageOne before opening participant list
+    await pageOne.waitForSelector('.subscriber', { state: 'visible' });
+    await expect(pageOne.locator('.subscriber').getByText('User Two')).toBeVisible();
+
     if (isMobile) {
       await pageOne.getByTestId('MoreVertIcon').click();
       await pageOne.mouse.move(0, 0); // Moves cursor to top-left corner to hide tooltip
@@ -49,5 +55,8 @@ test.describe('meeting room', () => {
     await pageOne.getByTestId('popup-dialog-primary-button').click();
 
     await expect(pageTwo.getByTestId('MicOffToolbar')).toBeVisible();
+
+    // Clean up the second context
+    await contextTwo.close();
   });
 });

--- a/integration-tests/tests/multiparty.spec.ts
+++ b/integration-tests/tests/multiparty.spec.ts
@@ -147,6 +147,9 @@ test.describe('display name for screenshare', () => {
       await pageOne.getByTestId('screen-publisher-container').getByText(`User One's screen`)
     ).toBeVisible();
 
+    // Wait for the screen-subscriber to appear
+    await pageTwo.waitForSelector('.screen-subscriber', { state: 'visible' });
+
     await expect(
       await pageTwo.locator('.screen-subscriber').getByText(`User One's screen`)
     ).toBeVisible();

--- a/integration-tests/tests/pinning.spec.ts
+++ b/integration-tests/tests/pinning.spec.ts
@@ -96,10 +96,12 @@ test.describe('participant pinning', () => {
 
     await pageThree.getByTestId('right-panel-title').getByTestId('CloseIcon').click();
 
+    // Wait for layout to re-render
+    await pageThree.waitForTimeout(1000);
+
     const newUserTwoSubscriberRet = await userTwoSubscriber.boundingBox();
     const newPublisherRect = await publisher.boundingBox();
 
-    await pageThree.waitForTimeout(1000);
     expect(newUserTwoSubscriberRet.width).toBeLessThan(1.2 * newPublisherRect.width);
     expect(newUserTwoSubscriberRet.height).toBeLessThan(2 * newPublisherRect.height);
   });

--- a/libs/common/srcBrowser/platform/isFirefox.ts
+++ b/libs/common/srcBrowser/platform/isFirefox.ts
@@ -1,0 +1,12 @@
+const isFirefox = () => {
+  const { navigator } = globalThis as {
+    navigator: Navigator & { userAgentData?: { brands: { brand: string }[] } };
+  };
+
+  if (navigator?.userAgentData?.brands) {
+    return navigator?.userAgentData.brands.some((b) => b.brand.toLowerCase().includes('firefox'));
+  }
+  return navigator?.userAgent?.toLowerCase().includes('firefox');
+};
+
+export default isFirefox;

--- a/libs/common/srcBrowser/schemas/MediaDeviceInfo/MediaDeviceInfo.schema.ts
+++ b/libs/common/srcBrowser/schemas/MediaDeviceInfo/MediaDeviceInfo.schema.ts
@@ -7,7 +7,7 @@ export type MediaDeviceInfoJSON = Omit<MediaDeviceInfo, 'toJSON'>;
  * Native browser MediaDeviceInfo schema
  */
 export const MediaDeviceInfoJSONSchema: z.ZodType<MediaDeviceInfoJSON> = z.looseObject({
-  deviceId: z.string(),
+  deviceId: z.string().min(1, 'deviceId cannot be empty'),
   kind: DeviceKindSchema,
   label: z.string(),
   groupId: z.string(),

--- a/libs/core/src/stores/devices/actions/getUserMedia/getUserMedia.ts
+++ b/libs/core/src/stores/devices/actions/getUserMedia/getUserMedia.ts
@@ -1,8 +1,12 @@
 import type { DevicesAPI } from '../../types';
 
+/**
+ * Wrapper around navigator.mediaDevices.getUserMedia that also syncs the media devices info in the store after successfully getting user media.
+ * This ensures that the store is always up to date with the latest media permissions and devices info, even if getUserMedia is called outside of the store's actions.
+ */
 function getUserMedia(this: DevicesAPI['actions'], constraints: MediaStreamConstraints) {
-  return (_: DevicesAPI): Promise<MediaStream> => {
-    return navigator.mediaDevices.getUserMedia(constraints).then((stream) => {
+  return ({ getMetadata }: DevicesAPI): Promise<MediaStream> => {
+    return getMetadata().__getUserMedia!(constraints).then((stream) => {
       // After successfully getting user media, sync the media devices info
       void this.syncMediaDevicesInfo();
       return stream;

--- a/libs/core/src/stores/devices/actions/selectDevice/selectDevice.ts
+++ b/libs/core/src/stores/devices/actions/selectDevice/selectDevice.ts
@@ -1,5 +1,5 @@
 import type { DevicesAPI } from '../../types';
-import { getMediaDevicesInfo } from '../../helpers';
+import { getMediaDevicesInfo$ } from '../../helpers';
 import { assertDeviceKind, assertMediaDeviceInfo } from '@web/schemas';
 import assertMediaStreamAccess from '../../helpers/assertMediaStreamAccess';
 import isSinkIdSupported from '@web/platform/isSinkIdSupported/isSinkIdSupported';
@@ -27,6 +27,7 @@ function selectDevice(
     }
 
     const meta = store.getMetadata();
+    const { getMediaDevicesInfo } = getMediaDevicesInfo$(store);
 
     /**
      * This is to prevent the super rare edge case where there could be an ongoing sync at the same time the user selects a device.

--- a/libs/core/src/stores/devices/actions/syncMediaDevicesInfo.ts
+++ b/libs/core/src/stores/devices/actions/syncMediaDevicesInfo.ts
@@ -1,5 +1,5 @@
 import { CancelablePromise } from 'easy-cancelable-promise';
-import { getMediaDevicesInfo, reviseMediaSelection } from '../helpers';
+import { getMediaDevicesInfo$, reviseMediaSelection } from '../helpers';
 import type { DevicesAPI } from '../types';
 import type { MediaDeviceInfoJSON } from '@web/types';
 import { setAudioOutputDevice as setVonageAudioOutputDevice } from '@vonage/client-sdk-video';
@@ -13,6 +13,7 @@ import { isSinkIdSupported } from '@web/platform';
 function syncMediaDevicesInfo(this: DevicesAPI['actions']) {
   return async (store: DevicesAPI): Promise<MediaDeviceInfoJSON[]> => {
     const meta = store.getMetadata();
+    const { getMediaDevicesInfo } = getMediaDevicesInfo$(store);
 
     // cancel ongoing update
     void meta.loadingMediaDevices?.cancel();

--- a/libs/core/src/stores/devices/constants/metadata.ts
+++ b/libs/core/src/stores/devices/constants/metadata.ts
@@ -18,9 +18,10 @@ const metadata = () => {
 
     loadingMediaDevices: null as null | CancelablePromise<MediaDeviceInfoJSON[]>,
 
-    // temporary backup for the local storage restored value
-    // localstorage value needs to be confirmed against actual available devices
-    restoredSelection: new Map<MediaDeviceKind, MediaDeviceInfoJSON>(),
+    /**
+     * bounded vanilla getUserMedia function
+     */
+    __getUserMedia: undefined as typeof globalThis.navigator.mediaDevices.getUserMedia | undefined,
   };
 
   markDevicesApiMetadata(meta);

--- a/libs/core/src/stores/devices/constants/metadata.ts
+++ b/libs/core/src/stores/devices/constants/metadata.ts
@@ -16,7 +16,15 @@ const metadata = () => {
     hasDeviceChangeCapability:
       typeof globalThis.navigator.mediaDevices?.ondevicechange !== 'undefined',
 
+    /**
+     * This promise is used to track the ongoing loading of media devices, to prevent multiple simultaneous calls to getMediaDevicesInfo, which could cause race conditions
+     */
     loadingMediaDevices: null as null | CancelablePromise<MediaDeviceInfoJSON[]>,
+
+    /**
+     * allows us to delay syncs and queries until permissions are reviewed.
+     */
+    permissionsRequests: null as unknown as Promise<void>,
 
     /**
      * bounded vanilla getUserMedia function

--- a/libs/core/src/stores/devices/constants/metadata.ts
+++ b/libs/core/src/stores/devices/constants/metadata.ts
@@ -1,4 +1,4 @@
-import type CancelablePromise from 'easy-cancelable-promise';
+import CancelablePromise from 'easy-cancelable-promise';
 import type { MediaDeviceInfoJSON } from '@web/types';
 import { markDevicesApiMetadata } from '../assertions';
 import { isSinkIdSupported } from '@web/platform';
@@ -24,10 +24,10 @@ const metadata = () => {
     /**
      * allows us to delay syncs and queries until permissions are reviewed.
      */
-    permissionsRequests: null as unknown as Promise<void>,
+    permissionsRequests: CancelablePromise.resolve(),
 
     /**
-     * bounded vanilla getUserMedia function
+     * bound vanilla getUserMedia function
      */
     __getUserMedia: undefined as typeof globalThis.navigator.mediaDevices.getUserMedia | undefined,
   };

--- a/libs/core/src/stores/devices/helpers/getMediaDevicesInfo.ts
+++ b/libs/core/src/stores/devices/helpers/getMediaDevicesInfo.ts
@@ -15,12 +15,15 @@ const getMediaDevicesInfo = async (): Promise<MediaDeviceInfoJSON[]> => {
       // native MediaDeviceInfo objects have methods and properties that may not be serializable, or work well when destructured,
       // so we create plain objects with the same properties.
       navigator.mediaDevices.enumerateDevices().then((devices) =>
-        devices.map((device) => ({
-          deviceId: device.deviceId,
-          kind: device.kind,
-          label: device.label,
-          groupId: device.groupId,
-        }))
+        devices
+          .map((device) => ({
+            deviceId: device.deviceId,
+            kind: device.kind,
+            label: device.label,
+            groupId: device.groupId,
+          }))
+          // Filter out devices with empty deviceId (e.g., Firefox before permission is granted)
+          .filter((device) => device.deviceId)
       ),
     {
       delayMs: 100,

--- a/libs/core/src/stores/devices/helpers/getMediaDevicesInfo.ts
+++ b/libs/core/src/stores/devices/helpers/getMediaDevicesInfo.ts
@@ -1,34 +1,45 @@
 import { idempotentCallbackWithRetry } from '@common/execution';
 import type { MediaDeviceInfoJSON } from '@web/types';
-
+import { DevicesAPI } from '../types';
+import { actions } from 'react-global-state-hooks';
 /**
  * Retrieves the list of media devices from the browser.
  */
-const getMediaDevicesInfo = async (): Promise<MediaDeviceInfoJSON[]> => {
-  /**
-   * Some browsers may intermittently fail to return the device list.
-   * This function uses a retry mechanism to improve reliability.
-   */
-  return idempotentCallbackWithRetry(
-    () =>
-      // Convert MediaDeviceInfo objects to plain JSON-serializable objects
-      // native MediaDeviceInfo objects have methods and properties that may not be serializable, or work well when destructured,
-      // so we create plain objects with the same properties.
-      navigator.mediaDevices.enumerateDevices().then((devices) =>
-        devices
-          .map((device) => ({
-            deviceId: device.deviceId,
-            kind: device.kind,
-            label: device.label,
-            groupId: device.groupId,
-          }))
-          // Filter out devices with empty deviceId (e.g., Firefox before permission is granted)
-          .filter((device) => device.deviceId)
-      ),
-    {
-      delayMs: 100,
-    }
-  );
-};
+const getMediaDevicesInfo$ = actions<DevicesAPI>()({
+  getMediaDevicesInfo() {
+    return ({ getMetadata }): Promise<MediaDeviceInfoJSON[]> => {
+      const { permissionsRequests } = getMetadata();
 
-export default getMediaDevicesInfo;
+      /**
+       * Some browsers may intermittently fail to return the device list.
+       * This function uses a retry mechanism to improve reliability.
+       */
+      return idempotentCallbackWithRetry(
+        async () => {
+          // Wait for permissions to be resolved before querying devices, as some browsers (e.g., Firefox) require permissions to be granted before providing device labels and IDs.
+          await permissionsRequests;
+
+          // Convert MediaDeviceInfo objects to plain JSON-serializable objects
+          // native MediaDeviceInfo objects have methods and properties that may not be serializable, or work well when destructured,
+          // so we create plain objects with the same properties.
+          return navigator.mediaDevices.enumerateDevices().then((devices) =>
+            devices
+              .map((device) => ({
+                deviceId: device.deviceId,
+                kind: device.kind,
+                label: device.label,
+                groupId: device.groupId,
+              }))
+              // In case there are remaining devices without deviceId
+              .filter((device) => device.deviceId)
+          );
+        },
+        {
+          delayMs: 100,
+        }
+      );
+    };
+  },
+});
+
+export default getMediaDevicesInfo$;

--- a/libs/core/src/stores/devices/helpers/index.ts
+++ b/libs/core/src/stores/devices/helpers/index.ts
@@ -1,4 +1,4 @@
-export { default as getMediaDevicesInfo } from './getMediaDevicesInfo';
+export { default as getMediaDevicesInfo$ } from './getMediaDevicesInfo';
 export { default as organizeMediaDevicesByKind } from './organizeMediaDevicesByKind';
 export { default as setupDeviceStore } from './setupDeviceStore';
 export { default as reviseMediaSelection } from './reviseMediaSelection';

--- a/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.test.ts
+++ b/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.test.ts
@@ -5,9 +5,14 @@ import mediaDevices$ from '../../devices$';
 import { setupPartialMock } from '@common-test/helpers';
 import { SPY_MARK } from '@common/types';
 import { setupWindowNavigatorMock } from '@web-test/fixtures';
+import * as vonageClientSdk from '@vonage/client-sdk-video';
+import * as isFirefoxModule from '@web/platform/isFirefox';
 
 describe('setupDeviceStore', () => {
   beforeEach(() => {
+    vi.spyOn(vonageClientSdk, 'setAudioOutputDevice').mockResolvedValue(undefined);
+    vi.spyOn(isFirefoxModule, 'default').mockReturnValue(false);
+
     setupWindowNavigatorMock({
       mediaDevices: {
         addEventListener: vi.fn(),
@@ -85,6 +90,301 @@ describe('setupDeviceStore', () => {
       writable: true,
     });
   });
+
+  it('should call setVonageAudioOutputDevice on initialization', () => {
+    const api$ = makeApiClone();
+
+    setupDeviceStore(api$);
+
+    expect(vonageClientSdk.setAudioOutputDevice).toHaveBeenCalled();
+  });
+
+  describe('visibility change handling', () => {
+    it('should sync devices when tab becomes visible', async () => {
+      const documentAddEventListenerSpy = vi.spyOn(document, 'addEventListener');
+      const api$ = makeApiClone();
+
+      setupDeviceStore(api$);
+
+      // Find the visibility change handler
+      const visibilityChangeCall = documentAddEventListenerSpy.mock.calls.find(
+        (call) => call[0] === 'visibilitychange'
+      );
+      const visibilityChangeHandler = visibilityChangeCall?.[1] as () => void;
+
+      // Clear previous calls
+      vi.mocked(mediaDevices$.actions.syncMediaDevicesInfo).mockClear();
+
+      // Simulate tab becoming visible
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        writable: true,
+        configurable: true,
+      });
+
+      visibilityChangeHandler();
+
+      await waitFor(
+        () => {
+          expect(mediaDevices$.actions.syncMediaDevicesInfo).toHaveBeenCalled();
+        },
+        { timeout: 100 }
+      );
+    });
+
+    it('should NOT sync devices when tab becomes hidden', async () => {
+      const documentAddEventListenerSpy = vi.spyOn(document, 'addEventListener');
+      const api$ = makeApiClone();
+
+      setupDeviceStore(api$);
+
+      // Wait for initial sync
+      await waitFor(
+        () => {
+          expect(mediaDevices$.actions.syncMediaDevicesInfo).toHaveBeenCalled();
+        },
+        { timeout: 100 }
+      );
+
+      const initialCallCount = vi.mocked(mediaDevices$.actions.syncMediaDevicesInfo).mock.calls
+        .length;
+
+      // Find the visibility change handler
+      const visibilityChangeCall = documentAddEventListenerSpy.mock.calls.find(
+        (call) => call[0] === 'visibilitychange'
+      );
+      const visibilityChangeHandler = visibilityChangeCall?.[1] as () => void;
+
+      // Simulate tab becoming hidden
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        writable: true,
+        configurable: true,
+      });
+
+      visibilityChangeHandler();
+
+      // Wait a bit and verify no additional calls were made
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(mediaDevices$.actions.syncMediaDevicesInfo).toHaveBeenCalledTimes(initialCallCount);
+    });
+  });
+
+  describe('permission change handling', () => {
+    it('should sync devices when camera permission changes', async () => {
+      const permissionStatusMock = {
+        addEventListener: vi.fn(),
+        state: 'granted',
+      };
+
+      setupWindowNavigatorMock({
+        mediaDevices: {
+          addEventListener: vi.fn(),
+        },
+        permissions: {
+          query: vi.fn().mockResolvedValue(permissionStatusMock),
+        },
+      });
+
+      const api$ = makeApiClone();
+
+      setupDeviceStore(api$);
+
+      // Wait for permission query to be called
+      await waitFor(
+        () => {
+          expect(navigator.permissions.query).toHaveBeenCalledWith({ name: 'camera' });
+        },
+        { timeout: 100 }
+      );
+
+      // Simulate permission change
+      const changeCall = permissionStatusMock.addEventListener.mock.calls.find(
+        (call) => call[0] === 'change'
+      );
+      const changeHandler = changeCall?.[1] as () => void;
+
+      vi.mocked(mediaDevices$.actions.syncMediaDevicesInfo).mockClear();
+
+      changeHandler?.();
+
+      await waitFor(
+        () => {
+          expect(mediaDevices$.actions.syncMediaDevicesInfo).toHaveBeenCalled();
+        },
+        { timeout: 100 }
+      );
+    });
+
+    it('should sync devices when microphone permission changes', async () => {
+      const permissionStatusMock = {
+        addEventListener: vi.fn(),
+        state: 'granted',
+      };
+
+      setupWindowNavigatorMock({
+        mediaDevices: {
+          addEventListener: vi.fn(),
+        },
+        permissions: {
+          query: vi.fn().mockResolvedValue(permissionStatusMock),
+        },
+      });
+
+      const api$ = makeApiClone();
+
+      setupDeviceStore(api$);
+
+      // Wait for permission query to be called
+      await waitFor(
+        () => {
+          expect(navigator.permissions.query).toHaveBeenCalledWith({ name: 'microphone' });
+        },
+        { timeout: 100 }
+      );
+    });
+  });
+
+  describe('Firefox permission handling', () => {
+    it('should request permissions when on Firefox and device labels are empty', async () => {
+      vi.spyOn(isFirefoxModule, 'default').mockReturnValue(true);
+
+      const mockStream = {
+        getTracks: vi.fn().mockReturnValue([{ stop: vi.fn() }, { stop: vi.fn() }]),
+      };
+
+      setupWindowNavigatorMock({
+        mediaDevices: {
+          addEventListener: vi.fn(),
+          enumerateDevices: vi.fn().mockResolvedValue([
+            { deviceId: 'device1', kind: 'audioinput', label: '' },
+            { deviceId: 'device2', kind: 'videoinput', label: '' },
+          ]),
+          getUserMedia: vi.fn().mockResolvedValue(mockStream),
+        },
+      });
+
+      const api$ = makeApiClone();
+
+      setupDeviceStore(api$);
+
+      await waitFor(
+        () => {
+          expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+            audio: true,
+            video: true,
+          });
+        },
+        { timeout: 200 }
+      );
+
+      // Verify tracks were stopped after getting permissions
+      expect(mockStream.getTracks).toHaveBeenCalled();
+    });
+
+    it('should NOT request permissions when on Firefox and device labels are present', async () => {
+      vi.spyOn(isFirefoxModule, 'default').mockReturnValue(true);
+
+      setupWindowNavigatorMock({
+        mediaDevices: {
+          addEventListener: vi.fn(),
+          enumerateDevices: vi.fn().mockResolvedValue([
+            { deviceId: 'device1', kind: 'audioinput', label: 'Microphone' },
+            { deviceId: 'device2', kind: 'videoinput', label: 'Camera' },
+          ]),
+          getUserMedia: vi.fn(),
+        },
+      });
+
+      const api$ = makeApiClone();
+
+      setupDeviceStore(api$);
+
+      // Wait a bit to ensure async operations complete
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    });
+
+    it('should skip permission request when not on Firefox', async () => {
+      vi.spyOn(isFirefoxModule, 'default').mockReturnValue(false);
+
+      setupWindowNavigatorMock({
+        mediaDevices: {
+          addEventListener: vi.fn(),
+          enumerateDevices: vi
+            .fn()
+            .mockResolvedValue([{ deviceId: 'device1', kind: 'audioinput', label: '' }]),
+          getUserMedia: vi.fn(),
+        },
+      });
+
+      const api$ = makeApiClone();
+
+      setupDeviceStore(api$);
+
+      // Wait for initial sync
+      await waitFor(
+        () => {
+          expect(mediaDevices$.actions.syncMediaDevicesInfo).toHaveBeenCalled();
+        },
+        { timeout: 100 }
+      );
+
+      // Should not call getUserMedia for permission request
+      expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    });
+  });
+
+  // Note: getUserMedia monkey patching tests are skipped because `isBrowserEnvironment`
+  // is evaluated at module load time before test mocks are set up. This means the
+  // monkey patching code path (`shouldMonkeyPatchGetUserMedia`) is never reached
+  // in the test environment. The monkey patching behavior is verified via
+  // integration tests in a real browser environment.
+
+  describe('metadata setup', () => {
+    it('should set __getUserMedia on metadata', () => {
+      const originalGetUserMedia = vi.fn();
+
+      setupWindowNavigatorMock({
+        mediaDevices: {
+          addEventListener: vi.fn(),
+          getUserMedia: originalGetUserMedia,
+        },
+      });
+
+      const api$ = makeApiClone();
+
+      setupDeviceStore(api$);
+
+      const metadata = api$.getMetadata();
+      expect(metadata.__getUserMedia).toBeDefined();
+    });
+  });
+
+  describe('cleanup behavior', () => {
+    it('should cancel pending permissions request on cleanup', () => {
+      vi.spyOn(isFirefoxModule, 'default').mockReturnValue(true);
+
+      const neverResolve = new Promise<MediaDeviceInfo[]>(() => {});
+      setupWindowNavigatorMock({
+        mediaDevices: {
+          addEventListener: vi.fn(),
+          enumerateDevices: vi.fn().mockReturnValue(neverResolve),
+        },
+      });
+
+      const api$ = makeApiClone();
+
+      const cleanup = setupDeviceStore(api$);
+
+      // Cleanup immediately - should cancel pending permission request
+      cleanup?.();
+
+      // Verify no errors are thrown and cleanup completed
+      expect(cleanup).toBeDefined();
+    });
+  });
 });
 
 function makeApiClone() {
@@ -94,6 +394,7 @@ function makeApiClone() {
   setupPartialMock('mediaDevices$.actions', mediaDevices$.actions, {
     syncMediaDevicesInfo: SPY_MARK,
     selectDevice: SPY_MARK,
+    getUserMedia: SPY_MARK,
   });
 
   setupPartialMock('mediaDevices$', clone, {

--- a/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
+++ b/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
@@ -3,9 +3,10 @@ import debounce from '@common/execution/debounce';
 import { assertDevicesAPI } from '../../assertions';
 import { attempt } from '@common/execution';
 import isFirefox from '@web/platform/isFirefox';
+import CancelablePromise from 'easy-cancelable-promise';
 
 /**
- * Avoid money patching getUserMedia in non browser environment, like test or server side rendering
+ * Avoid monkey patching getUserMedia in non browser environment, like test or server side rendering
  */
 const isBrowserEnvironment = Boolean(globalThis.navigator.mediaDevices?.addEventListener);
 
@@ -36,11 +37,13 @@ function setupDeviceStore(api: unknown) {
     void api.actions.syncMediaDevicesInfo().catch(() => {});
   }, 10);
 
-  meta.permissionsRequests = isFirefox()
-    ? navigator.mediaDevices.enumerateDevices().then((devices) => {
-        if (abortController.signal.aborted) {
-          throw new Error('aborting enumerateDevices query');
-        }
+  meta.permissionsRequests = new CancelablePromise((resolve, reject, { isCanceled }) => {
+    if (!isFirefox()) return resolve();
+
+    void navigator.mediaDevices
+      .enumerateDevices()
+      .then((devices) => {
+        if (isCanceled()) return;
 
         const hasLabels = devices.some((device) => device.label);
         if (hasLabels) return;
@@ -50,7 +53,15 @@ function setupDeviceStore(api: unknown) {
           stream.getTracks().forEach((track) => track.stop());
         });
       })
-    : Promise.resolve();
+      .then(resolve)
+      .catch(reject);
+  });
+
+  abortController.signal.addEventListener('abort', () => {
+    void meta.permissionsRequests.cancel(
+      new Error('permissions request cancelled due to store cleanup')
+    );
+  });
 
   void meta.permissionsRequests.then(() => {
     syncMediaDevicesInfoDebounced();
@@ -99,7 +110,7 @@ function setupDeviceStore(api: unknown) {
   /**
    * Restore the original getUserMedia function.
    */
-  const __restoreMonkeyPath = () => {
+  const __restoreMonkeyPatch = () => {
     if (!isBrowserEnvironment) return;
     globalThis.navigator.mediaDevices.getUserMedia = __getUserMedia;
   };
@@ -109,13 +120,13 @@ function setupDeviceStore(api: unknown) {
    */
   if (shouldMonkeyPatchGetUserMedia) {
     globalThis.navigator.mediaDevices.getUserMedia = Object.assign(api.actions.getUserMedia, {
-      __restoreMonkeyPath,
+      __restoreMonkeyPatch,
     });
   }
 
   return () => {
     abortController.abort();
-    __restoreMonkeyPath();
+    __restoreMonkeyPatch();
   };
 }
 

--- a/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
+++ b/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
@@ -2,6 +2,7 @@ import { setAudioOutputDevice as setVonageAudioOutputDevice } from '@vonage/clie
 import debounce from '@common/execution/debounce';
 import { assertDevicesAPI } from '../../assertions';
 import { attempt } from '@common/execution';
+import isFirefox from '@web/platform/isFirefox';
 
 /**
  * Avoid money patching getUserMedia in non browser environment, like test or server side rendering
@@ -19,15 +20,41 @@ function setupDeviceStore(api: unknown) {
     return;
   }
 
+  const meta = api.getMetadata();
+  const __getUserMedia = globalThis.navigator.mediaDevices.getUserMedia;
+  const shouldMonkeyPatchGetUserMedia = isBrowserEnvironment && __getUserMedia;
+
   const abortController = new AbortController();
 
   void attempt(() => {
     void setVonageAudioOutputDevice(api.getState().audiooutput!);
   });
 
-  const syncMediaDevicesInfoDebounced = debounce(() => {
+  const syncMediaDevicesInfoDebounced = debounce(async () => {
+    await meta.permissionsRequests;
+
     void api.actions.syncMediaDevicesInfo().catch(() => {});
   }, 10);
+
+  meta.permissionsRequests = isFirefox()
+    ? navigator.mediaDevices.enumerateDevices().then((devices) => {
+        if (abortController.signal.aborted) {
+          throw new Error('aborting enumerateDevices query');
+        }
+
+        const hasLabels = devices.some((device) => device.label);
+        if (hasLabels) return;
+
+        //we should request permissions to be able to see the devices labels.
+        return navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then((stream) => {
+          stream.getTracks().forEach((track) => track.stop());
+        });
+      })
+    : Promise.resolve();
+
+  void meta.permissionsRequests.then(() => {
+    syncMediaDevicesInfoDebounced();
+  });
 
   // listen for permission changes to resync devices when granted
   void Promise.allSettled(
@@ -40,11 +67,11 @@ function setupDeviceStore(api: unknown) {
           },
           abortController
         );
+
+        return status;
       });
     })
-  ).finally(() => {
-    syncMediaDevicesInfoDebounced();
-  });
+  );
 
   // keep all devices synced on devicechange event
   globalThis.navigator.mediaDevices.addEventListener(
@@ -60,15 +87,11 @@ function setupDeviceStore(api: unknown) {
     'visibilitychange',
     () => {
       if (document.visibilityState === 'visible') {
-        void api.actions.syncMediaDevicesInfo();
+        syncMediaDevicesInfoDebounced();
       }
     },
     abortController
   );
-
-  const meta = api.getMetadata();
-  const __getUserMedia = globalThis.navigator.mediaDevices.getUserMedia;
-  const shouldMonkeyPatchGetUserMedia = isBrowserEnvironment && __getUserMedia;
 
   // make accessible to the actions the vanilla getUserMedia function
   meta.__getUserMedia = __getUserMedia.bind(navigator.mediaDevices);

--- a/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
+++ b/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
@@ -4,6 +4,11 @@ import { assertDevicesAPI } from '../../assertions';
 import { attempt } from '@common/execution';
 
 /**
+ * Avoid money patching getUserMedia in non browser environment, like test or server side rendering
+ */
+const isBrowserEnvironment = Boolean(globalThis.navigator.mediaDevices?.addEventListener);
+
+/**
  * Pull devices lists and try to restore previous selected devices
  */
 function setupDeviceStore(api: unknown) {
@@ -61,8 +66,33 @@ function setupDeviceStore(api: unknown) {
     abortController
   );
 
+  const meta = api.getMetadata();
+  const __getUserMedia = globalThis.navigator.mediaDevices.getUserMedia;
+  const shouldMonkeyPatchGetUserMedia = isBrowserEnvironment && __getUserMedia;
+
+  // make accessible to the actions the vanilla getUserMedia function
+  meta.__getUserMedia = __getUserMedia.bind(navigator.mediaDevices);
+
+  /**
+   * Restore the original getUserMedia function.
+   */
+  const __restoreMonkeyPath = () => {
+    if (!isBrowserEnvironment) return;
+    globalThis.navigator.mediaDevices.getUserMedia = __getUserMedia;
+  };
+
+  /**
+   * Monkey patch navigator.mediaDevices.getUserMedia to keep the store in sync when it's called outside of the store's getUserMedia action.
+   */
+  if (shouldMonkeyPatchGetUserMedia) {
+    globalThis.navigator.mediaDevices.getUserMedia = Object.assign(api.actions.getUserMedia, {
+      __restoreMonkeyPath,
+    });
+  }
+
   return () => {
     abortController.abort();
+    __restoreMonkeyPath();
   };
 }
 

--- a/libs/core/tsconfig.json
+++ b/libs/core/tsconfig.json
@@ -20,8 +20,6 @@
       "@common/*": ["../common/src/*"],
       "@core": ["./src"],
       "@core/*": ["./src/*"],
-      "@common": ["../common/src"],
-      "@common/*": ["../common/src/*"],
       "@web": ["../common/srcBrowser"],
       "@web/*": ["../common/srcBrowser/*"],
       "@common-test": ["../common/test"],


### PR DESCRIPTION
#### What is this PR doing?
This PR addresses Firefox-specific issues with video preview by filtering out devices with empty deviceIds before permission is granted, and implements proper persistence of audio/video enabled states across publisher initialization. The changes also introduce monkey patching of navigator.mediaDevices.getUserMedia to keep the device store synchronized when getUserMedia is called outside the store's actions.

Changes:

Added filtering of devices with empty deviceIds to handle Firefox's behavior before permissions are granted
Implemented monkey patching of navigator.mediaDevices.getUserMedia to automatically sync device store state
Changed publisher initialization to read audio/video enabled states from localStorage instead of always resetting to enabled
Updated schema validation to reject MediaDeviceInfo objects with empty deviceIds


#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-488](https://jira.vonage.com/browse/VIDSOL-488)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
