### PR TITLE
VIDSOL-493: Changing session redis key to don't use the old session id key

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,6 +12,7 @@ env:
   OT_API_SECRET: ${{secrets.API_SECRET}}
   VONAGE_APP_ID: ${{secrets.VONAGE_APP_ID}}
   VONAGE_PRIVATE_KEY: ${{secrets.VONAGE_PRIVATE_KEY}}
+  SESSION_KEY_SECRET: ${{secrets.SESSION_KEY_SECRET}}
 
 jobs:
   # ----------------------------------------------------

--- a/backend/storage/vcrSessionStorage.ts
+++ b/backend/storage/vcrSessionStorage.ts
@@ -10,7 +10,7 @@ class VcrSessionStorage implements SessionStorage {
     await this.dbState.expire(key, ENTRY_EXPIRATION_TIME);
   }
   async getSessionKey({ roomName }: { roomName: string }): Promise<string | null> {
-    const key = `sessions:${roomName}`;
+    const key = `sessionKey:${roomName}`;
     const session: string | null = await this.dbState.get(key);
     if (!session) {
       return null;
@@ -28,7 +28,7 @@ class VcrSessionStorage implements SessionStorage {
     roomName: string;
     sessionKey: string;
   }): Promise<void> {
-    const key = `sessions:${roomName}`;
+    const key = `sessionKey:${roomName}`;
     await this.dbState.set(key, sessionKey);
     // setting expiry on the set command in case the room is
     // created before hand but never accessed.

--- a/libs/api/src/handlers/decodeSessionKey.ts
+++ b/libs/api/src/handlers/decodeSessionKey.ts
@@ -53,7 +53,7 @@ function decodeSessionKey(
 
     return details;
   } catch (error) {
-    throw makeBadRequestErrorHandler('Invalid session key')(error);
+    throw makeBadRequestErrorHandler(`Invalid sessionKey: \n${sessionKey}`)(error);
   }
 }
 

--- a/vcr-gha.yml
+++ b/vcr-gha.yml
@@ -42,5 +42,7 @@ instance:
       secret: JIRA_EPIC_URL
     - name: JIRA_SEVERITY_ID
       secret: JIRA_SEVERITY_ID
+    - name: SESSION_KEY_SECRET
+      secret: SESSION_KEY_SECRET
 debug:
   entrypoint: [node, bundle.cjs]


### PR DESCRIPTION
#### What is this PR doing?
VIDSOL-493: Changing session redis key to don't use the old session id key

#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-493](https://jira.vonage.com/browse/VIDSOL-493)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
