### PR TITLE
IGNORE: issue #397:: fix: force dompurify >=3.3.2 to remediate CVE-2026-0540

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,8 @@
     "@babel/helpers": "^7.27.0",
     "@babel/runtime": "^7.26.10",
     "brace-expansion": "2.0.2",
-    "form-data": "^4.0.4"
+    "form-data": "^4.0.4",
+    "dompurify": "^3.3.2"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7228,10 +7228,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.1.tgz#c7e1ddebfe3301eacd6c0c12a4af284936dbbb86"
-  integrity sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==
+dompurify@^3.3.0, dompurify@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.2.tgz#58c515d0f8508b8749452a028aa589ad80b36325"
+  integrity sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## What

Adds a yarn `resolutions` entry to force `dompurify@^3.3.2` across the dependency tree.

## Why

Mend raised issue #397: `dompurify@3.3.1` (transitive via `@vonage/vivid`) is vulnerable to **CVE-2026-0540** (CVSS 6.1 — Medium).

The vulnerability allows attackers to bypass attribute sanitization via five missing rawtext elements (`noscript`, `xmp`, `noembed`, `noframes`, `iframe`) in the `SAFE_FOR_XML` regex, enabling XSS when sanitized output is placed inside these unprotected contexts.

No fixed version of `vivid` is available yet. The fix pins `dompurify` to `^3.3.2` via yarn resolutions, consistent with how the project already handles other transitive vulnerability fixes (see existing `resolutions` in `package.json`).

Closes #397