### PR TITLE
VIDSOL-585: Hide Video Effects option in MenuMoreOptions on unsupported browsers

### DIFF
--- a/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.spec.tsx
+++ b/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.spec.tsx
@@ -1,17 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render as renderBase, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactElement } from 'react';
+import * as clientSdkVideo from '@vonage/client-sdk-video';
 import backgroundEffectsDialog$ from '@Context/BackgroundEffectsDialog';
 import precallNetworkTestDialog$ from '@Context/PrecallNetworkTestDialog';
 import composeProviders from '@web/helpers/composeProviders';
 import MenuMoreOptions from './MenuMoreOptions';
 import { env } from '../../../env';
-
-const mockHasMediaProcessorSupport = vi.hoisted(() => vi.fn(() => true));
-vi.mock('@vonage/client-sdk-video', () => ({
-  hasMediaProcessorSupport: mockHasMediaProcessorSupport,
-}));
 
 describe('MenuMoreOptions', () => {
   const mockOnClose = vi.fn();
@@ -19,6 +15,11 @@ describe('MenuMoreOptions', () => {
 
   beforeEach(() => {
     mockOnClose.mockClear();
+    vi.spyOn(clientSdkVideo, 'hasMediaProcessorSupport').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should render when open is true', () => {
@@ -56,7 +57,7 @@ describe('MenuMoreOptions', () => {
   });
 
   it('should not display video effects option when media processor is not supported', () => {
-    mockHasMediaProcessorSupport.mockReturnValue(false);
+    vi.spyOn(clientSdkVideo, 'hasMediaProcessorSupport').mockReturnValue(false);
     render(<MenuMoreOptions onClose={mockOnClose} open anchorEl={mockAnchorEl} />);
 
     expect(screen.queryByText(/video effects/i)).not.toBeInTheDocument();
@@ -70,7 +71,7 @@ describe('MenuMoreOptions', () => {
   });
 
   it('should still display precall network test when media processor is not supported', () => {
-    mockHasMediaProcessorSupport.mockReturnValue(false);
+    vi.spyOn(clientSdkVideo, 'hasMediaProcessorSupport').mockReturnValue(false);
     render(<MenuMoreOptions onClose={mockOnClose} open anchorEl={mockAnchorEl} />);
 
     expect(screen.queryByText(/video effects/i)).not.toBeInTheDocument();

--- a/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.spec.tsx
+++ b/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.spec.tsx
@@ -6,6 +6,12 @@ import backgroundEffectsDialog$ from '@Context/BackgroundEffectsDialog';
 import precallNetworkTestDialog$ from '@Context/PrecallNetworkTestDialog';
 import composeProviders from '@web/helpers/composeProviders';
 import MenuMoreOptions from './MenuMoreOptions';
+import { env } from '../../../env';
+
+const mockHasMediaProcessorSupport = vi.hoisted(() => vi.fn(() => true));
+vi.mock('@vonage/client-sdk-video', () => ({
+  hasMediaProcessorSupport: mockHasMediaProcessorSupport,
+}));
 
 describe('MenuMoreOptions', () => {
   const mockOnClose = vi.fn();
@@ -27,7 +33,7 @@ describe('MenuMoreOptions', () => {
     expect(screen.queryByText(/video effects/i)).not.toBeInTheDocument();
   });
 
-  it('should display video effects option', () => {
+  it('should display video effects option when media processor is supported', () => {
     render(<MenuMoreOptions onClose={mockOnClose} open anchorEl={mockAnchorEl} />);
 
     expect(screen.getByText(/video effects/i)).toBeInTheDocument();
@@ -47,6 +53,28 @@ describe('MenuMoreOptions', () => {
     render(<MenuMoreOptions onClose={mockOnClose} open anchorEl={mockAnchorEl} />);
 
     expect(screen.getByTestId('vivid-icon-gallery-line')).toBeInTheDocument();
+  });
+
+  it('should not display video effects option when media processor is not supported', () => {
+    mockHasMediaProcessorSupport.mockReturnValue(false);
+    render(<MenuMoreOptions onClose={mockOnClose} open anchorEl={mockAnchorEl} />);
+
+    expect(screen.queryByText(/video effects/i)).not.toBeInTheDocument();
+  });
+
+  it('should not display video effects option when background effects are not allowed', () => {
+    env.partialUpdate({ ALLOW_BACKGROUND_EFFECTS: false });
+    render(<MenuMoreOptions onClose={mockOnClose} open anchorEl={mockAnchorEl} />);
+
+    expect(screen.queryByText(/video effects/i)).not.toBeInTheDocument();
+  });
+
+  it('should still display precall network test when media processor is not supported', () => {
+    mockHasMediaProcessorSupport.mockReturnValue(false);
+    render(<MenuMoreOptions onClose={mockOnClose} open anchorEl={mockAnchorEl} />);
+
+    expect(screen.queryByText(/video effects/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/pre-call network test/i)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.spec.tsx
+++ b/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render as renderBase, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactElement } from 'react';
@@ -16,10 +16,6 @@ describe('MenuMoreOptions', () => {
   beforeEach(() => {
     mockOnClose.mockClear();
     vi.spyOn(clientSdkVideo, 'hasMediaProcessorSupport').mockReturnValue(true);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it('should render when open is true', () => {

--- a/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.tsx
+++ b/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.tsx
@@ -1,11 +1,12 @@
 import { ReactElement, useCallback } from 'react';
+import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
 import { useTranslation } from 'react-i18next';
 import VividIcon from '@components/VividIcon';
-import Box from '@mui/material/Box';
 import backgroundEffectsDialog$ from '@Context/BackgroundEffectsDialog';
 import precallNetworkTestDialog$ from '@Context/PrecallNetworkTestDialog';
+import { env } from '../../../env';
 
 export type MenuMoreOptionsWaitingRoomProps = {
   onClose: () => void;
@@ -29,6 +30,7 @@ const MenuMoreOptions = ({
   anchorEl,
 }: MenuMoreOptionsWaitingRoomProps): ReactElement => {
   const { t } = useTranslation();
+  const shouldDisplayBackgroundEffects = hasMediaProcessorSupport() && env.ALLOW_BACKGROUND_EFFECTS;
   const { open: openBackgroundEffects } = backgroundEffectsDialog$.use.actions();
   const { open: openPrecallNetworkTest } = precallNetworkTestDialog$.use.actions();
 
@@ -51,15 +53,17 @@ const MenuMoreOptions = ({
       MenuListProps={{ 'aria-labelledby': 'basic-button' }}
       data-testid="menu-more-options"
     >
-      <MenuItem
-        onClick={() => {
-          handleClickBackgroundEffects();
-        }}
-        key="backgroundEffects-option"
-      >
-        <VividIcon name="gallery-line" customSize={-6} />
-        <Box sx={{ ml: 1 }}>{t('backgroundEffects.title')}</Box>
-      </MenuItem>
+      {shouldDisplayBackgroundEffects && (
+        <MenuItem
+          onClick={() => {
+            handleClickBackgroundEffects();
+          }}
+          key="backgroundEffects-option"
+        >
+          <VividIcon name="gallery-line" customSize={-6} />
+          <span className="ml-2">{t('backgroundEffects.title')}</span>
+        </MenuItem>
+      )}
       <MenuItem
         onClick={() => {
           handleClickNetworkTest();
@@ -67,7 +71,7 @@ const MenuMoreOptions = ({
         key="precallNetworkTest-option"
       >
         <VividIcon name="cell-reception-line" customSize={-6} />
-        <Box sx={{ ml: 1 }}>{t('waitingRoom.precallNetworkTest.title')}</Box>
+        <span className="ml-2">{t('waitingRoom.precallNetworkTest.title')}</span>
       </MenuItem>
     </Menu>
   );


### PR DESCRIPTION
Hi team! 👋

This is my first contribution to this project, and I'm really excited to be part of it. Thank you for making this amazing reference app open source — I've learned a lot just by reading through the codebase.

I noticed a small bug and wanted to help out. I hope this PR meets your standards, and I'm very happy to make any changes you suggest.

#### What is this PR doing?

The "Video Effects" menu item in the waiting room's `...` (more options) menu was being rendered unconditionally, even on browsers that do not support media processors (Safari, Firefox, iOS). Clicking it on an unsupported browser would lead to a broken experience.

This PR adds the same `hasMediaProcessorSupport() && allowBackgroundEffects` guard that is already used by `BackgroundEffectsButton` and `DeviceSettingsMenu`, so the menu item is only shown when the browser actually supports it.

**Changes:**
- `MenuMoreOptions.tsx` — Added conditional rendering for the Video Effects menu item based on browser support and app config
- `MenuMoreOptions.spec.tsx` — Added test cases covering the new conditional behavior

#### How should this be manually tested?

1. Open the app in **Safari** or **Firefox**
2. Enter the waiting room
3. Click the `...` (more options) button
4. Verify that **"Video Effects" is NOT shown** in the menu
5. Verify that **"Pre-call network test" is still shown**
6. Open the app in **Chrome** (or Edge/Opera)
7. Repeat steps 2–3 and verify **"Video Effects" IS shown**

**Tested on macOS Tahoe 26.3 (arm64):**

| Browser | Video Effects | Expected | Result |
|---------|:---:|:---:|:---:|
| Chrome 145.0.7632.117 | Shown | Supported | ✅ |
| Edge 145.0.3800.82 | Shown | Supported | ✅ |
| Opera One 127.0.5778.76 | Shown | Supported | ✅ |
| Safari 26.3 | Hidden | Unsupported | ✅ |
| Safari Technology Preview 238 | Hidden | Unsupported | ✅ |
| Firefox 148.0 | Hidden | Unsupported | ✅ |

#### What are the relevant tickets?

Resolves [VIDSOL-585](https://jira.vonage.com/browse/VIDSOL-585)

#### Checklist
- [x] Branch is based on `develop` (not `main`).
- [ ] Resolves a `Known Issue`.
- [ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`?
- [ ] Resolves an item reported in `Issues`.

Thank you for taking the time to review this! I truly appreciate any feedback. 🙏