### PR TITLE
fix(core): add explicit type annotations to device hooks

### DIFF
--- a/libs/core/src/stores/devices/hooks/useDeviceId.ts
+++ b/libs/core/src/stores/devices/hooks/useDeviceId.ts
@@ -1,10 +1,11 @@
 import mediaDevices$ from '../devicesStore';
+import type { DevicesStoreState } from '../types';
 
 /**
  * Returns the selected device ID for the given media device kind.
  */
 function useDeviceId(kind: MediaDeviceKind): string | undefined {
-  return mediaDevices$.use.select((state) => state[kind], [kind]);
+  return mediaDevices$.use.select((state: DevicesStoreState) => state[kind], [kind]);
 }
 
 export default useDeviceId;

--- a/libs/core/src/stores/devices/hooks/useMediaDeviceInfo/useMediaDeviceInfo.ts
+++ b/libs/core/src/stores/devices/hooks/useMediaDeviceInfo/useMediaDeviceInfo.ts
@@ -4,6 +4,8 @@ import { UseHookOptions } from 'react-global-state-hooks';
 import { isString } from '@common/assertions';
 import type { MediaDeviceInfoJSON } from '@web/types';
 
+type MediaDevicesMap = Record<MediaDeviceKind, Record<string, MediaDeviceInfoJSON>>;
+
 /**
  * Returns the selected media device for a specific kind.
  */
@@ -27,12 +29,12 @@ function useMediaDeviceInfo(
   const options = isString(arg1) ? arg2 : arg1;
 
   return useMediaDeviceInfoByKind$(
-    (state) => {
+    (state: MediaDevicesMap) => {
       return getDeviceInfo(kind, deviceId, state);
     },
     {
       dependencies: [kind, deviceId],
-      isEqualRoot: (prev, next) => {
+      isEqualRoot: (prev: MediaDevicesMap, next: MediaDevicesMap) => {
         const deviceA = getDeviceInfo(kind, deviceId, prev);
         const deviceB = getDeviceInfo(kind, deviceId, next);
 

--- a/libs/core/src/stores/devices/hooks/useMediaDeviceInfoByKind$.ts
+++ b/libs/core/src/stores/devices/hooks/useMediaDeviceInfoByKind$.ts
@@ -1,10 +1,13 @@
 import mediaDevicesMap$ from '../observables/mediaDevicesMap$';
+import type { MediaDeviceInfoJSON } from '@web/types';
+
+type MediaDevicesMap = Record<MediaDeviceKind, Record<string, MediaDeviceInfoJSON>>;
 
 /**
  * Base hook, gives access to the media devices organized by kind and deviceId
  */
 const useMediaDeviceInfoByKind$ = mediaDevicesMap$.createSelectorHook(
-  (mediaDeviceInfoByKind) => mediaDeviceInfoByKind
+  (mediaDeviceInfoByKind: MediaDevicesMap) => mediaDeviceInfoByKind
 );
 
 export default useMediaDeviceInfoByKind$;

--- a/libs/core/src/stores/devices/hooks/useMediaDevices.ts
+++ b/libs/core/src/stores/devices/hooks/useMediaDevices.ts
@@ -4,6 +4,8 @@ import { isFunction, isString } from '@common/assertions';
 import useMediaDeviceInfoByKind$ from './useMediaDeviceInfoByKind$';
 import type { MediaDeviceInfoJSON } from '@web/types';
 
+type MediaDevicesMap = Record<MediaDeviceKind, Record<string, MediaDeviceInfoJSON>>;
+
 /**
  * Returns media devices organized by kind and deviceId.
  */
@@ -82,16 +84,19 @@ function useMediaDevices(
     return { dependencies };
   })();
 
-  return useMediaDeviceInfoByKind$((state) => selector(kind ? state[kind] : state), {
-    ...options,
-    dependencies: [kind, ...(options.dependencies ?? [])],
-    isEqualRoot: (prev, next) => {
-      if (options.isEqualRoot) return options.isEqualRoot(prev, next);
-      if (kind) return prev[kind] === next[kind];
+  return useMediaDeviceInfoByKind$(
+    (state: MediaDevicesMap) => selector(kind ? state[kind] : state),
+    {
+      ...options,
+      dependencies: [kind, ...(options.dependencies ?? [])],
+      isEqualRoot: (prev, next) => {
+        if (options.isEqualRoot) return options.isEqualRoot(prev, next);
+        if (kind) return prev[kind] === next[kind];
 
-      return prev === next;
-    },
-  }) as
+        return prev === next;
+      },
+    }
+  ) as
     | Record<string, MediaDeviceInfoJSON>
     | Record<MediaDeviceKind, Record<string, MediaDeviceInfoJSON>>;
 }


### PR DESCRIPTION
## Summary

- Adds explicit `MediaDevicesMap` and `DevicesStoreState` type annotations to callback parameters in four device hook files
- Callback parameters passed to `react-global-state-hooks` methods (`createSelectorHook`, `use.select`) were previously left for TypeScript to infer, which is fragile — a package update or TSC version change can cause them to silently widen to `any`, triggering `@typescript-eslint/no-unsafe-return` and `@typescript-eslint/no-unsafe-argument` errors
- This was surfaced by @behei-vonage in PR #345 after merging latest develop into his branch

**Files changed:**
- `libs/core/src/stores/devices/hooks/useMediaDeviceInfoByKind$.ts`
- `libs/core/src/stores/devices/hooks/useDeviceId.ts`
- `libs/core/src/stores/devices/hooks/useMediaDeviceInfo/useMediaDeviceInfo.ts`
- `libs/core/src/stores/devices/hooks/useMediaDevices.ts`

No runtime behaviour changes — type annotations only.

## Test plan

- [x] `npx nx run core:lint --skip-nx-cache` passes with 0 errors
- [x] Pre-push hook: full lint + ts-check across all 7 projects passes
- [x] Pre-push hook: 890 tests pass across all 6 projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)