### PR TITLE
VIDSOL-643: Add media device label translation support

### DIFF
--- a/frontend/src/components/MeetingRoom/InputAudioDevices/InputAudioDevices.tsx
+++ b/frontend/src/components/MeetingRoom/InputAudioDevices/InputAudioDevices.tsx
@@ -5,6 +5,7 @@ import useTheme from '@ui/theme';
 import VividIcon from '@components/VividIcon';
 import { useDistinctLabelMediaDevices } from '@ui/hooks';
 import mediaDevices$ from '@core/stores/devices';
+import translateMediaDeviceLabel from '@utils/translateMediaDeviceLabel/translateMediaDeviceLabel';
 import { env } from '../../../env';
 
 export type InputAudioDevicesProps = {
@@ -20,17 +21,25 @@ export type InputAudioDevicesProps = {
  * @returns {ReactElement | false} - The InputAudioDevices component.
  */
 const InputAudioDevices = ({ handleToggle }: InputAudioDevicesProps): ReactElement | false => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const theme = useTheme();
 
   // Use store's selection as source of truth, not publisher.getAudioSource() which can be stale
   const selectedDeviceId = mediaDevices$.useDeviceId('audioinput');
 
-  const audioInputDevices = useDistinctLabelMediaDevices('audioinput', (devices) =>
-    devices.map((device) => ({
-      ...device,
-      label: device.label || t('unknown.device'),
-    }))
+  const audioInputDevices = useDistinctLabelMediaDevices(
+    'audioinput',
+    (devices) =>
+      devices.map((device) => ({
+        ...device,
+        label: device.label
+          ? translateMediaDeviceLabel({
+              label: device.label,
+              translate: t,
+            })
+          : t('unknown.device'),
+      })),
+    [i18n.language]
   );
 
   const handleChangeAudioSource = (deviceId: string) => {

--- a/frontend/src/components/MeetingRoom/OutputAudioDevices/OutputAudioDevices.tsx
+++ b/frontend/src/components/MeetingRoom/OutputAudioDevices/OutputAudioDevices.tsx
@@ -12,6 +12,7 @@ import { isSinkIdSupported } from '@web/platform';
 import mediaDevices$ from '@core/stores/devices';
 import useTheme from '@ui/theme';
 import { Tooltip } from '@mui/material';
+import translateMediaDeviceLabel from '@utils/translateMediaDeviceLabel/translateMediaDeviceLabel';
 import { env } from '../../../env';
 
 export type OutputAudioDevicesProps = {
@@ -27,20 +28,28 @@ export type OutputAudioDevicesProps = {
  * @returns {ReactElement | false} - The OutputAudioDevices component.
  */
 const OutputAudioDevices = ({ handleToggle }: OutputAudioDevicesProps): ReactElement | false => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const theme = useTheme();
 
   const currentAudioOutputId = mediaDevices$.useDeviceId('audiooutput');
 
-  const availableDevices = useDistinctLabelMediaDevices('audiooutput', (devices) =>
-    isSinkIdSupported()
-      ? devices.map((device) =>
-          // Rename default audio output device to user-friendly label
-          device.deviceId === 'default'
-            ? { ...device, label: t('devices.audio.defaultLabel') }
-            : device
-        )
-      : [{ deviceId: 'default', label: t('devices.audio.defaultLabel') } as MediaDeviceInfoJSON]
+  const availableDevices = useDistinctLabelMediaDevices(
+    'audiooutput',
+    (devices) =>
+      isSinkIdSupported()
+        ? devices.map((device) =>
+            device.deviceId === 'default'
+              ? { ...device, label: t('devices.audio.defaultLabel') }
+              : {
+                  ...device,
+                  label: translateMediaDeviceLabel({
+                    label: device.label,
+                    translate: t,
+                  }),
+                }
+          )
+        : [{ deviceId: 'default', label: t('devices.audio.defaultLabel') } as MediaDeviceInfoJSON],
+    [i18n.language]
   );
 
   const handleChangeAudioOutput = async (deviceId: string) => {

--- a/frontend/src/components/MeetingRoom/VideoDevices/VideoDevices.tsx
+++ b/frontend/src/components/MeetingRoom/VideoDevices/VideoDevices.tsx
@@ -5,6 +5,7 @@ import { Box, Typography, MenuList, MenuItem, Tooltip, BoxProps } from '@mui/mat
 import VividIcon from '@components/VividIcon';
 import { useDistinctLabelMediaDevices } from '@ui/hooks';
 import mediaDevices$ from '@core/stores/devices';
+import translateMediaDeviceLabel from '@utils/translateMediaDeviceLabel/translateMediaDeviceLabel';
 import { env } from '../../../env';
 
 export type VideoDevicesProps = BoxProps & {
@@ -24,17 +25,25 @@ const VideoDevices = ({
   className,
   ...boxProps
 }: VideoDevicesProps): ReactElement | false => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const theme = useTheme();
 
   // Use store's selection as source of truth, not publisher.getVideoSource() which can be stale
   const selectedDeviceId = mediaDevices$.useDeviceId('videoinput');
 
-  const devicesAvailable = useDistinctLabelMediaDevices('videoinput', (devices) =>
-    devices.map((device) => ({
-      ...device,
-      label: device.label ?? t('unknown.device'),
-    }))
+  const devicesAvailable = useDistinctLabelMediaDevices(
+    'videoinput',
+    (devices) =>
+      devices.map((device) => ({
+        ...device,
+        label: device.label
+          ? translateMediaDeviceLabel({
+              label: device.label,
+              translate: t,
+            })
+          : t('unknown.device'),
+      })),
+    [i18n.language]
   );
 
   const handleChangeVideoSource = (deviceId: string) => {

--- a/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.tsx
+++ b/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.tsx
@@ -1,9 +1,11 @@
 import { ReactElement, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
 import VividIcon from '@components/VividIcon';
 import Box from '@mui/material/Box';
 import cleanAndDedupeDeviceLabels from '@utils/cleanAndDedupeDeviceLabels/cleanAndDedupeDeviceLabels';
+import translateMediaDeviceLabel from '@utils/translateMediaDeviceLabel/translateMediaDeviceLabel';
 import SoundTest from '../../SoundTest';
 import { isGetActiveAudioOutputDeviceSupported } from '@utils/util';
 import mediaDevices$ from '@core/stores/devices';
@@ -37,6 +39,7 @@ const MenuDevices = ({
   anchorEl,
   deviceChangeHandler,
 }: MenuDevicesWaitingRoomProps): ReactElement => {
+  const { t } = useTranslation();
   const devices = mediaDevices$.useMediaDevices(mediaDeviceKind, Object.values<MediaDeviceInfo>);
 
   const localSource = mediaDevices$.useDeviceId(mediaDeviceKind);
@@ -46,7 +49,19 @@ const MenuDevices = ({
     onClose();
   };
 
-  const processedDevices = useMemo(() => cleanAndDedupeDeviceLabels(devices), [devices]);
+  const processedDevices = useMemo(
+    () =>
+      cleanAndDedupeDeviceLabels(devices).map((device) => ({
+        ...device,
+        label: device.label
+          ? translateMediaDeviceLabel({
+              label: device.label,
+              translate: t,
+            })
+          : device.label,
+      })),
+    [devices, t]
+  );
 
   return (
     <Menu

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -70,6 +70,8 @@
   "devices.audio.disable": "Mikrofon deaktivieren",
   "devices.audio.disabled": "Mikrofonsteuerung ist in dieser Anwendung deaktiviert",
   "devices.audio.enable": "Mikrofon aktivieren oder Leertaste halten, um vorübergehend stummschaltung aufzuheben",
+  "devices.label.builtIn": "Integriert",
+  "devices.label.defaultPrefix": "Standard",
   "devices.audio.microphone.ariaLabel": "Audio umschalten",
   "devices.audio.microphone.full": "Mikrofon",
   "devices.audio.microphone.short": "Mikro",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -70,6 +70,8 @@
   "devices.audio.disable": "Disable microphone",
   "devices.audio.disabled": "Microphone control is disabled in this application",
   "devices.audio.enable": "Enable microphone or hold Space to temporarily unmute",
+  "devices.label.builtIn": "Built-in",
+  "devices.label.defaultPrefix": "Default",
   "devices.audio.microphone.ariaLabel": "toggle audio",
   "devices.audio.microphone.full": "Microphone",
   "devices.audio.microphone.short": "Mic",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -69,6 +69,8 @@
   "devices.audio.defaultLabel": "Predeterminado del sistema",
   "devices.audio.disable": "Apagar micrófono",
   "devices.audio.enable": "Encender micrófono o mantén presionada la barra espaciadora para activar temporalmente el micrófono",
+  "devices.label.builtIn": "Integrado",
+  "devices.label.defaultPrefix": "Predeterminado",
   "devices.audio.microphone.ariaLabel": "activar/desactivar audio",
   "devices.audio.microphone.full": "Micrófono",
   "devices.audio.microphone.short": "Mic",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -69,6 +69,8 @@
   "devices.audio.defaultLabel": "Predeterminado del sistema",
   "devices.audio.disable": "Desactivar micrófono",
   "devices.audio.enable": "Activar micrófono o mantén presionada la barra espaciadora para activar temporalmente el micrófono",
+  "devices.label.builtIn": "Integrado",
+  "devices.label.defaultPrefix": "Predeterminado",
   "devices.audio.microphone.ariaLabel": "alternar audio",
   "devices.audio.microphone.full": "Micrófono",
   "devices.audio.microphone.short": "Mic",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -69,6 +69,8 @@
   "devices.audio.defaultLabel": "Predefinito sistema",
   "devices.audio.disable": "Disattiva microfono",
   "devices.audio.enable": "Attiva il microfono o tieni premuta la barra spaziatrice per attivarlo temporaneamente",
+  "devices.label.builtIn": "Integrato",
+  "devices.label.defaultPrefix": "Predefinito",
   "devices.audio.microphone.ariaLabel": "attiva/disattiva audio",
   "devices.audio.microphone.full": "Microfono",
   "devices.audio.microphone.short": "Mic",

--- a/frontend/src/utils/translateMediaDeviceLabel/translateMediaDeviceLabel.spec.ts
+++ b/frontend/src/utils/translateMediaDeviceLabel/translateMediaDeviceLabel.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import translateMediaDeviceLabel from './translateMediaDeviceLabel';
+
+describe('translateMediaDeviceLabel', () => {
+  it('translates the default prefix and built-in suffix', () => {
+    const translatedLabel = translateMediaDeviceLabel({
+      label: 'Default - MacBook Pro Microphone (Built in)',
+      translate: makeTranslate({
+        'devices.label.builtIn': 'Integrado',
+        'devices.label.defaultPrefix': 'Predeterminado',
+      }),
+    });
+
+    expect(translatedLabel).toBe('Predeterminado - MacBook Pro Microphone (Integrado)');
+  });
+
+  it('translates the hyphenated built-in label variant', () => {
+    const translatedLabel = translateMediaDeviceLabel({
+      label: 'MacBook Pro Speakers (Built-in)',
+      translate: makeTranslate({
+        'devices.label.builtIn': 'Integrato',
+        'devices.label.defaultPrefix': 'Predefinito',
+      }),
+    });
+
+    expect(translatedLabel).toBe('MacBook Pro Speakers (Integrato)');
+  });
+
+  it('leaves unrelated labels unchanged', () => {
+    const translatedLabel = translateMediaDeviceLabel({
+      label: 'USB Headset Microphone',
+      translate: makeTranslate({
+        'devices.label.builtIn': 'Integrado',
+        'devices.label.defaultPrefix': 'Predeterminado',
+      }),
+    });
+
+    expect(translatedLabel).toBe('USB Headset Microphone');
+  });
+});
+
+function makeTranslate(translations: Record<string, string>) {
+  return (key: string): string => translations[key] ?? key;
+}

--- a/frontend/src/utils/translateMediaDeviceLabel/translateMediaDeviceLabel.ts
+++ b/frontend/src/utils/translateMediaDeviceLabel/translateMediaDeviceLabel.ts
@@ -1,0 +1,16 @@
+type TranslateMediaDeviceLabelArgs = {
+  label: string;
+  translate: (key: string) => string;
+};
+
+const translateMediaDeviceLabel = ({ label, translate }: TranslateMediaDeviceLabelArgs): string => {
+  if (!label) {
+    return label;
+  }
+
+  return label
+    .replace(/^Default\b/iu, translate('devices.label.defaultPrefix'))
+    .replace(/\bBuilt(?:-|\s)in\b/giu, translate('devices.label.builtIn'));
+};
+
+export default translateMediaDeviceLabel;


### PR DESCRIPTION
#### What is this PR doing?
This PR fixes that by switching languages on a waiting room not all words were translated from the context drop down lists.

#### How should this be manually tested?
Change languages and check devices are properly translated.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-643](https://jira.vonage.com/browse/VIDSOL-643)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
