### PR TITLE
VIDSOL-552: fix sonarCloud git hub action error

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -165,7 +165,7 @@ jobs:
           ls -la coverage-* || true
 
       - name: SonarCloud Scan On PR
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -176,7 +176,7 @@ jobs:
             -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}
 
       - name: SonarCloud Branch Analysis On base branch
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -165,25 +165,21 @@ jobs:
           ls -la coverage-* || true
 
       - name: SonarCloud Scan On PR
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_BRANCH: ${{ github.head_ref }}
-          BASE_BRANCH: ${{ github.event.pull_request.head.ref }}
         with:
           args: >
-            -Dsonar.pullrequest.key="$PR_NUMBER"
-            -Dsonar.pullrequest.branch="$PR_BRANCH"
-            -Dsonar.pullrequest.base="$BASE_BRANCH"
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.head_ref }}
+            -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}
 
       - name: SonarCloud Branch Analysis On base branch
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          BASE_BRANCH: ${{ github.event.pull_request.head.ref }}
         with:
           args: >
-            -Dsonar.branch.name="$BASE_BRANCH"
+            -Dsonar.branch.name=${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
#### What is this PR doing?

- Fix `BASE_BRANCH`: use `github.event.pull_request.base.ref` (target) instead of head.ref (source)
- Upgrade `sonarqube-scan-action` from `v4` to `v6` (deprecation and security fix)
- Use GitHub Actions expressions in args instead of bash variable expansion for `v6`
- Using external GitHub actions and workflows without a commit reference is [security-sensitive](https://sonarcloud.io/organizations/vonage/rules?open=githubactions%3AS7637&rule_key=githubactions%3AS7637)

References: 
  [SonarSource v6 update]( https://community.sonarsource.com/t/sonarqube-scanner-github-action-v6/149281 )
#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-552](https://jira.vonage.com/browse/VIDSOL-552)

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
