### PR TITLE
VIDSOL-689: Upgrade SDK to version 2.33.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@trpc/client": "^11.11.0",
     "@trpc/server": "^11.11.0",
     "@vonage/auth": "^1.13.1",
-    "@vonage/client-sdk-video": "2.32.1",
+    "@vonage/client-sdk-video": "^2.33.1",
     "@vonage/server-sdk": "3.25.1",
     "@vonage/vcr-sdk": "1.3.0",
     "@vonage/video": "1.26.1",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@trpc/client": "^11.11.0",
     "@trpc/server": "^11.11.0",
     "@vonage/auth": "^1.13.1",
-    "@vonage/client-sdk-video": "^2.33.1",
+    "@vonage/client-sdk-video": "2.33.1",
     "@vonage/server-sdk": "3.25.1",
     "@vonage/vcr-sdk": "1.3.0",
     "@vonage/video": "1.26.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5117,10 +5117,10 @@
     "@vonage/jwt" "1.13.0"
     debug "4.4.3"
 
-"@vonage/client-sdk-video@2.32.1":
-  version "2.32.1"
-  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.32.1.tgz#08aa4ea559648bdbdc69259194cfd1298565fa05"
-  integrity sha512-ko0KRVMbhIHNUR/WgskOD6H3stz702pq2yDeRZf9STNb4srp4MADb7KgleoHeLMNxxFU+ipDMr49xmygZn9rhA==
+"@vonage/client-sdk-video@^2.33.1":
+  version "2.33.1"
+  resolved "https://registry.yarnpkg.com/@vonage/client-sdk-video/-/client-sdk-video-2.33.1.tgz#cad91bc6f013c42e85b2ee75f86f57e5578536b4"
+  integrity sha512-Hm0TyKjtRU7WP5W+Jky3CYJULX7UP3hIDLe9YXmASbGLBZrjJas119RY/RhsR3nMhU8sTBee3dLaJ0kOtI7BYg==
 
 "@vonage/conversations@1.12.1":
   version "1.12.1"


### PR DESCRIPTION
#### What is this PR doing?
This pull request includes a minor dependency update in the `package.json` file, upgrading the `@vonage/client-sdk-video` package to a newer version. This helps ensure compatibility with the latest features and bug fixes.

#### How should this be manually tested?
Check everything works as expected.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-689](https://jira.vonage.com/browse/VIDSOL-689)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
