### PR TITLE
VIDSOL-642: /feedback/report 500 error  

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,3 +36,6 @@ VONAGE_PRIVATE_KEY=''
 # JIRA_TOKEN=jira-token
 # JIRA_PROJECT_KEY=jira-project-key
 # JIRA_COMPONENT_ID=jira-component-id
+# JIRA_EPIC_URL='jira-epic-url'
+# JIRA_EPIC_LINK='jira-epic-link'
+# JIRA_SEVERITY_ID='jira-severity-id'

--- a/backend/helpers/config.ts
+++ b/backend/helpers/config.ts
@@ -29,6 +29,7 @@ const loadConfig = (): Config => {
     androidComponentId: process.env.JIRA_ANDROID_COMPONENT_ID,
     epicLink: process.env.JIRA_EPIC_LINK,
     epicUrl: process.env.JIRA_EPIC_URL,
+    severityId: process.env.JIRA_SEVERITY_ID,
     gollumUrl: process.env.GOLLUM_BASE_URL,
   };
 

--- a/backend/routes/feedback.ts
+++ b/backend/routes/feedback.ts
@@ -28,10 +28,7 @@ feedbackRouter.post('/report', async (req: Request, res: Response) => {
       attachment,
       origin,
     });
-    if (feedbackData) {
-      return res.status(200).json({ feedbackData });
-    }
-    return res.status(500).json({ message: 'Failed to create a report ticket' });
+    return res.status(200).json({ feedbackData });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : error;
     return res.status(500).json({ message: `Error reporting issue: ${message}` });

--- a/backend/services/feedbackService.ts
+++ b/backend/services/feedbackService.ts
@@ -1,5 +1,5 @@
 import { FeedbackData, ReportIssueReturn } from '../types/feedback';
 
 export interface FeedbackService {
-  reportIssue(data: FeedbackData): Promise<ReportIssueReturn | null>;
+  reportIssue(data: FeedbackData): Promise<ReportIssueReturn>;
 }

--- a/backend/services/jiraFeedbackService.ts
+++ b/backend/services/jiraFeedbackService.ts
@@ -32,7 +32,7 @@ class JiraFeedbackService implements FeedbackService {
     this.jiraSeverityId = this.config.severityId as string;
   }
 
