### PR TITLE
VIDSOL-621: Fix Firefox camera device list empty when deviceIds are missing

### DIFF
--- a/frontend/src/stores/appConfig/hooks/useSuspenseUntilAppConfigReady/useSuspenseUntilAppConfigReady.ts
+++ b/frontend/src/stores/appConfig/hooks/useSuspenseUntilAppConfigReady/useSuspenseUntilAppConfigReady.ts
@@ -9,7 +9,7 @@ import appConfigStore from '../../appConfigStore';
 const useSuspenseUntilAppConfigReady = (): void => {
   const observable = appConfigStore.use.observable(({ isAppConfigLoaded }) => isAppConfigLoaded);
 
-  useSuspenseMemo(() => {
+  void useSuspenseMemo(() => {
     const isAppConfigLoaded = observable.getState();
 
     if (isAppConfigLoaded) {

--- a/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.test.ts
+++ b/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.test.ts
@@ -290,6 +290,42 @@ describe('setupDeviceStore', () => {
       expect(mockStream.getTracks).toHaveBeenCalled();
     });
 
+    it('should request permissions when on Firefox and deviceIds are empty but labels are present', async () => {
+      vi.spyOn(isFirefoxModule, 'default').mockReturnValue(true);
+
+      const mockStream = {
+        getTracks: vi.fn().mockReturnValue([{ stop: vi.fn() }, { stop: vi.fn() }]),
+      };
+
+      const getUserMediaSpy = vi.fn(() =>
+        Promise.resolve(mockStream)
+      ) as unknown as typeof navigator.mediaDevices.getUserMedia;
+
+      setupWindowNavigatorMock({
+        mediaDevices: {
+          addEventListener: vi.fn(),
+          enumerateDevices: vi.fn().mockResolvedValue([
+            { deviceId: '', kind: 'audioinput', label: 'Microphone' },
+            { deviceId: '', kind: 'videoinput', label: 'Camera' },
+          ]),
+          getUserMedia: getUserMediaSpy,
+        },
+      });
+
+      const api$ = makeApiClone();
+
+      setupDeviceStore(api$);
+
+      await waitFor(
+        () => {
+          expect(getUserMediaSpy).toHaveBeenCalledWith({ audio: true, video: true });
+        },
+        { timeout: 200 }
+      );
+
+      expect(mockStream.getTracks).toHaveBeenCalled();
+    });
+
     it('should NOT request permissions when on Firefox and device labels are present', async () => {
       vi.spyOn(isFirefoxModule, 'default').mockReturnValue(true);
 

--- a/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
+++ b/libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts
@@ -58,8 +58,8 @@ function setupDeviceStore(api: unknown) {
       .then((devices) => {
         if (isCanceled()) return;
 
-        const hasLabels = devices.some((device) => device.label);
-        if (hasLabels) return;
+        const hasValidDevices = devices.some((device) => device.label && device.deviceId);
+        if (hasValidDevices) return;
 
         //we should request permissions to be able to see the devices labels.
         return meta.__getUserMedia!({ audio: true, video: true }).then((stream) => {


### PR DESCRIPTION
Hi team! 👋

#### What is this PR doing?

Fixes **VIDSOL-621: [WEB] Firefox Devices List appears to be empty** — the camera/microphone dropdown in the conference room shows no devices on Firefox, even though the camera is actively streaming.

**Root cause:** `setupDeviceStore.ts` has a Firefox-specific initialisation path that decides whether to call `getUserMedia` (to force Firefox to populate `deviceId` values) based only on whether devices have **labels**. But Firefox can return devices with labels yet still return empty `deviceId` strings — e.g. when the publisher's stream was started before the device store initialised, or when a previous permission grant populated labels without properly seeding `deviceId`.

The downstream filter in `getMediaDevicesInfo.ts`:
```ts
.filter((device) => device.deviceId)  // empty string is falsy → removed
```
silently drops all those devices, leaving the store — and the dropdown — empty.

**The fix:** tighten the early-exit guard from "has labels" to "has both a label **and** a deviceId":

```ts
// Before
const hasLabels = devices.some((device) => device.label);
if (hasLabels) return;

// After
const hasValidDevices = devices.some((device) => device.label && device.deviceId);
if (hasValidDevices) return;
```

**Why this is safe:**
| Scenario | `label` | `deviceId` | `hasValidDevices` | Result |
|---|---|---|---|---|
| Fresh Firefox, no permissions | `""` | `""` | `false` | `getUserMedia` called ✓ (unchanged) |
| Firefox after proper permission grant | `"HD Camera"` | `"abc123"` | `true` | `getUserMedia` skipped ✓ (unchanged) |
| Bug scenario (labels present, empty deviceId) | `"HD Camera"` | `""` | `false` | `getUserMedia` now called ✓ (fixed) |

**Changes:**
- `libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.ts` — Two-word condition change: `hasLabels` → `hasValidDevices`, now requiring both `label && deviceId`
- `libs/core/src/stores/devices/helpers/setupDeviceStore/setupDeviceStore.test.ts` — One new test case covering the missing scenario (labels present, deviceIds empty → `getUserMedia` called)
- `frontend/src/stores/appConfig/hooks/useSuspenseUntilAppConfigReady/useSuspenseUntilAppConfigReady.ts` — Pre-existing `@typescript-eslint/no-floating-promises` lint error fixed (adds `void` prefix to `useSuspenseMemo` call; the pre-commit hook blocked the commit without it)

#### How should this be manually tested?

1. Open the app in **Firefox**
2. Join a meeting room
3. Click the chevron (▾) next to the camera button to open the camera device dropdown
4. Verify the **camera and microphone device list is populated** (not empty)
5. Verify switching devices works correctly

**Tested on macOS Tahoe 26.3 (arm64):**

| Browser | Device list shown | Expected |
|---------|:---:|:---:|
| Firefox 148.0 | ✅ | Fixed |
| Chrome 145 | ✅ | Unaffected |
| Safari 26.3 | ✅ | Unaffected |

#### What are the relevant tickets?

Resolves [VIDSOL-621](https://jira.vonage.com/browse/VIDSOL-621)

#### Checklist
- [x] Branch is based on `develop` (not `main`).
- [ ] Resolves a `Known Issue`.
- [ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`?
- [ ] Resolves an item reported in `Issues`.