### PR TITLE
VIDSOL-887: Handle case where Vonage subscriber is not created

### DIFF
--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
@@ -201,6 +201,32 @@ describe('VonageVideoClient', () => {
 
       await audioLevelUpdatedPromise;
     });
+
+    it('emits subscriptionError when subscribe returns null and does not attach subscriber listeners', async () => {
+      const streamId = 'null-subscriber-stream';
+
+      await vonageVideoClient?.connect();
+
+      const nullSubscriber = new EventEmitter() as unknown as TestSubscriber;
+      mockSubscribe.mockReturnValue(undefined);
+
+      const subscriptionErrorPromise = new Promise<unknown>((resolve) => {
+        vonageVideoClient?.on('subscriptionError', resolve);
+      });
+
+      mockSession.emit('streamCreated', {
+        stream: { streamId, videoType: 'camera' } as unknown as Stream,
+      });
+
+      const error = await subscriptionErrorPromise;
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('Vonage subscriber was not created.');
+      // setupSubscriberListeners should never have been called — no subscriber to attach to
+      expect(nullSubscriber.listenerCount('videoElementCreated')).toBe(0);
+      expect(nullSubscriber.listenerCount('destroyed')).toBe(0);
+      expect(nullSubscriber.listenerCount('audioLevelUpdated')).toBe(0);
+    });
   });
 
   it('disconnect should disconnect from the session and cleanup', async () => {

--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
@@ -146,7 +146,7 @@ describe('VonageVideoClient', () => {
 
       await vonageVideoClient?.connect();
 
-      vi.spyOn(vonageVideoClient!.clientSession!, 'subscribe').mockImplementation(
+      vi.spyOn(vonageVideoClient!.clientSession, 'subscribe').mockImplementation(
         (_a, _b, _c, callback) => {
           queueMicrotask(() => {
             callback!();

--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
@@ -164,8 +164,13 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
             }
           );
 
+          if (!subscriber) {
+            reject(new Error('Vonage subscriber was not created.'));
+            return;
+          }
+
           this.setupSubscriberListeners({
-            subscriber: subscriber!,
+            subscriber,
             streamId,
             isScreenshare,
           });

--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
@@ -55,12 +55,13 @@ type VonageVideoClientEvents = {
  * @augments {EventEmitter}
  */
 class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
-  public clientSession: Session | null;
+  public clientSession: Session;
   private readonly credential: Credential;
   private readonly applicationId: string;
   public readonly sessionId: string;
   private hiddenSubscriber: Subscriber | null = null;
   private readonly streams = new Map<string, Stream>();
+  private disconnected = false;
 
   /**
    * Creates an instance of VonageVideoClient.
@@ -88,9 +89,6 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
    * @private
    */
   private attachEventListeners = () => {
-    if (!this.clientSession) {
-      return;
-    }
     this.clientSession.on('archiveStarted', (event) => this.handleArchiveStarted(event));
     this.clientSession.on('archiveStopped', () => this.handleArchiveStopped());
     this.clientSession.on('sessionDisconnected', (event) => this.handleSessionDisconnected(event));
@@ -113,9 +111,10 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
    * @private
    */
   private async handleStreamCreated(event: StreamCreatedEvent) {
-    if (this.clientSession === null) {
+    if (this.disconnected) {
       return;
     }
+
     const { stream } = event;
     const { streamId } = stream;
 
@@ -131,7 +130,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
   }
 
   private subscribeToStream = async (stream: Stream) => {
-    if (this.clientSession === null) {
+    if (this.disconnected) {
       return;
     }
 
@@ -151,7 +150,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
     try {
       const subscribe = () =>
         new Promise<Subscriber>((resolve, reject) => {
-          const subscriber = this.clientSession?.subscribe(
+          const subscriber = this.clientSession.subscribe(
             stream,
             undefined,
             subscriberOptions,
@@ -160,7 +159,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
                 reject(error);
                 return;
               }
-              resolve(subscriber!);
+              resolve(subscriber);
             }
           );
 
@@ -218,7 +217,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
   };
 
   resubscribeToStreamId = async (streamId: string): Promise<void> => {
-    if (this.clientSession === null) {
+    if (this.disconnected) {
       return;
     }
 
@@ -428,10 +427,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
     const { token } = this.credential;
 
     return new Promise((resolve, reject) => {
-      if (!this.clientSession) {
-        reject(new Error('Session has not been initialized.'));
-      }
-      this.clientSession?.connect(token, (err?: OTError) => {
+      this.clientSession.connect(token, (err?: OTError) => {
         if (err) {
           frontendLogger.reportError(err, {
             eventSource: 'vonageVideoClient.connect.error',
@@ -459,14 +455,20 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
    * Disconnects from the current session and cleans up the session object.
    */
   disconnect = () => {
+    if (this.disconnected) {
+      return;
+    }
+
+    this.disconnected = true;
+
     // Clean up the hidden subscriber used for captions
     if (this.hiddenSubscriber) {
-      this.clientSession?.unsubscribe(this.hiddenSubscriber);
+      this.clientSession.unsubscribe(this.hiddenSubscriber);
       this.hiddenSubscriber = null;
     }
 
-    this.clientSession?.disconnect();
-    this.clientSession = null;
+    this.clientSession.disconnect();
+    this.clientSession = null as unknown as Session;
   };
 
   /**
@@ -474,7 +476,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
    * @param {Stream} stream - The stream to be muted.
    */
   forceMuteStream = async (stream: Stream) => {
-    await this.clientSession?.forceMuteStream(stream);
+    await this.clientSession.forceMuteStream(stream);
   };
 
   /**
@@ -484,12 +486,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
    */
   publish = (publisher: Publisher): Promise<void> => {
     return new Promise((resolve, reject) => {
-      if (!this.clientSession) {
-        reject(new Error('Session is not initialized.'));
-        return;
-      }
-
-      this.clientSession?.publish(publisher, (error) => {
+      this.clientSession.publish(publisher, (error) => {
         if (error) {
           frontendLogger.reportError(error, {
             eventSource: 'vonageVideoClient.publish.error',
@@ -506,7 +503,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
         // More information: https://developer.vonage.com/en/video/guides/live-caption#receiving-your-own-live-captions
         if (publisher.stream) {
           this.hiddenSubscriber =
-            this.clientSession?.subscribe(publisher.stream, document.createElement('div'), {
+            this.clientSession.subscribe(publisher.stream, document.createElement('div'), {
               audioVolume: 0,
             }) ?? null;
 
@@ -525,7 +522,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
    * @param {SignalType} data - The signal data to be sent.
    */
   signal = (data: SignalType) => {
-    this.clientSession?.signal(data);
+    this.clientSession.signal(data);
   };
 
   /**
@@ -535,11 +532,11 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
   unpublish = (publisher: Publisher) => {
     // Clean up the hidden subscriber used for captions
     if (this.hiddenSubscriber) {
-      this.clientSession?.unsubscribe(this.hiddenSubscriber);
+      this.clientSession.unsubscribe(this.hiddenSubscriber);
       this.hiddenSubscriber = null;
     }
 
-    this.clientSession?.unpublish(publisher);
+    this.clientSession.unpublish(publisher);
   };
 
   /**
@@ -547,7 +544,7 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
    * @returns {string | undefined} The connection ID.
    */
   get connectionId(): string | undefined {
-    return this.clientSession?.connection?.connectionId;
+    return this.clientSession.connection?.connectionId;
   }
 }
 


### PR DESCRIPTION
#### What is this PR doing?
Fixing and edge case where we get a null from a subscriber even if the typescript says the opposite.

#### How should this be manually tested?
No fixed way to test it, happens occasionally.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-887](https://jira.vonage.com/browse/VIDSOL-887)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
