### PR TITLE
VIDSOL-582: Preview-camera-on-when-user-setting-say-off

### DIFF
--- a/frontend/src/Context/PublisherProvider/usePublisher/hooks/useSyncPublisherDevices/useSyncPublisherDevices.ts
+++ b/frontend/src/Context/PublisherProvider/usePublisher/hooks/useSyncPublisherDevices/useSyncPublisherDevices.ts
@@ -7,6 +7,8 @@ import type { UnsubscribeCallback } from 'react-global-state-hooks';
 /**
  * Syncs publisher video/audio sources with the selected devices from the store.
  * Handles device changes (user selection) and disconnections (hardware unplugged).
+ *
+ * This is temporal until we refactor the publishers and we implement a more robust solution syncing with the publisher.
  */
 const useSyncPublisherDevices = (
   publisherRef: React.RefObject<Publisher | null>,
@@ -25,9 +27,9 @@ const useSyncPublisherDevices = (
               const didChanged = publisherRef.current?.getVideoSource()?.deviceId !== input;
               if (didChanged) attempt(() => publisherRef.current?.setVideoSource(input!));
 
-              const { permissionsRequests } = mediaDevices$.getMetadata();
-              if (permissionsRequests.status === 'pending') {
-                await permissionsRequests;
+              const { isStoreReady } = mediaDevices$.getMetadata();
+              if (isStoreReady.status === 'pending') {
+                await isStoreReady;
               }
 
               if (hasDevices('videoinput')) return;
@@ -46,9 +48,9 @@ const useSyncPublisherDevices = (
               const didChanged = publisherRef.current?.getAudioSource()?.id !== input;
               if (didChanged) attempt(() => publisherRef.current?.setAudioSource(input!));
 
-              const { permissionsRequests } = mediaDevices$.getMetadata();
-              if (permissionsRequests.status === 'pending') {
-                await permissionsRequests;
+              const { isStoreReady } = mediaDevices$.getMetadata();
+              if (isStoreReady.status === 'pending') {
+                await isStoreReady;
               }
 
               if (hasDevices('audioinput')) return;

--- a/frontend/src/components/WaitingRoom/UserNameInput/UserNameInput.skeleton.tsx
+++ b/frontend/src/components/WaitingRoom/UserNameInput/UserNameInput.skeleton.tsx
@@ -10,7 +10,7 @@ const UsernameInputSkeleton: FC<UsernameInputSkeletonProps> = ({ className, ...p
   return (
     <Card
       component="form"
-      className={twMerge('flex-col sm:inline-flex h-auto sm:h-[400px]', className)}
+      className={twMerge('flex-col sm:inline-flex h-auto sm:h-[400px] lg:max-w-[500px]', className)}
       {...props}
     >
       <div className="w-full flex flex-col gap-4">

--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.skeleton.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.skeleton.tsx
@@ -17,7 +17,7 @@ const VideoContainerSkeleton: FC<VideoContainerSkeletonProps> = ({ className, ..
           'bg-vera-surface',
           'rounded-vera-none sm:rounded-vera-large',
           '[-webkit-mask:linear-gradient(var(--vera-surface)_0_0)]',
-          'box-border w-[100dvw] sm:w-[584px] md:w-full',
+          'box-border w-[100dvw] sm:w-[584px]',
 
           // visibility & positioning
           'opacity-80',

--- a/frontend/src/pages/MeetingRoom/MeetingRoom.skeleton.tsx
+++ b/frontend/src/pages/MeetingRoom/MeetingRoom.skeleton.tsx
@@ -3,75 +3,50 @@ import useIsSmallViewport from '@hooks/useIsSmallViewport';
 import SmallViewportHeader from '@components/MeetingRoom/SmallViewportHeader';
 import Box from '@mui/material/Box';
 import type { BoxProps } from '@mui/material/Box';
-import useTheme from '@ui/theme';
 import CircularProgress from '@mui/material/CircularProgress';
+import classNames from 'classnames';
+import { twMerge } from 'tailwind-merge';
 
 type MeetingRoomSkeletonProps = BoxProps;
 
-const MeetingRoomSkeleton: React.FC<MeetingRoomSkeletonProps> = ({ sx, ...props }) => {
-  const theme = useTheme();
+const MeetingRoomSkeleton: React.FC<MeetingRoomSkeletonProps> = ({ className, ...props }) => {
   const isSmallViewport = useIsSmallViewport();
-
-  // Height is 100dvh - toolbar height (80px) and header height (80px) - 24px wrapper margin on small viewport device
-  // Height is 100dvh - toolbar height (80px) - 24px wrapper margin on desktop
-  const wrapperHeight = isSmallViewport ? 'calc(100dvh - 184px)' : 'calc(100dvh - 104px)';
-  const wrapperWidth = 'calc(100vw - 24px)';
 
   return (
     <Box
       data-testid="meetingRoom"
-      sx={{
-        height: 'calc(100dvh - 80px)',
-        width: '100vw',
-        backgroundColor: theme.colors.darkBackground,
-        ...sx,
-      }}
       {...props}
-      className="animate-fade-in"
+      className={twMerge(
+        classNames(
+          'MeetingRoomSkeleton h-full w-screen bg-vera-dark-background flex flex-col',
+          className
+        )
+      )}
     >
       {isSmallViewport && <SmallViewportHeader />}
 
       {/* VideoTileCanvas Skeleton */}
-      <Box
-        sx={{
-          padding: 3,
-          width: wrapperWidth,
-          height: wrapperHeight,
-        }}
-      >
-        <Box
-          sx={{ position: 'relative', width: '100%', height: '100%' }}
-          className="flex justify-center items-center"
-        >
-          <CircularProgress
-            data-testid="progress-spinner"
-            sx={{ position: 'absolute', top: '50%' }}
-          />
+      <Box className="px-6 flex-1">
+        <Box className="flex justify-center items-center w-full h-full relative">
+          <CircularProgress data-testid="progress-spinner" className="absolute top-1/2" />
         </Box>
       </Box>
 
       {/* Toolbar Skeleton */}
-      <Box
-        sx={{
-          height: '80px',
-          display: 'flex',
-          flexDirection: 'row',
-          gap: 3,
-          justifyContent: 'center',
-          alignItems: 'center',
-          backgroundColor: 'rgb(32, 33, 36)',
-          padding: 4,
-        }}
-      >
-        <ButtonGroupSkeleton>
-          <ToolBarButtonSkeleton isTransparent />
-          <ToolBarButtonSkeleton isTransparent />
-        </ButtonGroupSkeleton>
+      <Box className="flex flex-row gap-6 justify-center items-center h-20 p-4">
+        {!isSmallViewport && (
+          <>
+            <ButtonGroupSkeleton>
+              <ToolBarButtonSkeleton isTransparent />
+              <ToolBarButtonSkeleton isTransparent />
+            </ButtonGroupSkeleton>
 
-        <ButtonGroupSkeleton>
-          <ToolBarButtonSkeleton isTransparent />
-          <ToolBarButtonSkeleton isTransparent />
-        </ButtonGroupSkeleton>
+            <ButtonGroupSkeleton>
+              <ToolBarButtonSkeleton isTransparent />
+              <ToolBarButtonSkeleton isTransparent />
+            </ButtonGroupSkeleton>
+          </>
+        )}
 
         {new Array(3).fill(null).map((_, index) => (
           <ToolBarButtonSkeleton key={index} />
@@ -94,18 +69,13 @@ function ToolBarButtonSkeleton({ isTransparent, isExit }: ToolBarButtonSkeletonP
       component="button"
       tabIndex={-1}
       type="button"
-      sx={{
-        height: '48px',
-        width: '48px',
-        backgroundColor: isExit
-          ? 'rgb(239, 68, 68)'
-          : isTransparent
-            ? 'transparent'
-            : 'rgba(60, 64, 67, .55)',
-        borderRadius: '50%',
-        border: 'none',
-        cursor: 'pointer',
-      }}
+      className={twMerge(
+        classNames('h-12 w-12 rounded-full border-none cursor-pointer text-vera-on-secondary', {
+          'bg-vera-alert-text': isExit,
+          'bg-transparent': isTransparent && !isExit,
+          'bg-vera-dark-grey-opacity': !isExit && !isTransparent,
+        })
+      )}
     />
   );
 }
@@ -116,17 +86,7 @@ type ButtonGroupSkeletonProps = {
 
 function ButtonGroupSkeleton({ children }: ButtonGroupSkeletonProps) {
   return (
-    <Box
-      sx={{
-        backgroundColor: 'rgba(60, 64, 67, .55)',
-        borderRadius: '50px',
-        display: 'flex',
-        flexDirection: 'row',
-        gap: 1,
-      }}
-    >
-      {children}
-    </Box>
+    <Box className="flex flex-row gap-2 rounded-full bg-vera-dark-grey-opacity">{children}</Box>
   );
 }
 

--- a/libs/common/srcBrowser/hooks/useSuspenseMemo/useSuspenseMemo.ts
+++ b/libs/common/srcBrowser/hooks/useSuspenseMemo/useSuspenseMemo.ts
@@ -3,7 +3,7 @@ import use$ from '../use$';
 import useStableRef from '../useStableRef';
 import useAssertSuspense from '../useAssertSuspense';
 
-type Builder<T> = () => Promise<T> | T;
+type Builder<T, P extends Promise<T>> = () => T | P;
 
 /**
  * Like useMemo, but supports async values through Suspense.
@@ -17,10 +17,13 @@ type Builder<T> = () => Promise<T> | T;
  *                      result is a Promise, rendering will suspend.
  * @returns The callback's returned value (or the resolved value if async).
  */
-function useSuspenseMemo<T>(callback: Builder<T>, dependencies: React.DependencyList): T {
+function useSuspenseMemo<T, P extends Promise<T> = Promise<T>>(
+  callback: Builder<T, P>,
+  dependencies: React.DependencyList
+): T {
   useAssertSuspense('useSuspenseMemo must be used within a SuspenseBoundary Provider');
 
-  const usable = useStableRef<Promise<T> | T>(() => callback(), dependencies).current;
+  const usable = useStableRef<P | T>(() => callback(), dependencies).current;
 
   return use$(usable as Promise<T>);
 }

--- a/libs/common/test/helpers/setupPartialMock.ts
+++ b/libs/common/test/helpers/setupPartialMock.ts
@@ -67,9 +67,6 @@ function setupPartialMock<T extends object>(
       );
     }
 
-    // is already a spy skip
-    if (vi.isMockFunction(currentValue)) return;
-
     // Spy the function without modifying its implementation
     if (value === SPY_MARK) {
       if (isFunction(currentValue)) {

--- a/libs/core/src/stores/devices/constants/metadata.ts
+++ b/libs/core/src/stores/devices/constants/metadata.ts
@@ -22,9 +22,9 @@ const metadata = () => {
     loadingMediaDevices: null as null | CancelablePromise<MediaDeviceInfoJSON[]>,
 
     /**
-     * allows us to delay syncs and queries until permissions are reviewed.
+     * A promise that resolves when the media devices store is ready and full loaded with the available media devices.
      */
-    permissionsRequests: CancelablePromise.resolve(),
+    isStoreReady: CancelablePromise.resolve(),
 
     /**
      * bound vanilla getUserMedia function

--- a/libs/core/src/stores/devices/helpers/getMediaDevicesInfo.ts
+++ b/libs/core/src/stores/devices/helpers/getMediaDevicesInfo.ts
@@ -8,7 +8,7 @@ import { actions } from 'react-global-state-hooks';
 const getMediaDevicesInfo$ = actions<DevicesAPI>()({
   getMediaDevicesInfo() {
     return ({ getMetadata }): Promise<MediaDeviceInfoJSON[]> => {
-      const { permissionsRequests } = getMetadata();
+      const { isStoreReady } = getMetadata();
 
       /**
        * Some browsers may intermittently fail to return the device list.
@@ -17,7 +17,7 @@ const getMediaDevicesInfo$ = actions<DevicesAPI>()({
       return idempotentCallbackWithRetry(
         async () => {
           // Wait for permissions to be resolved before querying devices, as some browsers (e.g., Firefox) require permissions to be granted before providing device labels and IDs.
-          await permissionsRequests;
+          await isStoreReady;
 
           // Convert MediaDeviceInfo objects to plain JSON-serializable objects
           // native MediaDeviceInfo objects have methods and properties that may not be serializable, or work well when destructured,

--- a/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.test.ts
+++ b/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.test.ts
@@ -7,6 +7,9 @@ import { SPY_MARK } from '@common/types';
 import { setupWindowNavigatorMock } from '@web-test/fixtures';
 import * as vonageClientSdk from '@vonage/client-sdk-video';
 import * as isFirefoxModule from '@web/platform/isFirefox';
+import { makeMediaDeviceInfos } from '@web-test/fixtures';
+
+const someDevices = makeMediaDeviceInfos();
 
 describe('setupDeviceStore', () => {
   beforeEach(() => {
@@ -16,6 +19,7 @@ describe('setupDeviceStore', () => {
     setupWindowNavigatorMock({
       mediaDevices: {
         addEventListener: vi.fn(),
+        enumerateDevices: Promise.resolve(someDevices),
       },
     });
   });
@@ -253,14 +257,18 @@ describe('setupDeviceStore', () => {
         getTracks: vi.fn().mockReturnValue([{ stop: vi.fn() }, { stop: vi.fn() }]),
       };
 
+      const getUserMediaSpy = vi.fn(() =>
+        Promise.resolve(mockStream)
+      ) as unknown as typeof navigator.mediaDevices.getUserMedia;
+
       setupWindowNavigatorMock({
         mediaDevices: {
           addEventListener: vi.fn(),
-          enumerateDevices: vi.fn().mockResolvedValue([
+          enumerateDevices: Promise.resolve([
             { deviceId: 'device1', kind: 'audioinput', label: '' },
             { deviceId: 'device2', kind: 'videoinput', label: '' },
-          ]),
-          getUserMedia: vi.fn().mockResolvedValue(mockStream),
+          ] as MediaDeviceInfo[]),
+          getUserMedia: getUserMediaSpy,
         },
       });
 
@@ -270,7 +278,7 @@ describe('setupDeviceStore', () => {
 
       await waitFor(
         () => {
-          expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+          expect(getUserMediaSpy).toHaveBeenCalledWith({
             audio: true,
             video: true,
           });

--- a/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
+++ b/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
@@ -27,18 +27,31 @@ function setupDeviceStore(api: unknown) {
 
   const abortController = new AbortController();
 
+  // make accessible to the actions the vanilla getUserMedia function
+  meta.__getUserMedia = __getUserMedia.bind(navigator.mediaDevices);
+
   void attempt(() => {
     void setVonageAudioOutputDevice(api.getState().audiooutput!);
   });
 
   const syncMediaDevicesInfoDebounced = debounce(async () => {
-    await meta.permissionsRequests;
+    await meta.isStoreReady;
 
     void api.actions.syncMediaDevicesInfo().catch(() => {});
   }, 10);
 
-  meta.permissionsRequests = new CancelablePromise((resolve, reject, { isCanceled }) => {
-    if (!isFirefox()) return resolve();
+  meta.isStoreReady = new CancelablePromise((resolve, reject, { isCanceled }) => {
+    const syncDevicesAndResolve = () => {
+      void api.actions
+        .syncMediaDevicesInfo()
+        .then(() => resolve())
+        .catch(reject);
+    };
+
+    if (!isFirefox()) {
+      void syncDevicesAndResolve();
+      return;
+    }
 
     void navigator.mediaDevices
       .enumerateDevices()
@@ -49,22 +62,16 @@ function setupDeviceStore(api: unknown) {
         if (hasLabels) return;
 
         //we should request permissions to be able to see the devices labels.
-        return navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then((stream) => {
+        return meta.__getUserMedia!({ audio: true, video: true }).then((stream) => {
           stream.getTracks().forEach((track) => track.stop());
         });
       })
-      .then(resolve)
+      .then(() => syncDevicesAndResolve())
       .catch(reject);
   });
 
   abortController.signal.addEventListener('abort', () => {
-    void meta.permissionsRequests.cancel(
-      new Error('permissions request cancelled due to store cleanup')
-    );
-  });
-
-  void meta.permissionsRequests.then(() => {
-    syncMediaDevicesInfoDebounced();
+    void meta.isStoreReady.cancel(new Error('permissions request cancelled due to store cleanup'));
   });
 
   // listen for permission changes to resync devices when granted
@@ -103,9 +110,6 @@ function setupDeviceStore(api: unknown) {
     },
     abortController
   );
-
-  // make accessible to the actions the vanilla getUserMedia function
-  meta.__getUserMedia = __getUserMedia.bind(navigator.mediaDevices);
 
   /**
    * Restore the original getUserMedia function.


### PR DESCRIPTION
#### What is this PR doing?
This pull request addresses VIDSOL-582, fixing an issue where the camera preview would turn on even when user settings indicated it should be off. The root cause was that during the app not waiting for the mediaDevicesStore to be ready before doing the selection reconciliation. 


#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-582](https://jira.vonage.com/browse/VIDSOL-582)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
