### PR TITLE
VIDSOL-861: Background effects delete icon is not visible

### DIFF
--- a/frontend/src/components/BackgroundEffects/BackgroundGallery/BackgroundGallery.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundGallery/BackgroundGallery.tsx
@@ -74,7 +74,7 @@ const BackgroundGallery = (): ReactElement => {
                   size="small"
                   className={classNames({
                     'text-vera-text-disabled bg-vera-disabled cursor-default': isSelected,
-                    'text-vera-background bg-vera-on-background hover:bg-vera-background cursor-pointer':
+                    'bg-vera-dark-grey-opacity! text-vera-on-dark-grey hover:bg-vera-dark-grey! cursor-pointer':
                       !isSelected,
                   })}
                   sx={{
@@ -88,7 +88,7 @@ const BackgroundGallery = (): ReactElement => {
                     name="delete-solid"
                     customSize={-6}
                     style={{
-                      color: isSelected ? 'var(--vera-text-disabled)' : 'var(--vera-background)',
+                      color: isSelected ? 'var(--vera-text-disabled)' : 'var(--vera-on-dark-grey)',
                     }}
                   />
                 </IconButton>


### PR DESCRIPTION
#### What is this PR doing?
Make background effects delete icon visible.

#### How should this be manually tested?
Check that background effects delete custom image is visible.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-861](https://jira.vonage.com/browse/VIDSOL-861)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
