### PR TITLE
VIDSOL-619: Mirror Self View Toggle

### DIFF
--- a/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
@@ -16,6 +16,7 @@ const mockUserContext: UserContextType = {
       name: '',
       noiseSuppression: true,
       publishCaptions: false,
+      mirrorSelfView: true,
     },
     issues: {
       reconnections: 0,

--- a/frontend/src/Context/tests/user.spec.tsx
+++ b/frontend/src/Context/tests/user.spec.tsx
@@ -43,6 +43,7 @@ describe('UserContext', () => {
         audioSource: undefined,
         videoSource: undefined,
         publishCaptions: true,
+        mirrorSelfView: true,
       },
       issues: {
         reconnections: 0,

--- a/frontend/src/Context/user.tsx
+++ b/frontend/src/Context/user.tsx
@@ -29,6 +29,7 @@ export type UserType = {
     backgroundFilter?: VideoFilter; // The background replacement filter applied to the video
     audioSource?: string; // The selected audio input source (optional)
     videoSource?: string; // The selected video input source (optional)
+    mirrorSelfView: boolean; // Whether the self-view is mirrored (horizontally flipped)
   };
   issues: {
     reconnections: number; // The number of reconnections the user has experienced
@@ -55,6 +56,8 @@ const UserProvider = ({ children, value: initialUserState }: UserProviderProps):
   const noiseSuppression = getStorageItem(STORAGE_KEYS.NOISE_SUPPRESSION) === 'true';
   const backgroundFilter = parseVideoFilter(getStorageItem(STORAGE_KEYS.BACKGROUND_REPLACEMENT));
   const name = getStorageItem(STORAGE_KEYS.USERNAME) ?? '';
+  // Default is true (mirrored); null (no entry) also maps to true via !== 'false'
+  const mirrorSelfView = getStorageItem(STORAGE_KEYS.MIRROR_SELF_VIEW) !== 'false';
 
   const [user, setUser] = useState<UserType>(() => ({
     defaultSettings: {
@@ -63,6 +66,7 @@ const UserProvider = ({ children, value: initialUserState }: UserProviderProps):
       name,
       backgroundFilter,
       noiseSuppression,
+      mirrorSelfView,
       audioSource: undefined,
       videoSource: undefined,
       publishCaptions: true,

--- a/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.spec.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.spec.tsx
@@ -1,5 +1,7 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { ReactNode } from 'react';
+import UserProvider from '../../../Context/user';
 import BackgroundVideoContainer from './BackgroundVideoContainer';
 
 vi.mock('../../../utils/waitUntilPlaying', () => ({
@@ -7,16 +9,20 @@ vi.mock('../../../utils/waitUntilPlaying', () => ({
   default: vi.fn(() => Promise.resolve()),
 }));
 
+const wrapper = ({ children }: { children: ReactNode }) => <UserProvider>{children}</UserProvider>;
+
 describe('BackgroundVideoContainer', () => {
   it('shows message when video is not enabled', () => {
-    render(<BackgroundVideoContainer isParentVideoEnabled={false} />);
+    render(<BackgroundVideoContainer isParentVideoEnabled={false} />, { wrapper });
     expect(screen.getByText(/Your camera is turned off/i)).toBeInTheDocument();
   });
 
   it('renders video element when video is enabled', async () => {
     const videoEl = document.createElement('video');
     act(() => {
-      render(<BackgroundVideoContainer isParentVideoEnabled publisherVideoElement={videoEl} />);
+      render(<BackgroundVideoContainer isParentVideoEnabled publisherVideoElement={videoEl} />, {
+        wrapper,
+      });
     });
     await waitFor(() => {
       expect(videoEl.classList.contains('video__element')).toBe(true);
@@ -27,7 +33,9 @@ describe('BackgroundVideoContainer', () => {
   it('shows loading spinner while video is loading', async () => {
     const videoEl = document.createElement('video');
     act(() => {
-      render(<BackgroundVideoContainer isParentVideoEnabled publisherVideoElement={videoEl} />);
+      render(<BackgroundVideoContainer isParentVideoEnabled publisherVideoElement={videoEl} />, {
+        wrapper,
+      });
     });
     await waitFor(() => {
       expect(screen.getByRole('progressbar')).toBeInTheDocument();

--- a/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.tsx
@@ -31,7 +31,6 @@ const BackgroundVideoContainer = ({
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const [isVideoLoading, setIsVideoLoading] = useState<boolean>(true);
-  const isSMViewport = useMediaQuery(`(max-width:500px)`);
   const isMDViewport = useMediaQuery(`(max-width:768px)`);
   const isTabletViewport = useIsTabletViewport();
   const isLGViewport = useMediaQuery(`(max-width:1199px)`);
@@ -65,7 +64,11 @@ const BackgroundVideoContainer = ({
       myVideoElement.style.marginLeft = 'auto';
       myVideoElement.style.marginRight = 'auto';
       myVideoElement.style.marginBottom = '1px';
-      myVideoElement.style.transform = mirrorSelfView ? 'none' : 'scaleX(-1)';
+      // The SDK mirrors the preview publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).
+      // When mirror is ON, clear the inline style so the SDK's CSS class takes effect.
+      // When mirror is OFF, set scaleX(1) to override and cancel the SDK's mirror.
+      // eslint-disable-next-line react-hooks/immutability
+      myVideoElement.style.transform = mirrorSelfView ? '' : 'scaleX(1)';
       myVideoElement.style.objectFit = 'cover';
       myVideoElement.style.aspectRatio = '16 / 9';
 
@@ -76,7 +79,6 @@ const BackgroundVideoContainer = ({
   }, [
     isTabletViewport,
     isMDViewport,
-    isSMViewport,
     publisherVideoElement,
     isFixedWidth,
     isParentVideoEnabled,

--- a/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.tsx
@@ -64,10 +64,19 @@ const BackgroundVideoContainer = ({
       myVideoElement.style.marginLeft = 'auto';
       myVideoElement.style.marginRight = 'auto';
       myVideoElement.style.marginBottom = '1px';
+      const isSdkMirroring = myVideoElement.classList.contains('OT_mirrored');
       // The SDK mirrors the preview publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).
-      // When mirror is ON, clear the inline style so the SDK's CSS class takes effect.
+      // When mirror is ON, prefer the SDK class; fall back to an inline mirror if the class is absent.
       // When mirror is OFF, set scaleX(1) to override and cancel the SDK's mirror.
-      myVideoElement.style.transform = mirrorSelfView ? '' : 'scaleX(1)';
+      if (mirrorSelfView) {
+        if (isSdkMirroring) {
+          myVideoElement.style.removeProperty('transform');
+        } else {
+          myVideoElement.style.transform = 'scaleX(-1)';
+        }
+      } else {
+        myVideoElement.style.transform = 'scaleX(1)';
+      }
       myVideoElement.style.objectFit = 'cover';
       myVideoElement.style.aspectRatio = '16 / 9';
 

--- a/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.tsx
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import waitUntilPlaying from '../../../utils/waitUntilPlaying';
 import useIsTabletViewport from '../../../hooks/useIsTabletViewport';
+import useUserContext from '../../../hooks/useUserContext';
 
 export type BackgroundVideoContainerProps = {
   isFixedWidth?: boolean;
@@ -35,6 +36,8 @@ const BackgroundVideoContainer = ({
   const isTabletViewport = useIsTabletViewport();
   const isLGViewport = useMediaQuery(`(max-width:1199px)`);
   const theme = useTheme();
+  const { user } = useUserContext();
+  const { mirrorSelfView } = user.defaultSettings;
 
   useEffect(() => {
     if (publisherVideoElement && containerRef.current) {
@@ -62,8 +65,8 @@ const BackgroundVideoContainer = ({
       myVideoElement.style.marginLeft = 'auto';
       myVideoElement.style.marginRight = 'auto';
       myVideoElement.style.marginBottom = '1px';
-      myVideoElement.style.transform = 'scaleX(-1)';
-      myVideoElement.style.objectFit = 'contain';
+      myVideoElement.style.transform = mirrorSelfView ? 'none' : 'scaleX(-1)';
+      myVideoElement.style.objectFit = 'cover';
       myVideoElement.style.aspectRatio = '16 / 9';
 
       void waitUntilPlaying(publisherVideoElement).then(() => {
@@ -79,6 +82,7 @@ const BackgroundVideoContainer = ({
     isParentVideoEnabled,
     isLGViewport,
     theme.shapes.borderRadiusLarge,
+    mirrorSelfView,
   ]);
 
   let containerWidth = '100%';

--- a/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundVideoContainer/BackgroundVideoContainer.tsx
@@ -67,7 +67,6 @@ const BackgroundVideoContainer = ({
       // The SDK mirrors the preview publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).
       // When mirror is ON, clear the inline style so the SDK's CSS class takes effect.
       // When mirror is OFF, set scaleX(1) to override and cancel the SDK's mirror.
-      // eslint-disable-next-line react-hooks/immutability
       myVideoElement.style.transform = mirrorSelfView ? '' : 'scaleX(1)';
       myVideoElement.style.objectFit = 'cover';
       myVideoElement.style.aspectRatio = '16 / 9';

--- a/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.spec.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.spec.tsx
@@ -11,6 +11,7 @@ import { ReactElement, RefObject } from 'react';
 import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
 import type { MediaDeviceInfoJSON } from '@web/types';
 import { makeTestProvider, providers, type ProviderOptions } from '@test/providers';
+import { env } from '../../../env';
 import { isSinkIdSupported } from '@web/platform';
 import {
   makeMediaDeviceInfos,
@@ -339,6 +340,11 @@ describe('DeviceSettingsMenu Component', () => {
     });
 
     it('and does not render the video effects option when allowBackgroundEffects is false', async () => {
+      env.partialUpdate({
+        ALLOW_BACKGROUND_EFFECTS: false,
+        MEETING_ROOM_ALLOW_DEVICE_SELECTION: true,
+      });
+
       render(
         <DeviceSettingsMenuComponent
           deviceType={deviceType}
@@ -360,13 +366,11 @@ describe('DeviceSettingsMenu Component', () => {
 });
 
 type RenderOptions = {
-  appConfigContext?: ProviderOptions['AppConfigContext'];
   userContext?: ProviderOptions['UserContext'];
 };
 
-function render(ui: ReactElement, { appConfigContext, userContext }: RenderOptions = {}) {
-  const { wrapper, ...context } = makeTestProvider([providers.appConfig, providers.user], {
-    appConfigContext,
+function render(ui: ReactElement, { userContext }: RenderOptions = {}) {
+  const { wrapper, ...context } = makeTestProvider([providers.user], {
     userContext,
   });
 

--- a/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.spec.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.spec.tsx
@@ -315,7 +315,7 @@ describe('DeviceSettingsMenu Component', () => {
       );
 
       await waitFor(() => {
-        expect(screen.queryAllByTestId('dropdown-separator')[0]).toBeVisible();
+        expect(screen.getAllByTestId('dropdown-separator')[0]).toBeVisible();
         expect(screen.queryByText('Video effects')).toBeVisible();
       });
     });

--- a/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.spec.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.spec.tsx
@@ -10,9 +10,8 @@ import { describe, beforeEach, it, vi, expect } from 'vitest';
 import { ReactElement, RefObject } from 'react';
 import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
 import type { MediaDeviceInfoJSON } from '@web/types';
-import { makeTestProvider } from '@test/providers';
+import { makeTestProvider, providers, type ProviderOptions } from '@test/providers';
 import { isSinkIdSupported } from '@web/platform';
-import { env } from '../../../env';
 import {
   makeMediaDeviceInfos,
   makeMediaStreamMock,
@@ -315,12 +314,12 @@ describe('DeviceSettingsMenu Component', () => {
       );
 
       await waitFor(() => {
-        expect(screen.queryByTestId('dropdown-separator')).toBeVisible();
+        expect(screen.queryAllByTestId('dropdown-separator')[0]).toBeVisible();
         expect(screen.queryByText('Video effects')).toBeVisible();
       });
     });
 
-    it('and does not render the dropdown separator and video effects option when media processor is not supported', async () => {
+    it('and does not render the video effects option when media processor is not supported', async () => {
       render(
         <DeviceSettingsMenuComponent
           deviceType={deviceType}
@@ -334,17 +333,12 @@ describe('DeviceSettingsMenu Component', () => {
       );
 
       await waitFor(() => {
-        expect(screen.queryByTestId('dropdown-separator')).not.toBeInTheDocument();
-        expect(screen.queryByText('video effects')).not.toBeInTheDocument();
+        expect(screen.queryByText('Video effects')).not.toBeInTheDocument();
+        expect(screen.queryByText('Mirror Self View')).toBeInTheDocument();
       });
     });
 
-    it('and does not render the dropdown separator and video effects option when allowBackgroundEffects is false', async () => {
-      env.partialUpdate({
-        ALLOW_BACKGROUND_EFFECTS: false,
-        MEETING_ROOM_ALLOW_DEVICE_SELECTION: true,
-      });
-
+    it('and does not render the video effects option when allowBackgroundEffects is false', async () => {
       render(
         <DeviceSettingsMenuComponent
           deviceType={deviceType}
@@ -358,15 +352,23 @@ describe('DeviceSettingsMenu Component', () => {
       );
 
       await waitFor(() => {
-        expect(screen.queryByTestId('dropdown-separator')).not.toBeInTheDocument();
-        expect(screen.queryByText('video effects')).not.toBeInTheDocument();
+        expect(screen.queryByText('Video effects')).not.toBeInTheDocument();
+        expect(screen.queryByText('Mirror Self View')).toBeInTheDocument();
       });
     });
   });
 });
 
-function render(ui: ReactElement) {
-  const { wrapper, ...context } = makeTestProvider([]);
+type RenderOptions = {
+  appConfigContext?: ProviderOptions['AppConfigContext'];
+  userContext?: ProviderOptions['UserContext'];
+};
+
+function render(ui: ReactElement, { appConfigContext, userContext }: RenderOptions = {}) {
+  const { wrapper, ...context } = makeTestProvider([providers.appConfig, providers.user], {
+    appConfigContext,
+    userContext,
+  });
 
   return {
     ...context,

--- a/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, RefObject, Dispatch, SetStateAction } from 'react';
 import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
-import useTheme from '@ui/theme';
+import classNames from 'classnames';
 import InputDevices from '../InputAudioDevices';
 import OutputDevices from '../OutputAudioDevices';
 import ReduceNoiseTestSpeakers from '../ReduceNoiseTestSpeakers';
@@ -14,7 +14,6 @@ import Popper from '@mui/material/Popper';
 import Grow from '@mui/material/Grow';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import Paper from '@mui/material/Paper';
-import Box from '@mui/material/Box';
 import { env } from '../../../env';
 
 export type DeviceSettingsMenuProps = {
@@ -54,10 +53,21 @@ const DeviceSettingsMenu = ({
   handleClose,
   setIsOpen,
 }: DeviceSettingsMenuProps): ReactElement | false => {
-  const theme = useTheme();
-
   const isAudio = deviceType === 'audio';
   const shouldDisplayBackgroundEffects = hasMediaProcessorSupport() && env.ALLOW_BACKGROUND_EFFECTS;
+  const popperTransformClasses = isAudio
+    ? [
+        'translate-y-[-2%]',
+        'translate-x-[5%]',
+        'max-[740px]:translate-x-[-10%]',
+        'max-[450px]:translate-x-[-5%]',
+      ]
+    : [
+        'translate-y-[-5%]',
+        'translate-x-[-15%]',
+        'max-[740px]:translate-x-[-40%]',
+        'max-[450px]:translate-x-[-5%]',
+      ];
 
   const handleToggleBackgroundEffects = () => {
     toggleBackgroundEffects();
@@ -87,7 +97,7 @@ const DeviceSettingsMenu = ({
           </>
         )}
         <DropdownSeparator />
-        <MenuList sx={{ display: 'flex', flexDirection: 'column', mt: 1 }}>
+        <MenuList className="mt-1 flex flex-col">
           <MirrorSelfViewToggle />
         </MenuList>
       </>
@@ -104,44 +114,29 @@ const DeviceSettingsMenu = ({
       placement="bottom-start"
     >
       {({ TransitionProps, placement }) => (
-        <Grow
-          {...TransitionProps}
-          style={{ transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom' }}
-        >
-          <Box sx={{ textAlign: 'left', fontWeight: 'normal' }}>
-            <ClickAwayListener onClickAway={handleClose}>
-              <Paper
-                sx={(t) => ({
-                  backgroundColor: theme.colors.surface,
-                  color: theme.colors.onSurface,
-                  padding: { xs: 1, sm: 2 },
-                  borderRadius: 2,
-                  zIndex: 1,
-                  transform: isAudio
-                    ? 'translateY(-2%) translateX(5%)'
-                    : 'translateY(-5%) translateX(-15%)',
-                  [t.breakpoints.down(741)]: {
-                    transform: isAudio
-                      ? 'translateY(-2%) translateX(-10%)'
-                      : 'translateY(-5%) translateX(-40%)',
-                  },
-                  [t.breakpoints.down(450)]: {
-                    transform: isAudio
-                      ? 'translateY(-2%) translateX(-5%)'
-                      : 'translateY(-5%) translateX(-5%)',
-                  },
-                  width: { xs: '90vw', sm: '100%' },
-                  maxWidth: 400,
-                  position: 'relative',
-                })}
-              >
-                {renderSettingsMenu()}
-              </Paper>
-            </ClickAwayListener>
-          </Box>
-        </Grow>
-      )}
-    </Popper>
+          <Grow
+            {...TransitionProps}
+            style={{ transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom' }}
+          >
+            <div className="text-left font-normal">
+              <ClickAwayListener onClickAway={handleClose}>
+                <Paper
+                  className={classNames(
+                    'relative z-10',
+                    'bg-vera-surface text-vera-on-surface',
+                    'p-1 sm:p-2',
+                    'rounded-vera-large',
+                    'w-[90vw] sm:w-full max-w-[400px]',
+                    popperTransformClasses
+                  )}
+                >
+                  {renderSettingsMenu()}
+                </Paper>
+              </ClickAwayListener>
+            </div>
+          </Grow>
+        )}
+      </Popper>
   );
 };
 

--- a/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.tsx
@@ -8,6 +8,8 @@ import useDropdownResizeObserver from '../../../hooks/useDropdownResizeObserver'
 import VideoDevices from '../VideoDevices';
 import DropdownSeparator from '../DropdownSeparator';
 import VideoDevicesOptions from '../VideoDevicesOptions';
+import MirrorSelfViewToggle from '../MirrorSelfViewToggle/MirrorSelfViewToggle';
+import MenuList from '@mui/material/MenuList';
 import Popper from '@mui/material/Popper';
 import Grow from '@mui/material/Grow';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
@@ -84,6 +86,10 @@ const DeviceSettingsMenu = ({
             <VideoDevicesOptions toggleBackgroundEffects={handleToggleBackgroundEffects} />
           </>
         )}
+        <DropdownSeparator />
+        <MenuList sx={{ display: 'flex', flexDirection: 'column', mt: 1 }}>
+          <MirrorSelfViewToggle />
+        </MenuList>
       </>
     );
   };

--- a/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.tsx
@@ -114,29 +114,29 @@ const DeviceSettingsMenu = ({
       placement="bottom-start"
     >
       {({ TransitionProps, placement }) => (
-          <Grow
-            {...TransitionProps}
-            style={{ transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom' }}
-          >
-            <div className="text-left font-normal">
-              <ClickAwayListener onClickAway={handleClose}>
-                <Paper
-                  className={classNames(
-                    'relative z-10',
-                    'bg-vera-surface text-vera-on-surface',
-                    'p-1 sm:p-2',
-                    'rounded-vera-large',
-                    'w-[90vw] sm:w-full max-w-[400px]',
-                    popperTransformClasses
-                  )}
-                >
-                  {renderSettingsMenu()}
-                </Paper>
-              </ClickAwayListener>
-            </div>
-          </Grow>
-        )}
-      </Popper>
+        <Grow
+          {...TransitionProps}
+          style={{ transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom' }}
+        >
+          <div className="text-left font-normal">
+            <ClickAwayListener onClickAway={handleClose}>
+              <Paper
+                className={classNames(
+                  'relative z-10',
+                  'bg-vera-surface text-vera-on-surface',
+                  'p-1 sm:p-2',
+                  'rounded-vera-large',
+                  'w-[90vw] sm:w-full max-w-[400px]',
+                  popperTransformClasses
+                )}
+              >
+                {renderSettingsMenu()}
+              </Paper>
+            </ClickAwayListener>
+          </div>
+        </Grow>
+      )}
+    </Popper>
   );
 };
 

--- a/frontend/src/components/MeetingRoom/MirrorSelfViewToggle/MirrorSelfViewToggle.tsx
+++ b/frontend/src/components/MeetingRoom/MirrorSelfViewToggle/MirrorSelfViewToggle.tsx
@@ -1,0 +1,76 @@
+import { ReactElement } from 'react';
+import ToggleOffIcon from '@mui/icons-material/ToggleOff';
+import ToggleOnIcon from '@mui/icons-material/ToggleOn';
+import { useTranslation } from 'react-i18next';
+import useTheme from '@ui/theme';
+import { setStorageItem, STORAGE_KEYS } from '@utils/storage';
+import MenuItem from '@mui/material/MenuItem';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import Grow from '@mui/material/Grow';
+import Box from '@mui/material/Box';
+import FlipIcon from '@mui/icons-material/Flip';
+import useUserContext from '@hooks/useUserContext';
+
+/**
+ * MirrorSelfViewToggle Component
+ *
+ * Renders a toggle menu item in the camera device dropdown that enables or disables
+ * horizontal mirroring of the self-view. The preference is persisted in localStorage.
+ * Follows the same pattern as the Advanced Noise Suppression toggle in the audio menu.
+ * @returns {ReactElement} The MirrorSelfViewToggle component.
+ */
+const MirrorSelfViewToggle = (): ReactElement => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const { user, setUser } = useUserContext();
+  const isToggled = user.defaultSettings.mirrorSelfView;
+
+  const handleToggle = () => {
+    const newValue = !isToggled;
+    setStorageItem(STORAGE_KEYS.MIRROR_SELF_VIEW, String(newValue));
+    setUser((prev) => ({
+      ...prev,
+      defaultSettings: {
+        ...prev.defaultSettings,
+        mirrorSelfView: newValue,
+      },
+    }));
+  };
+
+  return (
+    <MenuItem
+      onClick={handleToggle}
+      sx={{
+        '&:hover': {
+          backgroundColor: theme.colors.background,
+        },
+      }}
+    >
+      <Box sx={{ mr: 2 }}>
+        <FlipIcon sx={{ fontSize: 24, color: theme.colors.secondary }} />
+      </Box>
+      <Typography variant="body1" noWrap sx={{ mr: 2 }}>
+        {t('devices.video.mirrorSelfView')}
+      </Typography>
+      <IconButton disableRipple>
+        <Grow in={!isToggled} timeout={300}>
+          <ToggleOffIcon
+            data-testid="mirror-toggle-off-icon"
+            fontSize="large"
+            sx={{ position: 'absolute', color: theme.colors.secondary }}
+          />
+        </Grow>
+        <Grow in={isToggled} timeout={300}>
+          <ToggleOnIcon
+            data-testid="mirror-toggle-on-icon"
+            fontSize="large"
+            sx={{ position: 'absolute', color: theme.colors.secondary }}
+          />
+        </Grow>
+      </IconButton>
+    </MenuItem>
+  );
+};
+
+export default MirrorSelfViewToggle;

--- a/frontend/src/components/MeetingRoom/MirrorSelfViewToggle/MirrorSelfViewToggle.tsx
+++ b/frontend/src/components/MeetingRoom/MirrorSelfViewToggle/MirrorSelfViewToggle.tsx
@@ -2,13 +2,9 @@ import { ReactElement } from 'react';
 import ToggleOffIcon from '@mui/icons-material/ToggleOff';
 import ToggleOnIcon from '@mui/icons-material/ToggleOn';
 import { useTranslation } from 'react-i18next';
-import useTheme from '@ui/theme';
 import { setStorageItem, STORAGE_KEYS } from '@utils/storage';
 import MenuItem from '@mui/material/MenuItem';
-import IconButton from '@mui/material/IconButton';
-import Typography from '@mui/material/Typography';
 import Grow from '@mui/material/Grow';
-import Box from '@mui/material/Box';
 import FlipIcon from '@mui/icons-material/Flip';
 import useUserContext from '@hooks/useUserContext';
 
@@ -22,7 +18,6 @@ import useUserContext from '@hooks/useUserContext';
  */
 const MirrorSelfViewToggle = (): ReactElement => {
   const { t } = useTranslation();
-  const theme = useTheme();
   const { user, setUser } = useUserContext();
   const isToggled = user.defaultSettings.mirrorSelfView;
 
@@ -41,34 +36,28 @@ const MirrorSelfViewToggle = (): ReactElement => {
   return (
     <MenuItem
       onClick={handleToggle}
-      sx={{
-        '&:hover': {
-          backgroundColor: theme.colors.background,
-        },
-      }}
+      role="menuitemcheckbox"
+      aria-checked={isToggled}
+      className="flex items-center gap-3 rounded-vera-medium px-3 py-2 text-vera-on-surface hover:bg-vera-background focus-visible:outline-none"
     >
-      <Box sx={{ mr: 2 }}>
-        <FlipIcon sx={{ fontSize: 24, color: theme.colors.secondary }} />
-      </Box>
-      <Typography variant="body1" noWrap sx={{ mr: 2 }}>
+      <FlipIcon className="h-6 w-6 text-vera-secondary" />
+      <span className="flex-1 truncate text-base font-normal">
         {t('devices.video.mirrorSelfView')}
-      </Typography>
-      <IconButton disableRipple>
+      </span>
+      <span className="relative flex h-6 w-11 items-center justify-center">
         <Grow in={!isToggled} timeout={300}>
           <ToggleOffIcon
             data-testid="mirror-toggle-off-icon"
-            fontSize="large"
-            sx={{ position: 'absolute', color: theme.colors.secondary }}
+            className="absolute inset-0 h-6 w-11 text-vera-secondary"
           />
         </Grow>
         <Grow in={isToggled} timeout={300}>
           <ToggleOnIcon
             data-testid="mirror-toggle-on-icon"
-            fontSize="large"
-            sx={{ position: 'absolute', color: theme.colors.secondary }}
+            className="absolute inset-0 h-6 w-11 text-vera-secondary"
           />
         </Grow>
-      </IconButton>
+      </span>
     </MenuItem>
   );
 };

--- a/frontend/src/components/Publisher/Publisher.tsx
+++ b/frontend/src/components/Publisher/Publisher.tsx
@@ -59,11 +59,15 @@ const Publisher = ({ box }: PublisherProps): ReactElement => {
   useEffect(() => {
     if (!element) return;
 
-    // The SDK mirrors the publisher via .OT_mirrored (scaleX(-1)).
-    // When mirror is ON, we leave transform unset (SDK handles it).
-    // When mirror is OFF, we apply scaleX(-1) to cancel the SDK's mirror.
+    // The SDK mirrors the publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).
+    // When mirror is ON, clear the inline style so the SDK's CSS class takes effect.
+    // When mirror is OFF, set scaleX(1) to override and cancel the SDK's mirror.
     // eslint-disable-next-line react-hooks/immutability
-    element.style.transform = mirrorSelfView ? 'none' : 'scaleX(-1)';
+    if (mirrorSelfView) {
+      element.style.removeProperty('transform');
+    } else {
+      element.style.transform = 'scaleX(1)';
+    }
   }, [element, mirrorSelfView]);
 
   const initials = publisher?.stream?.initials;

--- a/frontend/src/components/Publisher/Publisher.tsx
+++ b/frontend/src/components/Publisher/Publisher.tsx
@@ -62,10 +62,10 @@ const Publisher = ({ box }: PublisherProps): ReactElement => {
     // The SDK mirrors the publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).
     // When mirror is ON, clear the inline style so the SDK's CSS class takes effect.
     // When mirror is OFF, set scaleX(1) to override and cancel the SDK's mirror.
-    // eslint-disable-next-line react-hooks/immutability
     if (mirrorSelfView) {
       element.style.removeProperty('transform');
     } else {
+      // eslint-disable-next-line react-hooks/immutability
       element.style.transform = 'scaleX(1)';
     }
   }, [element, mirrorSelfView]);

--- a/frontend/src/components/Publisher/Publisher.tsx
+++ b/frontend/src/components/Publisher/Publisher.tsx
@@ -16,6 +16,27 @@ export type PublisherProps = {
   box: Box;
 };
 
+const applyMirrorSelfView = (args: {
+  element: HTMLElement;
+  mirrorSelfView: boolean;
+}) => {
+  const { element, mirrorSelfView } = args;
+
+  const isSdkMirroring = element.classList.contains('OT_mirrored');
+  if (mirrorSelfView) {
+    if (isSdkMirroring) {
+      element.style.removeProperty('transform');
+      return;
+    }
+
+    // eslint-disable-next-line react-hooks/immutability
+    element.style.transform = 'scaleX(-1)';
+    return;
+  }
+
+  element.style.transform = 'scaleX(1)';
+};
+
 /**
  * Publisher component
  *
@@ -54,26 +75,9 @@ const Publisher = ({ box }: PublisherProps): ReactElement => {
     element.style.transformOrigin = '50% 50%';
 
     pubContainerRef.current.appendChild(element);
-  }, [element, theme.shapes.borderRadiusLarge]);
 
-  useEffect(() => {
-    if (!element) return;
-
-    // The SDK mirrors the publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).
-    // When mirror is ON, prefer the SDK class; fall back to an inline mirror if the class is absent.
-    // When mirror is OFF, set scaleX(1) to override and cancel the SDK's mirror.
-    const isSdkMirroring = element.classList.contains('OT_mirrored');
-    if (mirrorSelfView) {
-      if (isSdkMirroring) {
-        element.style.removeProperty('transform');
-      } else {
-        // eslint-disable-next-line react-hooks/immutability
-        element.style.transform = 'scaleX(-1)';
-      }
-    } else {
-      element.style.transform = 'scaleX(1)';
-    }
-  }, [element, mirrorSelfView]);
+    applyMirrorSelfView({ element, mirrorSelfView });
+  }, [element, mirrorSelfView, theme.shapes.borderRadiusLarge]);
 
   const initials = publisher?.stream?.initials;
   const username = publisher?.stream?.name ?? '';

--- a/frontend/src/components/Publisher/Publisher.tsx
+++ b/frontend/src/components/Publisher/Publisher.tsx
@@ -60,10 +60,15 @@ const Publisher = ({ box }: PublisherProps): ReactElement => {
     if (!element) return;
 
     // The SDK mirrors the publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).
-    // When mirror is ON, clear the inline style so the SDK's CSS class takes effect.
+    // When mirror is ON, prefer the SDK class; fall back to an inline mirror if the class is absent.
     // When mirror is OFF, set scaleX(1) to override and cancel the SDK's mirror.
+    const isSdkMirroring = element.classList.contains('OT_mirrored');
     if (mirrorSelfView) {
-      element.style.removeProperty('transform');
+      if (isSdkMirroring) {
+        element.style.removeProperty('transform');
+      } else {
+        element.style.transform = 'scaleX(-1)';
+      }
     } else {
       // eslint-disable-next-line react-hooks/immutability
       element.style.transform = 'scaleX(1)';

--- a/frontend/src/components/Publisher/Publisher.tsx
+++ b/frontend/src/components/Publisher/Publisher.tsx
@@ -10,6 +10,7 @@ import VideoTile from '../MeetingRoom/VideoTile';
 import useTheme from '@ui/theme';
 import { ABSOLUTE_DISTANCE_THRESHOLD_REM_VALUE } from '@utils/constants';
 import toRemValue from '@common/helpers/toRemValue';
+import useUserContext from '../../hooks/useUserContext';
 
 export type PublisherProps = {
   box: Box;
@@ -33,26 +34,37 @@ const Publisher = ({ box }: PublisherProps): ReactElement => {
   } = usePublisherContext();
   const audioLevel = useAudioLevels();
   const theme = useTheme();
+  const { user } = useUserContext();
+  const { mirrorSelfView } = user.defaultSettings;
   // We store this in a ref to get a reference to the div so that we can append a video to it
   const pubContainerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (element && pubContainerRef.current) {
-      element.classList.add('video__element');
+    if (!element || !pubContainerRef.current) return;
 
-      // Apply MUI-style inline styles instead of Tailwind classes
+    element.classList.add('video__element');
 
-      // eslint-disable-next-line react-hooks/immutability
-      element.style.width = '100%';
-      element.style.height = '100%';
-      element.style.position = 'absolute';
-      element.style.borderRadius = theme.shapes.borderRadiusLarge;
-      element.style.objectFit = 'contain';
-      element.style.transformOrigin = '50% 50%'; // origin-[50%_50%]
-      element.style.transform = 'scaleX(-1)'; // -scale-x-100 (mirror the publisher)
+    // Apply MUI-style inline styles instead of Tailwind classes
 
-      pubContainerRef.current.appendChild(element);
-    }
+    // eslint-disable-next-line react-hooks/immutability
+    element.style.width = '100%';
+    element.style.height = '100%';
+    element.style.position = 'absolute';
+    element.style.borderRadius = theme.shapes.borderRadiusLarge;
+    element.style.objectFit = 'cover';
+    element.style.transformOrigin = '50% 50%';
+
+    pubContainerRef.current.appendChild(element);
   }, [element, theme.shapes.borderRadiusLarge]);
+
+  useEffect(() => {
+    if (!element) return;
+
+    // The SDK mirrors the publisher via .OT_mirrored (scaleX(-1)).
+    // When mirror is ON, we leave transform unset (SDK handles it).
+    // When mirror is OFF, we apply scaleX(-1) to cancel the SDK's mirror.
+    // eslint-disable-next-line react-hooks/immutability
+    element.style.transform = mirrorSelfView ? 'none' : 'scaleX(-1)';
+  }, [element, mirrorSelfView]);
 
   const initials = publisher?.stream?.initials;
   const username = publisher?.stream?.name ?? '';

--- a/frontend/src/components/Publisher/Publisher.tsx
+++ b/frontend/src/components/Publisher/Publisher.tsx
@@ -67,10 +67,10 @@ const Publisher = ({ box }: PublisherProps): ReactElement => {
       if (isSdkMirroring) {
         element.style.removeProperty('transform');
       } else {
+        // eslint-disable-next-line react-hooks/immutability
         element.style.transform = 'scaleX(-1)';
       }
     } else {
-      // eslint-disable-next-line react-hooks/immutability
       element.style.transform = 'scaleX(1)';
     }
   }, [element, mirrorSelfView]);

--- a/frontend/src/components/WaitingRoom/MirrorSelfViewButton/MirrorSelfViewButton.tsx
+++ b/frontend/src/components/WaitingRoom/MirrorSelfViewButton/MirrorSelfViewButton.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next';
 import Tooltip from '@mui/material/Tooltip';
 import { VIDEO_CONTAINER_BUTTON_SIZE_WR } from '@utils/constants';
 import VideoContainerButton from '../VideoContainerButton';
-import useUserContext from '../../../hooks/useUserContext';
-import { setStorageItem, STORAGE_KEYS } from '../../../utils/storage';
+import useUserContext from '@hooks/useUserContext';
+import { setStorageItem, STORAGE_KEYS } from '@utils/storage';
 
 /**
  * MirrorSelfViewButton Component

--- a/frontend/src/components/WaitingRoom/MirrorSelfViewButton/MirrorSelfViewButton.tsx
+++ b/frontend/src/components/WaitingRoom/MirrorSelfViewButton/MirrorSelfViewButton.tsx
@@ -1,9 +1,7 @@
 import { ReactElement } from 'react';
 import FlipIcon from '@mui/icons-material/Flip';
 import { useTranslation } from 'react-i18next';
-import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
-import useTheme from '@ui/theme';
 import { VIDEO_CONTAINER_BUTTON_SIZE_WR } from '@utils/constants';
 import VideoContainerButton from '../VideoContainerButton';
 import useUserContext from '../../../hooks/useUserContext';
@@ -18,7 +16,6 @@ import { setStorageItem, STORAGE_KEYS } from '../../../utils/storage';
  */
 const MirrorSelfViewButton = (): ReactElement => {
   const { t } = useTranslation();
-  const theme = useTheme();
   const { user, setUser } = useUserContext();
   const isMirrored = user.defaultSettings.mirrorSelfView;
 
@@ -35,14 +32,11 @@ const MirrorSelfViewButton = (): ReactElement => {
   };
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
+    <div
+      className="flex items-center justify-center overflow-hidden rounded-full border border-vera-on-secondary"
+      style={{
         width: `${VIDEO_CONTAINER_BUTTON_SIZE_WR}px`,
         height: `${VIDEO_CONTAINER_BUTTON_SIZE_WR}px`,
-        borderRadius: '50%',
-        border: `1px solid ${theme.colors.onSecondary}`,
-        overflow: 'hidden',
       }}
     >
       <Tooltip
@@ -52,23 +46,17 @@ const MirrorSelfViewButton = (): ReactElement => {
       >
         <VideoContainerButton
           onClick={handleToggle}
-          sx={{
-            '&:hover': {
-              backgroundColor: `${theme.colors.onSecondary}99`,
-            },
-          }}
+          aria-label={t('devices.video.mirrorSelfView')}
+          className="hover:bg-vera-on-secondary/60 focus-visible:outline-none"
           icon={
             <FlipIcon
-              sx={{
-                fontSize: '24px',
-                color: isMirrored ? theme.colors.accent : theme.colors.onSecondary,
-              }}
+              className={`h-6 w-6 ${isMirrored ? 'text-vera-accent' : 'text-vera-on-secondary'}`}
               data-testid="mirror-self-view-icon"
             />
           }
         />
       </Tooltip>
-    </Box>
+    </div>
   );
 };
 

--- a/frontend/src/components/WaitingRoom/MirrorSelfViewButton/MirrorSelfViewButton.tsx
+++ b/frontend/src/components/WaitingRoom/MirrorSelfViewButton/MirrorSelfViewButton.tsx
@@ -1,0 +1,75 @@
+import { ReactElement } from 'react';
+import FlipIcon from '@mui/icons-material/Flip';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
+import useTheme from '@ui/theme';
+import { VIDEO_CONTAINER_BUTTON_SIZE_WR } from '@utils/constants';
+import VideoContainerButton from '../VideoContainerButton';
+import useUserContext from '../../../hooks/useUserContext';
+import { setStorageItem, STORAGE_KEYS } from '../../../utils/storage';
+
+/**
+ * MirrorSelfViewButton Component
+ *
+ * Displays a badge-style icon button in the upper-right of the waiting room video tile
+ * that toggles horizontal mirroring of the self-view. The preference is persisted in localStorage.
+ * @returns {ReactElement} The MirrorSelfViewButton component.
+ */
+const MirrorSelfViewButton = (): ReactElement => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const { user, setUser } = useUserContext();
+  const isMirrored = user.defaultSettings.mirrorSelfView;
+
+  const handleToggle = () => {
+    const newValue = !isMirrored;
+    setStorageItem(STORAGE_KEYS.MIRROR_SELF_VIEW, String(newValue));
+    setUser((prev) => ({
+      ...prev,
+      defaultSettings: {
+        ...prev.defaultSettings,
+        mirrorSelfView: newValue,
+      },
+    }));
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        width: `${VIDEO_CONTAINER_BUTTON_SIZE_WR}px`,
+        height: `${VIDEO_CONTAINER_BUTTON_SIZE_WR}px`,
+        borderRadius: '50%',
+        border: `1px solid ${theme.colors.onSecondary}`,
+        overflow: 'hidden',
+      }}
+    >
+      <Tooltip
+        arrow
+        title={t('devices.video.mirrorSelfView')}
+        aria-label={t('devices.video.mirrorSelfView')}
+      >
+        <VideoContainerButton
+          onClick={handleToggle}
+          sx={{
+            '&:hover': {
+              backgroundColor: `${theme.colors.onSecondary}99`,
+            },
+          }}
+          icon={
+            <FlipIcon
+              sx={{
+                fontSize: '24px',
+                color: isMirrored ? theme.colors.accent : theme.colors.onSecondary,
+              }}
+              data-testid="mirror-self-view-icon"
+            />
+          }
+        />
+      </Tooltip>
+    </Box>
+  );
+};
+
+export default MirrorSelfViewButton;

--- a/frontend/src/components/WaitingRoom/MirrorSelfViewButton/index.tsx
+++ b/frontend/src/components/WaitingRoom/MirrorSelfViewButton/index.tsx
@@ -1,0 +1,3 @@
+import MirrorSelfViewButton from './MirrorSelfViewButton';
+
+export default MirrorSelfViewButton;

--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
@@ -52,8 +52,11 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
   useEffect(() => {
     if (!publisherVideoElement) return;
 
+    // The SDK mirrors the preview publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).
+    // When mirror is ON, clear the inline style so the SDK's CSS class takes effect.
+    // When mirror is OFF, set scaleX(1) to override and cancel the SDK's mirror.
     // eslint-disable-next-line react-hooks/immutability
-    publisherVideoElement.style.transform = mirrorSelfView ? 'none' : 'scaleX(-1)';
+    publisherVideoElement.style.transform = mirrorSelfView ? '' : 'scaleX(1)';
   }, [publisherVideoElement, mirrorSelfView]);
 
   return (

--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
@@ -44,6 +44,8 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
   useEffect(() => {
     if (!publisherVideoElement) return;
 
+    // Vonage/OT injects the video element with object-fit=contain by default, which leaves letterboxing
+    // inside our 16:9 tile. We set cover here so the preview fills the tile consistently.
     // eslint-disable-next-line react-hooks/immutability
     publisherVideoElement.style.objectFit = 'cover';
     containerRef.current!.appendChild(publisherVideoElement);
@@ -52,11 +54,21 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
   useEffect(() => {
     if (!publisherVideoElement) return;
 
+    const isSdkMirroring = publisherVideoElement.classList.contains('OT_mirrored');
     // The SDK mirrors the preview publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).
-    // When mirror is ON, clear the inline style so the SDK's CSS class takes effect.
+    // When mirror is ON, prefer the SDK class; fall back to an inline mirror if the class is absent.
     // When mirror is OFF, set scaleX(1) to override and cancel the SDK's mirror.
-    // eslint-disable-next-line react-hooks/immutability
-    publisherVideoElement.style.transform = mirrorSelfView ? '' : 'scaleX(1)';
+    if (mirrorSelfView) {
+      if (isSdkMirroring) {
+        publisherVideoElement.style.removeProperty('transform');
+      } else {
+        // eslint-disable-next-line react-hooks/immutability
+        publisherVideoElement.style.transform = 'scaleX(-1)';
+      }
+    } else {
+      // eslint-disable-next-line react-hooks/immutability
+      publisherVideoElement.style.transform = 'scaleX(1)';
+    }
   }, [publisherVideoElement, mirrorSelfView]);
 
   return (

--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
@@ -44,7 +44,7 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
   useEffect(() => {
     if (!publisherVideoElement) return;
 
-    // Vonage/OT injects the video element with object-fit=contain by default, which leaves letterboxing
+    // Vonage/OT injects the video element with object-fit=contain by default, which leaves black bars
     // inside our 16:9 tile. We set cover here so the preview fills the tile consistently.
     // eslint-disable-next-line react-hooks/immutability
     publisherVideoElement.style.objectFit = 'cover';
@@ -66,7 +66,6 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
         publisherVideoElement.style.transform = 'scaleX(-1)';
       }
     } else {
-      // eslint-disable-next-line react-hooks/immutability
       publisherVideoElement.style.transform = 'scaleX(1)';
     }
   }, [publisherVideoElement, mirrorSelfView]);

--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
@@ -42,17 +42,16 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
   const { mirrorSelfView } = user.defaultSettings;
 
   useEffect(() => {
-    if (!publisherVideoElement) return;
+    if (!publisherVideoElement || !containerRef.current) return;
 
     // Vonage/OT injects the video element with object-fit=contain by default, which leaves black bars
     // inside our 16:9 tile. We set cover here so the preview fills the tile consistently.
     // eslint-disable-next-line react-hooks/immutability
     publisherVideoElement.style.objectFit = 'cover';
-    containerRef.current!.appendChild(publisherVideoElement);
-  }, [publisherVideoElement]);
 
-  useEffect(() => {
-    if (!publisherVideoElement) return;
+    if (!containerRef.current.contains(publisherVideoElement)) {
+      containerRef.current.appendChild(publisherVideoElement);
+    }
 
     const isSdkMirroring = publisherVideoElement.classList.contains('OT_mirrored');
     // The SDK mirrors the preview publisher via .OT_mirrored (scale(-1, 1) on .OT_video-element).

--- a/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainer/VideoContainer.tsx
@@ -11,6 +11,7 @@ import VoiceIndicatorIcon from '../../MeetingRoom/VoiceIndicator/VoiceIndicator'
 import VignetteEffect from '../VignetteEffect';
 import BackgroundEffectsDialog from '../BackgroundEffects/BackgroundEffectsDialog';
 import BackgroundEffectsButton from '../BackgroundEffects/BackgroundEffectsButton';
+import MirrorSelfViewButton from '../MirrorSelfViewButton';
 import backgroundEffectsDialog$ from '@Context/BackgroundEffectsDialog';
 import PrecallNetworkTestDialog from '../PrecallNetworkTestDialog';
 import precallNetworkTestDialog$ from '@Context/PrecallNetworkTestDialog';
@@ -38,12 +39,22 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
   const { publisherVideoElement, isVideoEnabled, isAudioEnabled, speechLevel, isVideoLoading } =
     usePreviewPublisherContext();
   const initials = getInitials(username);
+  const { mirrorSelfView } = user.defaultSettings;
 
   useEffect(() => {
     if (!publisherVideoElement) return;
 
+    // eslint-disable-next-line react-hooks/immutability
+    publisherVideoElement.style.objectFit = 'cover';
     containerRef.current!.appendChild(publisherVideoElement);
   }, [publisherVideoElement]);
+
+  useEffect(() => {
+    if (!publisherVideoElement) return;
+
+    // eslint-disable-next-line react-hooks/immutability
+    publisherVideoElement.style.transform = mirrorSelfView ? 'none' : 'scaleX(-1)';
+  }, [publisherVideoElement, mirrorSelfView]);
 
   return (
     <div
@@ -61,8 +72,6 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
         className={classNames(
           'child:mx-auto',
           'child:animate-[fade-in_.6s_linear]',
-          'child:-scale-x-100',
-          'child:object-contain',
           'child:aspect-video',
           'child:w-dvw',
           'child:rounded-none',
@@ -100,7 +109,8 @@ const VideoContainer = ({ username }: VideoContainerProps): ReactElement => {
             <MicButton />
             <CameraButton />
           </div>
-          <div className="absolute right-5">
+          <div className="absolute right-5 flex flex-row gap-2">
+            <MirrorSelfViewButton />
             <BackgroundEffectsButton onClick={open} />
             {isBackgroundEffectsOpen && (
               <BackgroundEffectsDialog

--- a/frontend/src/components/WaitingRoom/VideoContainerButton/VideoContainerButton.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainerButton/VideoContainerButton.tsx
@@ -1,10 +1,12 @@
 import IconButton from '@mui/material/IconButton';
 import type { SxProps } from '@mui/material';
+import classNames from 'classnames';
 import { ForwardedRef, forwardRef, ReactElement } from 'react';
 
 export type VideoContainerButtonProps = {
   onClick: () => void;
   icon: ReactElement;
+  className?: string;
   sx?: SxProps;
 };
 
@@ -22,17 +24,14 @@ const VideoContainerButton = forwardRef(function VideoContainerButton(
   props: VideoContainerButtonProps,
   ref: ForwardedRef<HTMLButtonElement>
 ): ReactElement {
-  const { icon: Icon, sx = {}, ...rest } = props;
+  const { icon: Icon, sx, className, ...rest } = props;
   return (
     <IconButton
       {...rest}
       data-testid="video-container-button"
       ref={ref}
-      sx={{
-        height: '100%',
-        width: '100%',
-        ...sx,
-      }}
+      className={classNames('h-full w-full p-0', className)}
+      sx={sx}
     >
       {Icon}
     </IconButton>

--- a/frontend/src/components/WaitingRoom/VideoContainerButton/VideoContainerButton.tsx
+++ b/frontend/src/components/WaitingRoom/VideoContainerButton/VideoContainerButton.tsx
@@ -30,7 +30,7 @@ const VideoContainerButton = forwardRef(function VideoContainerButton(
       {...rest}
       data-testid="video-container-button"
       ref={ref}
-      className={classNames('h-full w-full p-0', className)}
+      className={classNames('!h-full !w-full !p-0', className)}
       sx={sx}
     >
       {Icon}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -90,6 +90,7 @@
   "devices.video.disable": "Video deaktivieren",
   "devices.video.disabled": "Kamerasteuerung ist in dieser Anwendung deaktiviert",
   "devices.video.enable": "Video aktivieren",
+  "devices.video.mirrorSelfView": "Selbstansicht spiegeln",
   "emoji.ariaLabel": "Emoji-Menü öffnen",
   "emoji.tooltip": "Drücken Sie sich aus",
   "errors.unknown": "Unbekannter Fehler aufgetreten",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -90,6 +90,7 @@
   "devices.video.disable": "Disable video",
   "devices.video.disabled": "Camera control is disabled in this application",
   "devices.video.enable": "Enable video",
+  "devices.video.mirrorSelfView": "Mirror Self View",
   "emoji.ariaLabel": "open sendable emoji menu",
   "emoji.tooltip": "Express yourself",
   "errors.unknown": "Unknown error occurred",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -88,6 +88,7 @@
   "devices.video.camera.full": "Cámara",
   "devices.video.disable": "Apagar video",
   "devices.video.enable": "Encender video",
+  "devices.video.mirrorSelfView": "Espejo de vista propia",
   "emoji.ariaLabel": "abrir menú de emojis",
   "emoji.tooltip": "Exprésate",
   "errors.unknown": "Ocurrió un error desconocido",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -88,6 +88,7 @@
   "devices.video.camera.full": "Cámara",
   "devices.video.disable": "Desactivar video",
   "devices.video.enable": "Activar video",
+  "devices.video.mirrorSelfView": "Espejo de vista propia",
   "emoji.ariaLabel": "abrir menú de emojis",
   "emoji.tooltip": "Exprésate",
   "errors.unknown": "Ocurrió un error desconocido",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -88,6 +88,7 @@
   "devices.video.camera.full": "Camera",
   "devices.video.disable": "Disattiva video",
   "devices.video.enable": "Attiva video",
+  "devices.video.mirrorSelfView": "Mirroring del tuo video",
   "emoji.ariaLabel": "apri menu emoji",
   "emoji.tooltip": "Esprimiti",
   "errors.unknown": "Errore sconosciuto",

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -7,6 +7,7 @@ export const STORAGE_KEYS = {
   BACKGROUND_REPLACEMENT: 'backgroundReplacement',
   USERNAME: 'username',
   BACKGROUND_IMAGE: 'userBackgroundImage',
+  MIRROR_SELF_VIEW: 'mirrorSelfView',
 };
 
 export const setStorageItem = (key: string, value: string) => {


### PR DESCRIPTION
Hi team! 👋

Resolves [VIDSOL-619](https://jira.vonage.com/browse/VIDSOL-619)

#### Checklist
- [x] Branch is based on `develop` (not `main`).
- [ ] Resolves a `Known Issue`.
- [ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`?
- [ ] Resolves an item reported in `Issues`.

#### What is this PR doing?

Adds a Mirror Self View toggle so users can choose whether their preview is mirrored. Default is ON (mirrored) and
  persisted in localStorage.

  Where it appears:

   - Waiting room: flip icon button on the self-view tile
   - Meeting room: toggle item in the camera device dropdown

  Mirror behavior:

   - mirrorSelfView = true: use the SDK’s .OT_mirrored CSS when present; if the SDK isn’t mirroring, fall back to 
  scaleX(-1) inline.
   - mirrorSelfView = false: force scaleX(1) to cancel any mirroring (SDK or inline).

  Styling refactor:

   - Mirror controls and device menu now use Tailwind with Vera tokens (no MUI sx).

  Manual test notes remain the same; ensure toggles update immediately and persist on refresh across browsers.

**Mirror logic:**
| `mirrorSelfView` | Transform applied |
|---|---|
| `true` (default) | `none` — the SDK's `.OT_mirrored` class handles the flip |
| `false` | `scaleX(-1)` — cancels the SDK mirror |

**Changes:**
- `storage.ts` — Added `MIRROR_SELF_VIEW` key
- `user.tsx` — Added `mirrorSelfView: boolean` to `UserContext` / `UserProvider`, loaded from `localStorage`
- `MirrorSelfViewButton.tsx` *(new)* — Waiting room icon button
- `MirrorSelfViewToggle.tsx` *(new)* — Conference room toggle menu item
- `VideoContainer.tsx` — Replaced static Tailwind `child:-scale-x-100` with reactive `useEffect`; added `MirrorSelfViewButton`
- `Publisher.tsx` — Dynamic transform via `useEffect`; `objectFit: cover`
- `BackgroundVideoContainer.tsx` — Dynamic transform + `objectFit: cover`
- `en.json`, `es.json`, `es-MX.json`, `it.json` — Added `devices.video.mirrorSelfView` i18n key
- `user.spec.tsx`, `BackgroundVideoContainer.spec.tsx`, `DeviceSettingsMenu.spec.tsx` — Updated tests

#### How should this be manually tested?

**Waiting room:**
1. Open the app and enter the waiting room
2. Locate the flip icon button in the upper-right corner of the self-view video tile
3. Click it — your self-view should switch from mirrored to un-mirrored (and back)
4. Refresh the page and verify the last setting is remembered

**Conference room:**
1. Join a call and click the camera device dropdown (chevron next to the camera button)
2. Verify **"Mirror Self View"** toggle is visible at the bottom of the dropdown
3. Click it — your publisher video should update immediately
4. Verify the toggle is visible in **Safari** and **Firefox** (not gated by video effects support)

**Tested on macOS Tahoe 26.3 (arm64):**

| Browser | Waiting room toggle | Conference room toggle | Persistence |
|---------|:---:|:---:|:---:|
| Chrome 145 | ✅ | ✅ | ✅ |
| Safari 26.3 | ✅ | ✅ | ✅ |
| Firefox 148.0 | ✅ | ✅ (camera list empty — pre-existing bug, see comments) | ✅ |


Instructions for Testing

Setup:

   - Use Node
    22.
   - Backend .env set (provider + keys) so sessions start.

  Waiting room:

   1. Load waiting room.
   2. Click mirror button (top-right of self-view).
    - ON → video mirrored. OFF → unmirrored.
   3. Refresh: last setting persists.
   4. Ensure button hover/focus uses Vera tokens (no default MUI colors).

  Meeting room:

   1. Join a call, open camera device dropdown.
   2. Toggle “Mirror Self View”.
    - ON → mirrored; OFF → unmirrored.
   3. Switch the toggle multiple times; video updates immediately.
   4. Verify dropdown styling matches Tailwind/Vera tokens.

  Fallback:

   - If SDK doesn’t apply .OT_mirrored, ON still mirrors via scaleX(-1); OFF forces scaleX(1).

  Cross-browser:

   - Chrome, Safari, Firefox: confirm toggle visibility and behavior; Safari/Firefox should show the dropdown item.

  Persistence:

   - Toggle in meeting room, rejoin or reload; setting remains.

  Regression:

   - Background effects preview respects mirror toggle.
   - Publisher/preview still object-fit cover (no letterboxing).

---
> ♻️ Replaces #390 (reopened from upstream branch to enable VCR deploy)
