### PR TITLE
VIDSOL-671: Dependendcy for Android and IOS logger. Adds Batch JSON Log Upload

### DIFF
--- a/backend/routes/logger.ts
+++ b/backend/routes/logger.ts
@@ -7,15 +7,14 @@ import { makeBadRequestErrorHandler } from '@api-lib/errors';
 
 const loggerRouter = Router();
 
-/** JSON body parser with 50kb limit (logger route only; avoids large payloads). */
-loggerRouter.use(express.json({ limit: '50kb' }));
-
 /**
  * Backend logging endpoint. Validates the payload and forwards to Kibana when configured.
  * For EnterMeeting events, also sends the OTKAnalytics-formatted log.
  * Fails fast on data violation. Returns 204 No Content on success.
+ *
+ * 50kb limit only
  */
-loggerRouter.post('/', (req: Request, res: Response) => {
+loggerRouter.post('/', express.json({ limit: '50kb' }), (req: Request, res: Response) => {
   const parsed = ClientLogEventSchema.safeParse(req.body);
 
   if (!parsed.success) {
@@ -26,6 +25,28 @@ loggerRouter.post('/', (req: Request, res: Response) => {
 
   const event = parsed.data;
   attempt(() => forward(event), console.error);
+
+  return res.sendStatus(204);
+});
+
+/**
+ * Batch logging endpoint. Accepts a JSON array of log events and processes each one.
+ * Fails fast on the first data violation. Returns 204 No Content on success.
+ *
+ * 50mb limit only
+ */
+loggerRouter.post('/batch', express.json({ limit: '50mb' }), (req: Request, res: Response) => {
+  const parsed = ClientLogEventSchema.array().safeParse(req.body);
+
+  if (!parsed.success) {
+    const validationError = makeBadRequestErrorHandler('Invalid log batch payload')(parsed.error);
+
+    return res.status(StatusCode.ClientErrorBadRequest).json(validationError.exportSafely());
+  }
+
+  for (const event of parsed.data) {
+    attempt(() => forward(event), console.error);
+  }
 
   return res.sendStatus(204);
 });

--- a/backend/tests/logger.test.ts
+++ b/backend/tests/logger.test.ts
@@ -160,3 +160,112 @@ describe('POST /client-logs', () => {
     );
   });
 });
+
+describe('POST /client-logs/batch', () => {
+  let server: Server;
+  const mockPost = jest.spyOn(axios, 'post');
+
+  beforeAll(async () => {
+    server = await startServer(0);
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  beforeEach(() => {
+    mockPost.mockClear();
+    mockPost.mockResolvedValue({ status: 200 });
+  });
+
+  it('returns 204 and forwards each event in a valid batch', async () => {
+    const batch = [
+      createValidLogPayload({
+        action: 'vonageVideoClient.connect.success',
+        sessionId: 's1',
+        connectionId: 'c1',
+      }),
+      createValidLogPayload({ action: 'EnterMeeting', sessionId: 's2', connectionId: 'c2' }),
+    ];
+
+    const res = await request(server)
+      .post('/client-logs/batch')
+      .set('Content-Type', 'application/json')
+      .send(batch);
+
+    expect(res.statusCode).toEqual(204);
+    expect(mockPost).toHaveBeenCalledTimes(batch.length);
+  });
+
+  it('returns 400 when one event in the batch is invalid', async () => {
+    const batch = [
+      createValidLogPayload(),
+      { action: 'SomeAction' }, // missing required fields
+    ];
+
+    const res = await request(server)
+      .post('/client-logs/batch')
+      .set('Content-Type', 'application/json')
+      .send(batch);
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toMatchObject({
+      message: 'Invalid log batch payload',
+      severity: 'error',
+      statusCode: 400,
+      issues: expect.any(Array),
+    });
+    expect(res.body.issues.length).toBeGreaterThan(0);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when body is not an array', async () => {
+    const res = await request(server)
+      .post('/client-logs/batch')
+      .set('Content-Type', 'application/json')
+      .send(createValidLogPayload());
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toMatchObject({
+      message: 'Invalid log batch payload',
+      severity: 'error',
+      statusCode: 400,
+      issues: expect.any(Array),
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for empty body', async () => {
+    const res = await request(server)
+      .post('/client-logs/batch')
+      .set('Content-Type', 'application/json')
+      .send({});
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toMatchObject({
+      message: 'Invalid log batch payload',
+      severity: 'error',
+      statusCode: 400,
+      issues: expect.any(Array),
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when an event in the batch has an invalid level', async () => {
+    const batch = [createValidLogPayload(), createValidLogPayload({ level: 'debug' })];
+
+    const res = await request(server)
+      .post('/client-logs/batch')
+      .set('Content-Type', 'application/json')
+      .send(batch);
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toMatchObject({
+      message: 'Invalid log batch payload',
+      severity: 'error',
+      statusCode: 400,
+      issues: expect.any(Array),
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
#### What is this PR doing?
Adds `client-logs/batch` endpoint that works like client-logs but accepts an array of json instead of just one json object

#### How should this be manually tested?
Send  `[{"guid":"816747fa-a603-4af3-923f-3c9a424209c5","clientSystemTime":1774933720700,"level":"info","userAgent":"main","source":"PiP","action":"API does not support PiP"},{"guid":"816747fa-a603-4af3-923f-3c9a424209c6","clientSystemTime":1774933720702,"level":"error","userAgent":"main","source":"Opentok","action":"TEST ERROR"}]` to client-logs/batch

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-](https://jira.vonage.com/browse/VIDSOL-)

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