-  async reportIssue(data: FeedbackData): Promise<ReportIssueReturn | null> {
+  async reportIssue(data: FeedbackData): Promise<ReportIssueReturn> {
     const feedbackIssueData = {
       fields: {
         project: {
@@ -89,6 +89,9 @@ class JiraFeedbackService implements FeedbackService {
     ticketData: ReportIssueReturn,
     key: string
   ): Promise<ReportIssueReturn> {
+    if (!/^[A-Z]+-\d+$/.test(key)) {
+      throw new Error(`Invalid Jira issue key: ${key}`);
+    }
     const fileBuffer = Buffer.from(attachment, 'base64');
     const formData = new FormData();
     formData.append('file', fileBuffer, {

--- a/backend/services/jiraFeedbackService.ts
+++ b/backend/services/jiraFeedbackService.ts
@@ -15,6 +15,7 @@ class JiraFeedbackService implements FeedbackService {
   jiraAndroidComponentId: string;
   jiraEpicUrl: string;
   jiraEpicLink: string;
+  jiraSeverityId: string;
   config: Config;
 
   constructor() {
@@ -28,6 +29,7 @@ class JiraFeedbackService implements FeedbackService {
     this.jiraUrl = this.config.url as string;
     this.jiraEpicUrl = this.config.epicUrl as string;
     this.jiraEpicLink = this.config.epicLink as string;
+    this.jiraSeverityId = this.config.severityId as string;
   }
 
   async reportIssue(data: FeedbackData): Promise<ReportIssueReturn | null> {
@@ -47,6 +49,9 @@ class JiraFeedbackService implements FeedbackService {
           },
         ],
         [this.jiraEpicLink]: this.jiraEpicUrl,
+        customfield_12403: { id: this.jiraSeverityId },
+        customfield_26112: 'Reported via user feedback form',
+        customfield_13112: data.issue,
       },
     };
 
@@ -70,8 +75,12 @@ class JiraFeedbackService implements FeedbackService {
       }
       return await this.addAttachment(data.attachment, ticketData, response.data.key);
     } catch (error) {
-      console.log('Response Error:', error);
-      return null;
+      if (axios.isAxiosError(error)) {
+        const errors = error.response?.data?.errors;
+        const message = errors ? JSON.stringify(errors) : error.message;
+        throw new Error(`Jira API error: ${message}`);
+      }
+      throw error;
     }
   }
 

--- a/backend/services/tests/jiraFeedbackService.test.ts
+++ b/backend/services/tests/jiraFeedbackService.test.ts
@@ -141,6 +141,19 @@ describe('JiraFeedbackService', () => {
     );
   });
 
+  it('should throw when the Jira issue key returned is invalid', async () => {
+    const feedbackData: FeedbackData = {
+      ...sharedData,
+      attachment: 'somerandomimagevalues',
+    };
+
+    mockPost.mockResolvedValue({ status: 200, data: { key: '2026' } });
+
+    await expect(jiraFeedbackService.reportIssue(feedbackData)).rejects.toThrow(
+      'Invalid Jira issue key: 2026'
+    );
+  });
+
   it('should throw with Jira error details when the request fails with a 400', async () => {
     const feedbackData: FeedbackData = { ...sharedData, attachment: '' };
     const axiosError = {

--- a/backend/services/tests/jiraFeedbackService.test.ts
+++ b/backend/services/tests/jiraFeedbackService.test.ts
@@ -20,7 +20,7 @@ describe('JiraFeedbackService', () => {
 
   beforeAll(() => {
     jest.resetModules();
-    process.env = { ...originalEnv, VIDEO_SERVICE_PROVIDER: 'opentok' };
+    process.env = { ...originalEnv, VIDEO_SERVICE_PROVIDER: 'opentok', JIRA_SEVERITY_ID: '12345' };
     jiraFeedbackService = new JiraFeedbackService();
   });
 
@@ -57,7 +57,7 @@ describe('JiraFeedbackService', () => {
             },
           ],
           [jiraFeedbackService.jiraEpicLink]: jiraFeedbackService.jiraEpicUrl,
-          customfield_12403: { id: jiraFeedbackService.jiraSeverityId },
+          customfield_12403: { id: '12345' },
           customfield_26112: 'Reported via user feedback form',
           customfield_13112: sharedData.issue,
         },
@@ -87,7 +87,7 @@ describe('JiraFeedbackService', () => {
     const mockScreenShotResponse = {
       status: 200,
       data: {
-        key: '2024',
+        key: 'VIDSOL-2024',
       },
     };
 
@@ -127,7 +127,7 @@ describe('JiraFeedbackService', () => {
             },
           ],
           [jiraFeedbackService.jiraEpicLink]: jiraFeedbackService.jiraEpicUrl,
-          customfield_12403: { id: jiraFeedbackService.jiraSeverityId },
+          customfield_12403: { id: '12345' },
           customfield_26112: 'Reported via user feedback form',
           customfield_13112: sharedData.issue,
         },
@@ -138,6 +138,25 @@ describe('JiraFeedbackService', () => {
           Authorization: `Basic ${jiraFeedbackService.jiraToken}`,
         },
       }
+    );
+  });
+
+  it('should throw with Jira error details when the request fails with a 400', async () => {
+    const feedbackData: FeedbackData = { ...sharedData, attachment: '' };
+    const axiosError = {
+      isAxiosError: true,
+      message: 'Request failed with status code 400',
+      response: {
+        data: {
+          errors: { customfield_12403: 'Severity is required.' },
+        },
+      },
+    };
+    mockPost.mockRejectedValue(axiosError);
+    jest.spyOn(axios, 'isAxiosError').mockReturnValue(true);
+
+    await expect(jiraFeedbackService.reportIssue(feedbackData)).rejects.toThrow(
+      'Jira API error: {"customfield_12403":"Severity is required."}'
     );
   });
 
@@ -171,7 +190,7 @@ describe('JiraFeedbackService', () => {
             },
           ],
           [jiraFeedbackService.jiraEpicLink]: jiraFeedbackService.jiraEpicUrl,
-          customfield_12403: { id: jiraFeedbackService.jiraSeverityId },
+          customfield_12403: { id: '12345' },
           customfield_26112: 'Reported via user feedback form',
           customfield_13112: sharedData.issue,
         },

--- a/backend/services/tests/jiraFeedbackService.test.ts
+++ b/backend/services/tests/jiraFeedbackService.test.ts
@@ -57,6 +57,9 @@ describe('JiraFeedbackService', () => {
             },
           ],
           [jiraFeedbackService.jiraEpicLink]: jiraFeedbackService.jiraEpicUrl,
+          customfield_12403: { id: jiraFeedbackService.jiraSeverityId },
+          customfield_26112: 'Reported via user feedback form',
+          customfield_13112: sharedData.issue,
         },
       },
       {
@@ -124,6 +127,9 @@ describe('JiraFeedbackService', () => {
             },
           ],
           [jiraFeedbackService.jiraEpicLink]: jiraFeedbackService.jiraEpicUrl,
+          customfield_12403: { id: jiraFeedbackService.jiraSeverityId },
+          customfield_26112: 'Reported via user feedback form',
+          customfield_13112: sharedData.issue,
         },
       },
       {
@@ -165,6 +171,9 @@ describe('JiraFeedbackService', () => {
             },
           ],
           [jiraFeedbackService.jiraEpicLink]: jiraFeedbackService.jiraEpicUrl,
+          customfield_12403: { id: jiraFeedbackService.jiraSeverityId },
+          customfield_26112: 'Reported via user feedback form',
+          customfield_13112: sharedData.issue,
         },
       },
       {

--- a/backend/types/config.ts
+++ b/backend/types/config.ts
@@ -8,6 +8,7 @@ export type FeedbackConfig = {
   androidComponentId?: string;
   epicLink?: string;
   epicUrl?: string;
+  severityId?: string;
   gollumUrl?: string;
 };
 

--- a/customWordList.mjs
+++ b/customWordList.mjs
@@ -20,6 +20,7 @@ const customWordList = [
   'unstub',
   'vonageAPIURL',
   'customfield',
+  'VIDSOL',
 ];
 
 export default customWordList;

--- a/customWordList.mjs
+++ b/customWordList.mjs
@@ -19,6 +19,7 @@ const customWordList = [
   'PWDEBUG',
   'unstub',
   'vonageAPIURL',
+  'customfield',
 ];
 
 export default customWordList;


### PR DESCRIPTION
#### What is this PR doing?
 
- Added three required VIDSOL project fields to the Jira issue payload: 
  Severity (`customfield_12403`), Severity Level Reason (`customfield_26112`), 
  and Steps to Reproduce (`customfield_13112`)
- Wired `JIRA_SEVERITY_ID` env var through `FeedbackConfig` and `JiraFeedbackService` 
  instead of hardcoding the field option ID
- Update error handling
- Added `customfield` to `customWordList.mjs` to resolve cspell false positives

#### Root cause
The `VIDSOL` Jira project requires additional mandatory fields that were not 
previously included in the payload, causing Jira to return 400/401 errors 
which surfaced as 500 to the client.


#### How should this be manually tested?
Simply join a meeting room then report an issue 

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-642](https://jira.vonage.com/browse/VIDSOL-642)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
