### PR TITLE
VIDSOL-642: add missing variable to the vcr yml

### DIFF
--- a/backend/routes/feedback.ts
+++ b/backend/routes/feedback.ts
@@ -31,6 +31,7 @@ feedbackRouter.post('/report', async (req: Request, res: Response) => {
     return res.status(200).json({ feedbackData });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : error;
+    console.error('[feedback] reportIssue failed:', message);
     return res.status(500).json({ message: `Error reporting issue: ${message}` });
   }
 });

--- a/backend/routes/feedback.ts
+++ b/backend/routes/feedback.ts
@@ -31,7 +31,6 @@ feedbackRouter.post('/report', async (req: Request, res: Response) => {
     return res.status(200).json({ feedbackData });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : error;
-    console.error('[feedback] reportIssue failed:', message);
     return res.status(500).json({ message: `Error reporting issue: ${message}` });
   }
 });

--- a/vcr-gha.yml
+++ b/vcr-gha.yml
@@ -40,5 +40,7 @@ instance:
       secret: JIRA_EPIC_LINK
     - name: JIRA_EPIC_URL
       secret: JIRA_EPIC_URL
+    - name: JIRA_SEVERITY_ID
+      secret: JIRA_SEVERITY_ID
 debug:
   entrypoint: [node, bundle.cjs]


### PR DESCRIPTION
#### What is this PR doing?
Adds support for passing JIRA_SEVERITY_ID into the VCR deployment environment so the backend can read process.env.JIRA_SEVERITY_ID at runtime.

#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-642](https://jira.vonage.com/browse/VIDSOL-642)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
