### PR TITLE
VIDSOL-827: Add local screenshare preview toggle

### DIFF
--- a/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.spec.tsx
@@ -13,6 +13,8 @@ describe('ScreenSharePublisher component', () => {
         element={undefined}
         publisher={null}
         isEntireScreen={false}
+        showLocalScreensharePreview={false}
+        toggleLocalScreensharePreview={vi.fn()}
       />
     );
     expect(container).toBeEmptyDOMElement();
@@ -42,6 +44,8 @@ describe('ScreenSharePublisher component', () => {
         element={element}
         publisher={mockPublisher}
         isEntireScreen={false}
+        showLocalScreensharePreview={false}
+        toggleLocalScreensharePreview={vi.fn()}
       />
     );
 
@@ -56,7 +60,14 @@ describe('ScreenSharePublisher component', () => {
     const box = { height: 100, width: 100, top: 0, left: 0 };
 
     render(
-      <ScreenSharePublisher box={box} element={undefined} publisher={null} isEntireScreen={true} />
+      <ScreenSharePublisher
+        box={box}
+        element={undefined}
+        publisher={null}
+        isEntireScreen={true}
+        showLocalScreensharePreview={false}
+        toggleLocalScreensharePreview={vi.fn()}
+      />
     );
 
     expect(screen.getByText('You are sharing your screen.')).toBeInTheDocument();

--- a/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.spec.tsx
@@ -56,6 +56,40 @@ describe('ScreenSharePublisher component', () => {
     expect(element.style.objectFit).toBe('contain');
   });
 
+  it('renders show preview button when entire screen preview is hidden', () => {
+    const box = { height: 100, width: 100, top: 0, left: 0 };
+
+    render(
+      <ScreenSharePublisher
+        box={box}
+        element={undefined}
+        publisher={null}
+        isEntireScreen={true}
+        showLocalScreensharePreview={false}
+        toggleLocalScreensharePreview={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Show preview')).toBeInTheDocument();
+  });
+
+  it('renders hide preview button when local preview is shown', () => {
+    const box = { height: 100, width: 100, top: 0, left: 0 };
+
+    render(
+      <ScreenSharePublisher
+        box={box}
+        element={undefined}
+        publisher={null}
+        isEntireScreen={true}
+        showLocalScreensharePreview={true}
+        toggleLocalScreensharePreview={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Hide preview')).toBeInTheDocument();
+  });
+
   it('renders hidden message when entire screen is shared', () => {
     const box = { height: 100, width: 100, top: 0, left: 0 };
 

--- a/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.spec.tsx
@@ -90,6 +90,40 @@ describe('ScreenSharePublisher component', () => {
     expect(screen.getByText('Hide preview')).toBeInTheDocument();
   });
 
+  it('renders show preview button when entire screen preview is hidden', () => {
+    const box = { height: 100, width: 100, top: 0, left: 0 };
+
+    render(
+      <ScreenSharePublisher
+        box={box}
+        element={undefined}
+        publisher={null}
+        isEntireScreen={true}
+        showLocalScreensharePreview={false}
+        toggleLocalScreensharePreview={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Show preview')).toBeInTheDocument();
+  });
+
+  it('renders hide preview button when local preview is shown', () => {
+    const box = { height: 100, width: 100, top: 0, left: 0 };
+
+    render(
+      <ScreenSharePublisher
+        box={box}
+        element={undefined}
+        publisher={null}
+        isEntireScreen={true}
+        showLocalScreensharePreview={true}
+        toggleLocalScreensharePreview={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Hide preview')).toBeInTheDocument();
+  });
+
   it('renders hidden message when entire screen is shared', () => {
     const box = { height: 100, width: 100, top: 0, left: 0 };
 

--- a/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Publisher } from '@vonage/client-sdk-video';
 import { EventEmitter } from 'stream';
@@ -56,8 +56,9 @@ describe('ScreenSharePublisher component', () => {
     expect(element.style.objectFit).toBe('contain');
   });
 
-  it('renders show preview button when entire screen preview is hidden', () => {
+  it('renders and toggles the show preview button when entire screen preview is hidden', () => {
     const box = { height: 100, width: 100, top: 0, left: 0 };
+    const toggleLocalScreensharePreview = vi.fn();
 
     render(
       <ScreenSharePublisher
@@ -66,15 +67,18 @@ describe('ScreenSharePublisher component', () => {
         publisher={null}
         isEntireScreen={true}
         showLocalScreensharePreview={false}
-        toggleLocalScreensharePreview={vi.fn()}
+        toggleLocalScreensharePreview={toggleLocalScreensharePreview}
       />
     );
 
-    expect(screen.getByText('Show preview')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show preview' }));
+
+    expect(toggleLocalScreensharePreview).toHaveBeenCalledOnce();
   });
 
-  it('renders hide preview button when local preview is shown', () => {
+  it('renders and toggles the hide preview button when local preview is shown', () => {
     const box = { height: 100, width: 100, top: 0, left: 0 };
+    const toggleLocalScreensharePreview = vi.fn();
 
     render(
       <ScreenSharePublisher
@@ -83,45 +87,13 @@ describe('ScreenSharePublisher component', () => {
         publisher={null}
         isEntireScreen={true}
         showLocalScreensharePreview={true}
-        toggleLocalScreensharePreview={vi.fn()}
+        toggleLocalScreensharePreview={toggleLocalScreensharePreview}
       />
     );
 
-    expect(screen.getByText('Hide preview')).toBeInTheDocument();
-  });
+    fireEvent.click(screen.getByRole('button', { name: 'Hide preview' }));
 
-  it('renders show preview button when entire screen preview is hidden', () => {
-    const box = { height: 100, width: 100, top: 0, left: 0 };
-
-    render(
-      <ScreenSharePublisher
-        box={box}
-        element={undefined}
-        publisher={null}
-        isEntireScreen={true}
-        showLocalScreensharePreview={false}
-        toggleLocalScreensharePreview={vi.fn()}
-      />
-    );
-
-    expect(screen.getByText('Show preview')).toBeInTheDocument();
-  });
-
-  it('renders hide preview button when local preview is shown', () => {
-    const box = { height: 100, width: 100, top: 0, left: 0 };
-
-    render(
-      <ScreenSharePublisher
-        box={box}
-        element={undefined}
-        publisher={null}
-        isEntireScreen={true}
-        showLocalScreensharePreview={true}
-        toggleLocalScreensharePreview={vi.fn()}
-      />
-    );
-
-    expect(screen.getByText('Hide preview')).toBeInTheDocument();
+    expect(toggleLocalScreensharePreview).toHaveBeenCalledOnce();
   });
 
   it('renders hidden message when entire screen is shared', () => {

--- a/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.tsx
@@ -23,7 +23,7 @@ export type ScreenSharePublisherProps = {
  *   @property {Publisher | null} publisher-- Publisher object for local screen share
  *   @property {boolean} isEntireScreen - Whether the local user is sharing the entire screen
  *   @property {boolean} showLocalScreensharePreview - Whether local screenshare preview is visible
- *   @property {boolean} toggleLocalScreensharePreview - Toggle local screenshare preview visibility
+ *   @property {() => void} toggleLocalScreensharePreview - Toggle local screenshare preview visibility
  * @returns {ReactElement | undefined} - ScreenSharePublisher Component
  */
 const ScreenSharePublisher = ({
@@ -75,7 +75,7 @@ const ScreenSharePublisher = ({
             {isEntireScreen && (
               <button
                 type="button"
-                className="absolute text-vera-heading-4 top-4 right-4 z-10 rounded bg-vera-primary px-4 py-2 text-sm text-vera-on-secondary"
+                className="absolute top-4 right-4 z-10 rounded bg-vera-primary px-4 py-2 text-sm text-vera-on-secondary"
                 onClick={toggleLocalScreensharePreview}
               >
                 {t('screenSharing.dialog.hidePreview')}

--- a/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenSharePublisher/ScreenSharePublisher.tsx
@@ -10,6 +10,8 @@ export type ScreenSharePublisherProps = {
   element: HTMLElement | HTMLObjectElement | undefined;
   publisher: Publisher | null;
   isEntireScreen: boolean;
+  showLocalScreensharePreview: boolean;
+  toggleLocalScreensharePreview: () => void;
 };
 
 /**
@@ -20,6 +22,8 @@ export type ScreenSharePublisherProps = {
  *   @property {HTMLElement | HTMLObjectElement | undefined} element - VideoElement
  *   @property {Publisher | null} publisher-- Publisher object for local screen share
  *   @property {boolean} isEntireScreen - Whether the local user is sharing the entire screen
+ *   @property {boolean} showLocalScreensharePreview - Whether local screenshare preview is visible
+ *   @property {boolean} toggleLocalScreensharePreview - Toggle local screenshare preview visibility
  * @returns {ReactElement | undefined} - ScreenSharePublisher Component
  */
 const ScreenSharePublisher = ({
@@ -27,6 +31,8 @@ const ScreenSharePublisher = ({
   element,
   publisher,
   isEntireScreen,
+  showLocalScreensharePreview,
+  toggleLocalScreensharePreview,
 }: ScreenSharePublisherProps): ReactElement | undefined => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
@@ -52,12 +58,30 @@ const ScreenSharePublisher = ({
         ref={containerRef}
         isScreenshare
       >
-        {isEntireScreen ? (
-          <div className="absolute inset-0 flex items-center justify-center text-vera-heading-4 font-vera-plain bg-vera-dark-background text-vera-on-background pointer-events-none">
-            {t('screenSharing.dialog.hiddenMessage')}
+        {isEntireScreen && !showLocalScreensharePreview ? (
+          <div className="absolute inset-0 flex items-center justify-center text-vera-heading-4 font-vera-plain bg-vera-dark-background text-vera-on-secondary">
+            <div>{t('screenSharing.dialog.hiddenMessage')}</div>
+            <button
+              type="button"
+              className="rounded bg-vera-primary px-4 py-2 text-sm"
+              onClick={toggleLocalScreensharePreview}
+            >
+              {t('screenSharing.dialog.showPreview')}
+            </button>
           </div>
         ) : (
-          <ScreenShareNameDisplay name={streamName} box={box} />
+          <>
+            <ScreenShareNameDisplay name={streamName} box={box} />
+            {isEntireScreen && (
+              <button
+                type="button"
+                className="absolute text-vera-heading-4 top-4 right-4 z-10 rounded bg-vera-primary px-4 py-2 text-sm text-vera-on-secondary"
+                onClick={toggleLocalScreensharePreview}
+              >
+                {t('screenSharing.dialog.hidePreview')}
+              </button>
+            )}
+          </>
         )}
       </VideoTile>
     )

--- a/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.spec.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.spec.tsx
@@ -18,6 +18,8 @@ describe('VideoTileCanvas', () => {
       <VideoTileCanvas
         isSharingScreen={false}
         isEntireScreen={false}
+        showLocalScreensharePreview={false}
+        toggleLocalScreensharePreview={vi.fn()}
         screensharingPublisher={null}
         screenshareVideoElement={undefined}
         isRightPanelOpen={false}
@@ -32,6 +34,8 @@ describe('VideoTileCanvas', () => {
       <VideoTileCanvas
         isSharingScreen={true}
         isEntireScreen={true}
+        showLocalScreensharePreview={false}
+        toggleLocalScreensharePreview={vi.fn()}
         screensharingPublisher={{} as unknown as never}
         screenshareVideoElement={undefined}
         isRightPanelOpen={false}
@@ -42,6 +46,8 @@ describe('VideoTileCanvas', () => {
 
     const props = mockScreenSharePublisher.mock.calls[0][0] as {
       isEntireScreen: boolean;
+      showLocalScreensharePreview: boolean;
+      toggleLocalScreensharePreview: () => void;
     };
 
     expect(props.isEntireScreen).toBe(true);

--- a/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
+++ b/frontend/src/components/MeetingRoom/VideoTileCanvas/VideoTileCanvas.tsx
@@ -19,6 +19,8 @@ import Box from '@mui/material/Box';
 export type VideoTileCanvasProps = {
   isSharingScreen: boolean;
   isEntireScreen: boolean;
+  showLocalScreensharePreview: boolean;
+  toggleLocalScreensharePreview: () => void;
   screensharingPublisher: OTPublisher | null;
   screenshareVideoElement: HTMLVideoElement | HTMLObjectElement | undefined;
   isRightPanelOpen: boolean;
@@ -41,6 +43,8 @@ export type VideoTileCanvasProps = {
 const VideoTileCanvas = ({
   isSharingScreen,
   isEntireScreen,
+  showLocalScreensharePreview,
+  toggleLocalScreensharePreview,
   screensharingPublisher,
   screenshareVideoElement,
   isRightPanelOpen,
@@ -129,6 +133,8 @@ const VideoTileCanvas = ({
             box={layoutBoxes.localScreenshareBox}
             element={screenshareVideoElement}
             isEntireScreen={isEntireScreen}
+            showLocalScreensharePreview={showLocalScreensharePreview}
+            toggleLocalScreensharePreview={toggleLocalScreensharePreview}
           />
         )}
         {// Note: we still render hidden subscribers with flag `hidden`

--- a/frontend/src/hooks/useMeetingRoom.ts
+++ b/frontend/src/hooks/useMeetingRoom.ts
@@ -65,6 +65,8 @@ const useMeetingRoom = () => {
   const {
     isSharingScreen,
     isEntireScreen,
+    showLocalScreensharePreview,
+    toggleLocalScreensharePreview,
     screensharingPublisher,
     screenshareVideoElement,
     toggleShareScreen,
@@ -175,6 +177,8 @@ const useMeetingRoom = () => {
     isSmallViewport,
     isSharingScreen,
     isEntireScreen,
+    showLocalScreensharePreview,
+    toggleLocalScreensharePreview,
     screensharingPublisher,
     screenshareVideoElement,
     toggleShareScreen,

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -13,6 +13,8 @@ export type UseScreenShareType = {
   toggleShareScreen: () => Promise<void>;
   isSharingScreen: boolean;
   isEntireScreen: boolean;
+  showLocalScreensharePreview: boolean;
+  toggleLocalScreensharePreview: () => void;
   screensharingPublisher: Publisher | null;
   screenshareVideoElement: HTMLVideoElement | HTMLObjectElement | undefined;
 };
@@ -32,13 +34,19 @@ const useScreenShare = (): UseScreenShareType => {
   // State to track sharing status
   const [isSharingScreen, setIsSharingScreen] = useState<boolean>(false);
   const [isEntireScreen, setIsEntireScreen] = useState<boolean>(false);
+  const [showLocalScreensharePreview, setShowLocalScreensharePreview] = useState<boolean>(false);
   const [screenshareVideoElement, setScreenshareVideoElement] = useState<
     HTMLVideoElement | HTMLObjectElement
   >();
 
+  const toggleLocalScreensharePreview = useCallback(() => {
+    setShowLocalScreensharePreview((current) => !current);
+  }, []);
+
   const onScreenShareStopped = useCallback(() => {
     setIsSharingScreen(false);
     setIsEntireScreen(false);
+    setShowLocalScreensharePreview(false);
     setScreenshareVideoElement(undefined);
     screenSharingPubRef.current = null;
   }, []);
@@ -48,6 +56,7 @@ const useScreenShare = (): UseScreenShareType => {
       unpublish(screenSharingPubRef.current);
       setIsSharingScreen(false);
       setIsEntireScreen(false);
+      setShowLocalScreensharePreview(false);
     }
   }, [unpublish]);
 
@@ -137,6 +146,8 @@ const useScreenShare = (): UseScreenShareType => {
     toggleShareScreen,
     isSharingScreen,
     isEntireScreen,
+    showLocalScreensharePreview,
+    toggleLocalScreensharePreview,
     screenshareVideoElement,
     /**
      * On the first render this will return null

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -175,6 +175,8 @@
   "screenSharing.dialog.content": "Es sieht so aus, als würde jemand anderes seinen Bildschirm teilen. Wenn Sie fortfahren, wird ihr Bildschirm nicht mehr geteilt.",
   "screenSharing.dialog.title": "Möchten Sie Ihren Bildschirm teilen?",
   "screenSharing.dialog.hiddenMessage": "Sie teilen gerade Ihren Bildschirm.",
+  "screenSharing.dialog.showPreview": "Vorschau anzeigen",
+  "screenSharing.dialog.hidePreview": "Vorschau ausblenden",
   "screenSharing.title.start": "Bildschirmfreigabe starten",
   "screenSharing.title.stop": "Bildschirmfreigabe stoppen",
   "screenSharing.tooltip.ariaLabel": "Bildschirmfreigabe starten oder stoppen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -183,6 +183,8 @@
   "screenSharing.dialog.content": "Looks like there is someone else sharing their screen. If you continue, their screen is no longer going to be shared.",
   "screenSharing.dialog.title": "Do you want to share your screen?",
   "screenSharing.dialog.hiddenMessage": "You are sharing your screen.",
+  "screenSharing.dialog.showPreview": "Show preview",
+  "screenSharing.dialog.hidePreview": "Hide preview",
   "screenSharing.title.start": "Start screen share",
   "screenSharing.title.stop": "Stop screen share",
   "screenSharing.tooltip.ariaLabel": "Start or stop screen share",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -181,6 +181,8 @@
   "screenSharing.dialog.content": "Alguien más está compartiendo pantalla. Si continúas, su pantalla dejará de mostrarse.",
   "screenSharing.dialog.title": "¿Quieres compartir tu pantalla?",
   "screenSharing.dialog.hiddenMessage": "Estás compartiendo tu pantalla.",
+  "screenSharing.dialog.showPreview": "Mostrar vista previa",
+  "screenSharing.dialog.hidePreview": "Ocultar vista previa",
   "screenSharing.title.start": "Iniciar compartir pantalla",
   "screenSharing.title.stop": "Dejar de compartir pantalla",
   "screenSharing.tooltip.ariaLabel": "Iniciar o detener compartir pantalla",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -181,6 +181,8 @@
   "screenSharing.dialog.content": "Parece que alguien más está compartiendo su pantalla. Si continúas, su pantalla dejará de compartirse.",
   "screenSharing.dialog.title": "¿Deseas compartir tu pantalla?",
   "screenSharing.dialog.hiddenMessage": "Estás compartiendo tu pantalla.",
+  "screenSharing.dialog.showPreview": "Mostrar vista previa",
+  "screenSharing.dialog.hidePreview": "Ocultar vista previa",
   "screenSharing.title.start": "Iniciar compartir pantalla",
   "screenSharing.title.stop": "Detener compartir pantalla",
   "screenSharing.tooltip.ariaLabel": "Iniciar o detener compartir pantalla",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -181,6 +181,8 @@
   "screenSharing.dialog.content": "Sembra che qualcun altro stia condividendo lo schermo. Se continui, il loro schermo non sarà più condiviso.",
   "screenSharing.dialog.title": "Vuoi condividere il tuo schermo?",
   "screenSharing.dialog.hiddenMessage": "Stai condividendo il tuo schermo.",
+  "screenSharing.dialog.showPreview": "Mostra anteprima",
+  "screenSharing.dialog.hidePreview": "Nascondi anteprima",
   "screenSharing.title.start": "Avvia condivisione schermo",
   "screenSharing.title.stop": "Interrompi condivisione schermo",
   "screenSharing.tooltip.ariaLabel": "Avvia o interrompi condivisione schermo",

--- a/frontend/src/pages/MeetingRoom/MeetingRoom.spec.tsx
+++ b/frontend/src/pages/MeetingRoom/MeetingRoom.spec.tsx
@@ -185,6 +185,8 @@ describe('MeetingRoom', () => {
       toggleShareScreen: () => Promise.resolve(),
       isSharingScreen: false,
       isEntireScreen: false,
+      showLocalScreensharePreview: false,
+      toggleLocalScreensharePreview: vi.fn(),
       screenshareVideoElement: undefined,
       screensharingPublisher: null,
     });

--- a/frontend/src/pages/MeetingRoom/MeetingRoom.tsx
+++ b/frontend/src/pages/MeetingRoom/MeetingRoom.tsx
@@ -34,6 +34,8 @@ const MeetingRoom = ({ fullSize = false, className }: MeetingRoomProps): ReactEl
     isSmallViewport,
     isSharingScreen,
     isEntireScreen,
+    showLocalScreensharePreview,
+    toggleLocalScreensharePreview,
     screensharingPublisher,
     screenshareVideoElement,
     toggleShareScreen,
@@ -83,6 +85,8 @@ const MeetingRoom = ({ fullSize = false, className }: MeetingRoomProps): ReactEl
       <VideoTileCanvas
         isSharingScreen={isSharingScreen}
         isEntireScreen={isEntireScreen}
+        showLocalScreensharePreview={showLocalScreensharePreview}
+        toggleLocalScreensharePreview={toggleLocalScreensharePreview}
         screensharingPublisher={screensharingPublisher}
         screenshareVideoElement={screenshareVideoElement}
         isRightPanelOpen={rightPanelActiveTab !== 'closed'}


### PR DESCRIPTION
#### What is this PR doing?
Adds a toggle to show or hide the local screenshare preview when sharing the entire screen.

By default after this PR https://github.com/Vonage/vonage-video-react-app/pull/381/, the local preview is hidden to avoid the infinite mirror effect.

Users can temporarily show the preview using a button in the screenshare tile (e.g. when using a dual-monitor).

#### How should this be manually tested?

1. Start a meeting with two participants.
2. Start sharing the entire screen.
3. Confirm the local preview is hidden by default.
4. Click "Show preview" and confirm the local preview appears.
5. Click "Hide preview" at the right top and confirm the preview is hidden again.
6. Confirm the remote participant can see the shared screen normally.
7. Stop sharing and confirm the UI returns to normal.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-827](https://jira.vonage.com/browse/VIDSOL-827)

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
