### PR TITLE
VIDSOL-512: Hide SoundTest component when no audio output devices are available

### DIFF
--- a/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.spec.tsx
@@ -7,6 +7,8 @@ import { defaultAudioDevice } from '@utils/mockData/device';
 import usePublisherContext from '@hooks/usePublisherContext';
 import { PublisherContextType } from '@Context/PublisherProvider';
 import { makeTestProvider } from '@test/providers';
+import { makeMediaDeviceInfos } from '@web-test/fixtures';
+import { mediaDevices$ } from '@core/stores';
 import ReduceNoiseTestSpeakers from './ReduceNoiseTestSpeakers';
 import { env } from '../../../env';
 
@@ -26,6 +28,8 @@ describe('ReduceNoiseTestSpeakers', () => {
   let publisherContext: PublisherContextType;
 
   beforeEach(() => {
+    mediaDevices$.reset();
+
     // Mock HTMLMediaElement methods used by SoundTest component
     vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
     vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
@@ -140,6 +144,24 @@ describe('ReduceNoiseTestSpeakers', () => {
     render(<ReduceNoiseTestSpeakers />);
 
     expect(screen.queryByText('Advanced Noise Suppression')).not.toBeInTheDocument();
+  });
+
+  it('does not render the SoundTest if no audiooutput devices are available', () => {
+    mediaDevices$.reset();
+
+    render(<ReduceNoiseTestSpeakers />);
+
+    expect(screen.queryByTestId('soundTest')).not.toBeInTheDocument();
+  });
+
+  it('renders the SoundTest if audiooutput devices are available', () => {
+    const devices = makeMediaDeviceInfos();
+
+    mediaDevices$.setState((state) => ({ ...state, mediaDeviceInfo: devices }));
+
+    render(<ReduceNoiseTestSpeakers />);
+
+    expect(screen.getByTestId('soundTest')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
+++ b/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import useTheme from '@ui/theme';
 import usePublisherContext from '@hooks/usePublisherContext';
 import { setStorageItem, STORAGE_KEYS } from '@utils/storage';
+import { mediaDevices$ } from '@core/stores';
 import DropdownSeparator from '../DropdownSeparator';
 import SoundTest from '../../SoundTest';
 import MenuList from '@mui/material/MenuList';
@@ -30,6 +31,10 @@ const ReduceNoiseTestSpeakers = (): ReactElement | false => {
 
   const [isToggled, setIsToggled] = useState(false);
   const shouldDisplayANS = hasMediaProcessorSupport() && env.ALLOW_ADVANCED_NOISE_SUPPRESSION;
+  const hasSpeakerDevices = mediaDevices$.useMediaDevices(
+    'audiooutput',
+    (devices) => Object.values(devices).length > 0
+  );
 
   const handleToggle = async () => {
     const newState = !isToggled;
@@ -101,15 +106,17 @@ const ReduceNoiseTestSpeakers = (): ReactElement | false => {
             </IconButton>
           </MenuItem>
         )}
-        <SoundTest labelClassName="text-vera-body-extended">
-          <Box sx={{ mr: 1.5 }}>
-            <VividIcon
-              customSize={-5}
-              name="audio-mid-solid"
-              sx={{ color: theme.colors.secondary }}
-            />
-          </Box>
-        </SoundTest>
+        {hasSpeakerDevices && (
+          <SoundTest labelClassName="text-vera-body-extended">
+            <Box sx={{ mr: 1.5 }}>
+              <VividIcon
+                customSize={-5}
+                name="audio-mid-solid"
+                sx={{ color: theme.colors.secondary }}
+              />
+            </Box>
+          </SoundTest>
+        )}
       </MenuList>
     </>
   );

--- a/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.spec.tsx
+++ b/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.spec.tsx
@@ -110,6 +110,57 @@ describe('MenuDevices Component', () => {
     testDeviceKindRendering('videoinput');
   });
 
+  it('renders SoundTest when audiooutput devices are available', async () => {
+    vi.spyOn(util, 'isGetActiveAudioOutputDeviceSupported').mockReturnValue(true);
+
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+
+    const anchorEl = document.createElement('div');
+
+    render(
+      <MenuDevices
+        mediaDeviceKind="audiooutput"
+        onClose={vi.fn()}
+        open
+        anchorEl={anchorEl}
+        deviceChangeHandler={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('soundTest')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render SoundTest when no audiooutput devices are available', async () => {
+    vi.spyOn(util, 'isGetActiveAudioOutputDeviceSupported').mockReturnValue(true);
+
+    act(() => {
+      mediaDevices$.setState((state) => ({
+        ...state,
+        mediaDeviceInfo: someDevices.filter((d) => d.kind !== 'audiooutput'),
+        audiooutput: undefined,
+      }));
+    });
+
+    const anchorEl = document.createElement('div');
+
+    render(
+      <MenuDevices
+        mediaDeviceKind="audiooutput"
+        onClose={vi.fn()}
+        open
+        anchorEl={anchorEl}
+        deviceChangeHandler={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('soundTest')).not.toBeInTheDocument();
+    });
+  });
+
   it('renders an empty state when no devices are available', async () => {
     const mockOnClose = vi.fn();
     const mockDeviceChangeHandler = vi.fn();

--- a/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.tsx
+++ b/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.tsx
@@ -86,13 +86,18 @@ const MenuDevices = ({
         </MenuItem>
       )}
 
-      {mediaDeviceKind === 'audiooutput' && !shouldDisplayEmptyState && (
-        <SoundTest>
-          <Box sx={{ mr: 1 }}>
-            <VividIcon name="hearing-line" customSize={-5} />
-          </Box>
-        </SoundTest>
-      )}
+      {mediaDeviceKind === 'audiooutput' &&
+        (processedDevices.length > 0 ? (
+          <SoundTest>
+            <Box sx={{ mr: 1 }}>
+              <VividIcon name="hearing-line" customSize={-5} />
+            </Box>
+          </SoundTest>
+        ) : (
+          <MenuItem disabled data-testid={`${mediaDeviceKind}-menu-empty-state`}>
+            {t('waitingRoom.devices.noDevicesFound')}
+          </MenuItem>
+        ))}
     </Menu>
   );
 };


### PR DESCRIPTION
#### What is this PR doing?
Hide Test Speakers if no speakers are available.
<img width="666" height="398" alt="image" src="https://github.com/user-attachments/assets/9e9d9b5b-38cb-4f2e-bebf-5251826164bc" />


#### How should this be manually tested?
Try to not have any speaker device available.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-512](https://jira.vonage.com/browse/VIDSOL-512)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
