### PR TITLE
VIDSOL-403: Split archive list and move reusable logic to core package

### DIFF
--- a/backend/routes/video/video.ts
+++ b/backend/routes/video/video.ts
@@ -1,12 +1,11 @@
 import { Router } from 'express';
-import { createVideoHandler } from '@api-lib';
+import { createVideoHandler, VideoAction } from '@api-lib';
 import { createSession, startArchive, enableCaptions, joinSession } from './constants';
 import type { Request, Response } from 'express';
 import { makeInternalErrorHandler } from '@api-lib/errors';
 import SessionHookPayloadSchema from './schemas/SessionHookPayload.schema';
 import CaptionsHookPayloadSchema from './schemas/CaptionsHookPayload.schema';
 import ArchiveHookPayloadSchema from './schemas/ArchiveHookPayload.schema';
-import { VideoAction } from '@api-lib';
 import { VideoSessionDetails } from '@common/types';
 import { assertResult } from '@api-lib/executions';
 import getSessionStorageService from '../../sessionStorageService';

--- a/frontend/src/components/GoodBye/ArchiveList/ArchiveList.tsx
+++ b/frontend/src/components/GoodBye/ArchiveList/ArchiveList.tsx
@@ -18,6 +18,7 @@ import VividIcon from '@ui/VividIcon';
 import formatDuration from '@utils/formatDuration';
 import formatFileSize from '@utils/formatFileSize';
 import classNames from 'classnames';
+import { isString } from '@common/assertions';
 
 const ArchiveErrorIcon = () => {
   const { t } = useTranslation();
@@ -89,7 +90,8 @@ export type ArchiveListProps = {
 const ArchiveList = ({ archives }: ArchiveListProps): ReactElement => {
   const { t } = useTranslation();
 
-  if (archives === 'error') {
+  const isError = isString(archives);
+  if (isError) {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <VividIcon name="warning-line" customSize={-4} style={{ color: 'var(--vera-warning)' }} />

--- a/frontend/src/hooks/tests/useGoodByePage.spec.tsx
+++ b/frontend/src/hooks/tests/useGoodByePage.spec.tsx
@@ -1,11 +1,11 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook as renderHookBase, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
 import useGoodByePage from '../useGoodByePage';
-import useArchives from '../useArchives';
 import { useLocation, useParams } from 'react-router-dom';
 import { availableArchive } from '../../api/archiving/tests/data';
-
-vi.mock('../useArchives');
+import { makeTestProvider, providers, type ProviderOptions } from '@core-test/providers';
+import { makeVideoClientMock } from '@core-test/fixtures';
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
@@ -16,39 +16,84 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-const mockUseArchives = useArchives as Mock;
 const mockUseParams = useParams as Mock;
 const mockUseLocation = useLocation as Mock;
+
+type RenderOptions = {
+  runtimeContext?: ProviderOptions['RuntimeContext'];
+};
+
+function renderHook<Result>(render: () => Result, { runtimeContext }: RenderOptions = {}) {
+  const { wrapper, ...context } = makeTestProvider([providers.runtime], {
+    runtimeContext,
+  });
+
+  return {
+    ...context,
+    ...renderHookBase(render, { wrapper }),
+  };
+}
 
 describe('useGoodByePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseParams.mockReturnValue({ roomIdentifier: 'my-session-key' });
-    mockUseArchives.mockReturnValue([]);
   });
 
   it('returns the sessionKey from URL params', () => {
-    const { result } = renderHook(() => useGoodByePage());
+    const videoClient = makeVideoClientMock({
+      searchArchives: Promise.resolve({ items: [], count: 0 }),
+    });
+    const { result } = renderHook(() => useGoodByePage(), { runtimeContext: { videoClient } });
     expect(result.current.sessionKey).toBe('my-session-key');
   });
 
-  it('passes sessionKey to useArchives', () => {
-    renderHook(() => useGoodByePage());
-    expect(mockUseArchives).toHaveBeenCalledWith({ sessionKey: 'my-session-key' });
+  it('fetches archives from videoClient with sessionKey', async () => {
+    const videoClient = makeVideoClientMock({
+      searchArchives: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    });
+
+    renderHook(() => useGoodByePage(), { runtimeContext: { videoClient } });
+
+    await waitFor(() => {
+      expect(videoClient.searchArchives).toHaveBeenCalled();
+    });
+
+    expect(videoClient.searchArchives).toHaveBeenCalledWith({
+      sessionKey: 'my-session-key',
+      count: undefined,
+      offset: undefined,
+    });
   });
 
-  it('forwards archives from useArchives', () => {
-    mockUseArchives.mockReturnValue([availableArchive]);
+  it('forwards archives from videoClient', async () => {
+    const videoClient = makeVideoClientMock({
+      searchArchives: Promise.resolve({
+        items: [availableArchive],
+        count: 1,
+      } as unknown as ReturnType<typeof videoClient.searchArchives>),
+    });
+    const { result } = renderHook(() => useGoodByePage(), { runtimeContext: { videoClient } });
 
-    const { result } = renderHook(() => useGoodByePage());
+    await waitFor(() => {
+      expect(result.current.archives).not.toBe('error');
+    });
+
     expect(result.current.archives).toEqual([availableArchive]);
   });
 
-  it('forwards "error" from useArchives when archives fail to load', () => {
-    mockUseArchives.mockReturnValue('error');
+  it('forwards "error" from videoClient when archives fail to load', async () => {
+    const videoClient = makeVideoClientMock({
+      searchArchives: vi.fn().mockRejectedValue(new Error('Failed')),
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    const { result } = renderHook(() => useGoodByePage(), {
+      runtimeContext: { videoClient, queryClient },
+    });
 
-    const { result } = renderHook(() => useGoodByePage());
-    expect(result.current.archives).toBe('error');
+    await waitFor(() => {
+      expect(result.current.archives).toBe('Failed');
+    });
   });
 
   it('uses location.state header when provided', () => {
@@ -56,7 +101,10 @@ describe('useGoodByePage', () => {
       state: { header: 'Custom Header', caption: 'Custom Caption' },
     });
 
-    const { result } = renderHook(() => useGoodByePage());
+    const videoClient = makeVideoClientMock({
+      searchArchives: Promise.resolve({ items: [], count: 0 }),
+    });
+    const { result } = renderHook(() => useGoodByePage(), { runtimeContext: { videoClient } });
     expect(result.current.header).toBe('Custom Header');
     expect(result.current.caption).toBe('Custom Caption');
   });
@@ -64,7 +112,10 @@ describe('useGoodByePage', () => {
   it('falls back to default i18n header when location.state is null', () => {
     mockUseLocation.mockReturnValue({ state: null });
 
-    const { result } = renderHook(() => useGoodByePage());
+    const videoClient = makeVideoClientMock({
+      searchArchives: Promise.resolve({ items: [], count: 0 }),
+    });
+    const { result } = renderHook(() => useGoodByePage(), { runtimeContext: { videoClient } });
     expect(typeof result.current.header).toBe('string');
     expect(result.current.header.length).toBeGreaterThan(0);
   });
@@ -72,7 +123,10 @@ describe('useGoodByePage', () => {
   it('falls back to default i18n caption when location.state has no caption', () => {
     mockUseLocation.mockReturnValue({ state: { header: 'Some Header' } });
 
-    const { result } = renderHook(() => useGoodByePage());
+    const videoClient = makeVideoClientMock({
+      searchArchives: Promise.resolve({ items: [], count: 0 }),
+    });
+    const { result } = renderHook(() => useGoodByePage(), { runtimeContext: { videoClient } });
     expect(typeof result.current.caption).toBe('string');
     expect(result.current.caption.length).toBeGreaterThan(0);
   });

--- a/frontend/src/hooks/useArchives.tsx
+++ b/frontend/src/hooks/useArchives.tsx
@@ -1,60 +1,56 @@
-import { useEffect, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { runtime$ } from '@core/stores';
-import { ArchiveResponse, getArchives } from '../api/archiving';
-import { Archive } from '../api/archiving/model';
+import { useArchives as useArchivesBase } from '@core/hooks';
+import { createArchiveFromServer, ServerArchive } from '../api/archiving/model';
+import { SingleArchiveResponse } from '@vonage/video';
 
 export type UseArchivesProps = {
-  sessionKey: string | null;
+  sessionKey: string | undefined;
 };
+
+const pollingIntervalMs = 5000;
 
 /**
  * Returns the archives from a session, or `error` if there is an error.
  * @param { UseArchivesProps} props - The props for the hook.
  * @returns {Archive[] | 'error'} An array of Archives, or the text, `error`.
  */
-const useArchives = ({ sessionKey }: UseArchivesProps): Archive[] | 'error' => {
-  const videoClient = runtime$.useVideoClient();
-  const { i18n } = useTranslation();
-  const [archives, setArchives] = useState<Archive[] | 'error'>([]);
-  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
+const useArchives = ({ sessionKey }: UseArchivesProps) => {
+  const { data, ...rest } = useArchivesBase({
+    sessionKey,
+    queryOptions: {
+      enabled: !!sessionKey,
+      refetchInterval: (query) => {
+        const archives = query.state.data?.items;
 
-  useEffect(() => {
-    const fetchArchives = async () => {
-      if (sessionKey) {
-        let archiveData: ArchiveResponse;
-        try {
-          archiveData = await getArchives({
-            sessionKey,
-            locale: i18n.language,
-            videoClient,
-          });
-        } catch (error: unknown) {
-          const message = error instanceof Error ? error.message : error;
-          console.error(`Error retrieving archive: ${message}`);
-          setArchives('error');
-          return;
+        if (!archives || !hasPending(archives)) {
+          return false;
         }
-        // If we have archives not yet available for download we poll the API every 5s to see if its' available.
-        if (archiveData.hasPending && pollingIntervalRef.current === undefined) {
-          pollingIntervalRef.current = setInterval(() => {
-            void fetchArchives();
-          }, 5000);
-        } else if (!archiveData.hasPending && pollingIntervalRef.current !== undefined) {
-          clearInterval(pollingIntervalRef.current);
-          pollingIntervalRef.current = undefined;
-        }
-        setArchives(archiveData.archives);
-      }
-    };
-    void fetchArchives();
-    return () => {
-      if (pollingIntervalRef.current) {
-        clearInterval(pollingIntervalRef.current);
-      }
-    };
-  }, [sessionKey, i18n.language, videoClient]);
-  return archives;
+
+        return pollingIntervalMs;
+      },
+    },
+  });
+
+  const { i18n } = useTranslation();
+
+  return {
+    ...rest,
+    data: useMemo(() => {
+      if (!data) return undefined;
+
+      return {
+        ...data,
+        items: data.items.map((archive) => {
+          return createArchiveFromServer(i18n.language, archive as ServerArchive);
+        }),
+      };
+    }, [data, i18n.language]),
+  };
 };
+
+function hasPending<T extends SingleArchiveResponse>(archives: T[]): boolean {
+  return archives.some((archive) => !['available', 'failed'].includes(archive.status));
+}
 
 export default useArchives;

--- a/frontend/src/hooks/useGoodByePage.ts
+++ b/frontend/src/hooks/useGoodByePage.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { Archive } from '../api/archiving/model';
 import useArchives from './useArchives';
 import useSessionKeyParam from './useSessionKeyParam';
+import { isErrorLike } from '@common/assertions';
 
 type UseGoodByePageResult = {
   sessionKey: string | null;
@@ -17,7 +18,7 @@ const useGoodByePage = (): UseGoodByePageResult => {
   const location = useLocation();
   const { sessionKey } = useSessionKeyParam();
 
-  const archives = useArchives({ sessionKey });
+  const { data, error } = useArchives({ sessionKey });
 
   const header: string = location.state?.header || t('goodbye.default.header');
   const caption: string = location.state?.caption || t('goodbye.default.message');
@@ -25,7 +26,7 @@ const useGoodByePage = (): UseGoodByePageResult => {
 
   return {
     sessionKey,
-    archives,
+    archives: data ? data.items : ((isErrorLike(error) ? error.message : 'error') as 'error'),
     header,
     caption,
     isSelfDeclinedRecording,

--- a/frontend/src/pages/GoodBye/GoodBye.spec.tsx
+++ b/frontend/src/pages/GoodBye/GoodBye.spec.tsx
@@ -18,7 +18,13 @@ vi.mock('react-router-dom', async () => {
 
 describe('GoodBye', () => {
   beforeEach(() => {
-    mockUseArchives.mockReturnValue([]);
+    mockUseArchives.mockReturnValue({
+      data: {
+        items: [],
+        count: 0,
+      },
+      error: null,
+    } as unknown as ReturnType<typeof useArchives>);
   });
 
   it('should render', () => {
@@ -33,7 +39,10 @@ describe('GoodBye', () => {
   });
 
   it('should fetch and display archives', () => {
-    mockUseArchives.mockReturnValue([availableArchive, failedArchive, pendingArchive]);
+    mockUseArchives.mockReturnValue({
+      data: { items: [availableArchive, failedArchive, pendingArchive] },
+      error: null,
+    } as unknown as ReturnType<typeof useArchives>);
     render(
       <BrowserRouter>
         <GoodBye />
@@ -62,7 +71,9 @@ describe('GoodBye', () => {
   });
 
   it('should display empty message when there are no archives', () => {
-    mockUseArchives.mockReturnValue([]);
+    mockUseArchives.mockReturnValue({ data: { items: [] }, error: null } as unknown as ReturnType<
+      typeof useArchives
+    >);
     render(
       <BrowserRouter>
         <GoodBye />
@@ -72,7 +83,10 @@ describe('GoodBye', () => {
   });
 
   it('should display error message when archives fail to load', () => {
-    mockUseArchives.mockReturnValue('error');
+    mockUseArchives.mockReturnValue({
+      data: null,
+      error: new Error('Failed'),
+    } as unknown as ReturnType<typeof useArchives>);
     render(
       <BrowserRouter>
         <GoodBye />
@@ -84,7 +98,10 @@ describe('GoodBye', () => {
   });
 
   it('should display available archive with download button', () => {
-    mockUseArchives.mockReturnValue([availableArchive]);
+    mockUseArchives.mockReturnValue({
+      data: { items: [availableArchive] },
+      error: null,
+    } as unknown as ReturnType<typeof useArchives>);
     render(
       <BrowserRouter>
         <GoodBye />
@@ -96,7 +113,10 @@ describe('GoodBye', () => {
   });
 
   it('should display failed archive with error icon', () => {
-    mockUseArchives.mockReturnValue([failedArchive]);
+    mockUseArchives.mockReturnValue({
+      data: { items: [failedArchive] },
+      error: null,
+    } as unknown as ReturnType<typeof useArchives>);
     render(
       <BrowserRouter>
         <GoodBye />
@@ -106,7 +126,10 @@ describe('GoodBye', () => {
   });
 
   it('should display pending archive with loading spinner', () => {
-    mockUseArchives.mockReturnValue([pendingArchive]);
+    mockUseArchives.mockReturnValue({
+      data: { items: [pendingArchive] },
+      error: null,
+    } as unknown as ReturnType<typeof useArchives>);
     render(
       <BrowserRouter>
         <GoodBye />
@@ -116,7 +139,10 @@ describe('GoodBye', () => {
   });
 
   it('should display recordings section title', () => {
-    mockUseArchives.mockReturnValue([availableArchive]);
+    mockUseArchives.mockReturnValue({
+      data: { items: [availableArchive] },
+      error: null,
+    } as unknown as ReturnType<typeof useArchives>);
     render(
       <BrowserRouter>
         <GoodBye />

--- a/libs/api/src/handlers/searchArchives.ts
+++ b/libs/api/src/handlers/searchArchives.ts
@@ -5,7 +5,7 @@ import { assertResult } from '@common/execution';
 async function searchArchives(this: IVideoClient, payload: SearchArchivesPayload) {
   try {
     const { sessionKey, ...filter } = payload;
-    const { sessionId } = this.decodeSessionKey({ sessionKey });
+    const { sessionId } = sessionKey ? this.decodeSessionKey({ sessionKey }) : {};
 
     const archives = await assertResult(
       () => this.video.searchArchives({ sessionId, ...filter }),

--- a/libs/api/src/schemas/SearchArchivesPayload.schema.ts
+++ b/libs/api/src/schemas/SearchArchivesPayload.schema.ts
@@ -2,9 +2,12 @@ import z from 'zod';
 import VideoPayloadSchema from './VideoPayload.schema';
 import ArchiveSearchFilterSchema from './ArchiveSearchFilter.schema';
 
-export const SearchArchivesPayloadSchema = VideoPayloadSchema.extend(
-  ArchiveSearchFilterSchema.shape
-);
+export const SearchArchivesPayloadSchema = VideoPayloadSchema.omit({
+  sessionKey: true,
+}).extend({
+  ...ArchiveSearchFilterSchema.shape,
+  sessionKey: VideoPayloadSchema.shape.sessionKey.optional(),
+});
 
 export type SearchArchivesPayload = z.infer<typeof SearchArchivesPayloadSchema>;
 

--- a/libs/core/src/hooks/index.ts
+++ b/libs/core/src/hooks/index.ts
@@ -1,1 +1,3 @@
 export { default as useVideoStats } from './useVideoStats';
+export { default as useArchives } from './useArchives';
+export type { UseArchivesProps } from './useArchives';

--- a/libs/core/src/hooks/useArchives/index.ts
+++ b/libs/core/src/hooks/useArchives/index.ts
@@ -1,0 +1,2 @@
+export { default } from './useArchives';
+export type { UseArchivesProps } from './useArchives';

--- a/libs/core/src/hooks/useArchives/useArchives.test.ts
+++ b/libs/core/src/hooks/useArchives/useArchives.test.ts
@@ -1,0 +1,109 @@
+import { renderHook as renderHookBase, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { makeTestProvider, providers, ProviderOptions } from '@core-test/providers';
+import useArchives from './useArchives';
+import { makeVideoClientMock } from '@core-test/fixtures';
+import { SingleArchiveResponse } from '@vonage/video';
+
+const singleArchiveResponse = {
+  id: 'archive-1',
+  name: 'test',
+} as SingleArchiveResponse;
+
+describe('useArchives', () => {
+  it('returns archives when the request succeeds', async () => {
+    expect.assertions(4);
+
+    const videoClient = makeVideoClientMock({
+      searchArchives: Promise.resolve({
+        count: 1,
+        items: [singleArchiveResponse],
+      }),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useArchives({
+          sessionKey: 'room-1',
+          queryOptions: { retry: false },
+        }),
+      {
+        runtimeContext: {
+          videoClient,
+        },
+      }
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      if (!result.current.data) {
+        throw new Error('No data');
+      }
+    });
+
+    expect(result.current.data).toEqual({
+      count: 1,
+      items: [{ id: 'archive-1', name: 'test' }],
+    });
+
+    expect(result.current.error).toBeNull();
+
+    expect(videoClient.searchArchives).toHaveBeenCalledWith({
+      sessionKey: 'room-1',
+      count: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('returns error when the request fails', async () => {
+    expect.assertions(3);
+
+    const error = new Error('Failed to fetch archives');
+
+    const videoClient = makeVideoClientMock({
+      searchArchives: Promise.reject(error),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useArchives({
+          sessionKey: 'room-1',
+          queryOptions: { retry: false },
+        }),
+      {
+        runtimeContext: {
+          videoClient,
+        },
+      }
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      if (!result.current.error) {
+        throw new Error('No error');
+      }
+    });
+
+    expect(result.current.error).toEqual(error);
+    expect(result.current.data).toBeUndefined();
+  });
+});
+
+type RenderOptions = {
+  runtimeContext?: ProviderOptions['RuntimeContext'];
+};
+
+function renderHook<Result>(render: () => Result, { runtimeContext }: RenderOptions = {}) {
+  const { wrapper, ...context } = makeTestProvider([providers.runtime], {
+    runtimeContext,
+  });
+
+  return {
+    ...context,
+    ...renderHookBase(render, {
+      wrapper,
+    }),
+  };
+}

--- a/libs/core/src/hooks/useArchives/useArchives.ts
+++ b/libs/core/src/hooks/useArchives/useArchives.ts
@@ -1,0 +1,50 @@
+import { runtime$ } from '@core/stores';
+import type { VideoClient } from '@core/services';
+import type { QueryOptions } from '@core/types';
+
+type Result = Awaited<ReturnType<VideoClient['searchArchives']>>;
+
+type Input = Parameters<VideoClient['searchArchives']>[0];
+
+export type UseArchivesProps<TData = Result> = Input & {
+  queryOptions?: QueryOptions<Result, TData>;
+};
+
+/**
+ * Hook to search for archives.
+ *
+ * @example
+ * const { data, error, isLoading } = useArchives({
+ *   sessionKey: 'room-1',
+ *   count: 10,
+ *   offset: 0
+ * });
+ *
+ * console.log(data); // { items: [...], count: 100 }
+ * console.log(error); // null or Error
+ * console.log(isLoading); // boolean
+ */
+const useArchives = <Selected = Result>({
+  queryOptions,
+  sessionKey,
+  count,
+  offset,
+}: UseArchivesProps<Selected>) => {
+  const videoClient = runtime$.useVideoClient();
+
+  return runtime$.useQuery({
+    ...queryOptions,
+
+    queryKey: ['archives', sessionKey, count, offset],
+
+    queryFn: async () => {
+      return await videoClient.searchArchives({
+        sessionKey,
+        count,
+        offset,
+      });
+    },
+  });
+};
+
+export default useArchives;

--- a/libs/core/test/fixtures/index.ts
+++ b/libs/core/test/fixtures/index.ts
@@ -1,0 +1,1 @@
+export { default as makeVideoClientMock } from './makeVideoClientMock';

--- a/libs/core/test/fixtures/makeVideoClientMock.ts
+++ b/libs/core/test/fixtures/makeVideoClientMock.ts
@@ -1,0 +1,46 @@
+import type { Mocked } from 'vitest';
+import type { VideoClient } from '@core/services';
+import { AnyFunction } from '@common/types';
+import { isFunction, isNil } from '@common/assertions';
+
+type VideoClientFnMock<K extends keyof VideoClient, Result = Awaited<ReturnType<VideoClient[K]>>> =
+  | Promise<Result>
+  | VideoClient[K];
+
+type VideoClientMock = Partial<{
+  [K in keyof VideoClient]: VideoClientFnMock<K>;
+}>;
+
+const makeVideoClientMock = (mock: VideoClientMock): Mocked<VideoClient> => {
+  const target: Record<string, AnyFunction> = {};
+
+  Object.keys(mock).forEach((key) => {
+    const value = mock[key as keyof VideoClientMock];
+
+    if (!isFunction(value)) {
+      target[key] = vi.fn(() => value);
+      return;
+    }
+
+    if (vi.isMockFunction(value)) {
+      target[key] = value as AnyFunction;
+      return;
+    }
+
+    target[key] = vi.fn(value);
+  });
+
+  return new Proxy(target, {
+    get(target, prop: string) {
+      const value = target[prop as keyof VideoClientMock];
+
+      if (isNil(value)) {
+        throw new Error(`Method ${prop} has not been implemented in the mock`);
+      }
+
+      return value;
+    },
+  }) as Mocked<VideoClient>;
+};
+
+export default makeVideoClientMock;

--- a/libs/core/test/index.ts
+++ b/libs/core/test/index.ts
@@ -1,0 +1,1 @@
+export * from './providers';

--- a/libs/core/test/providers/index.ts
+++ b/libs/core/test/providers/index.ts
@@ -1,0 +1,6 @@
+export {
+  default as makeRuntimeProviderWrapper,
+  type RuntimeProviderWrapperOptions,
+} from './makeRuntimeProviderWrapper';
+
+export { default as makeTestProvider, providers, type ProviderOptions } from './makeTestProvider';

--- a/libs/core/test/providers/makeRuntimeProviderWrapper.ts
+++ b/libs/core/test/providers/makeRuntimeProviderWrapper.ts
@@ -1,0 +1,23 @@
+import runtime$ from '@core/stores/runtime';
+import RuntimeProvider from '@core/stores/runtime/RuntimeProvider';
+import { makeGenericProviderWrapper } from '@web-test';
+import type { GenericWrapperOptions } from '@web-test/makeGenericProviderWrapper';
+import type { VideoClient } from '@core/services';
+
+export type RuntimeProviderWrapperOptions = Omit<
+  GenericWrapperOptions<typeof RuntimeProvider, typeof runtime$.Context>,
+  'videoClient'
+> & {
+  videoClient?: VideoClient | null;
+};
+
+function makeRuntimeProviderWrapper(options: RuntimeProviderWrapperOptions = {}) {
+  const [wrapper, context] = makeGenericProviderWrapper(RuntimeProvider, runtime$.Context, {
+    videoClient: null!,
+    ...options,
+  } as Parameters<typeof RuntimeProvider>[0]);
+
+  return { wrapper, context };
+}
+
+export default makeRuntimeProviderWrapper;

--- a/libs/core/test/providers/makeTestProvider.ts
+++ b/libs/core/test/providers/makeTestProvider.ts
@@ -1,0 +1,138 @@
+import composeProviders, { type ProviderComponent } from '@web/helpers/composeProviders';
+import { makeRuntimeProviderWrapper, type RuntimeProviderWrapperOptions } from './makersIndex';
+
+/**
+ * Keep updated accordingly to the providers you have and their dependencies.
+ */
+export enum providers {
+  runtime = 'runtime',
+}
+
+type ProviderOptionsByKey = {
+  [providers.runtime]: RuntimeProviderWrapperOptions;
+};
+
+type ProviderContextsByKey = {
+  [providers.runtime]: NonNullable<ReturnType<typeof makeRuntimeProviderWrapper>['context']>;
+};
+
+/**
+ * Keep updated accordingly to the providers you have and their dependencies.
+ */
+const PROVIDER_DEPENDENCIES = {
+  [providers.runtime]: [],
+} as const;
+
+/**
+ * Infer the possible parameters for the provided keys
+ */
+type ProviderOptionsFor<Keys extends readonly providers[]> = {
+  [K in Keys[number] as `${K}Context`]: ProviderOptionsByKey[K] | undefined;
+};
+
+/**
+ * Infer the context britches for the provided keys
+ */
+type ProviderContextsFor<Keys extends readonly providers[]> = {
+  [K in Keys[number] as `${K}Context`]: ProviderContextsByKey[K];
+};
+
+function makeTestProvider<
+  Keys extends readonly providers[],
+  Options extends ProviderOptionsFor<Keys>,
+>(
+  keys: Keys,
+  options?: Options
+): {
+  wrapper: ProviderComponent;
+} & ProviderContextsFor<Keys> {
+  /**
+   * Check all the dependencies are included in the keys
+   * Even if the maker knows it's dependencies, we need the keys to infer the correct type and to avoid duplicate providers
+   */
+  (() => {
+    const necessaryKeys = new Set(
+      keys.reduce((acc, key) => {
+        return [...acc, ...PROVIDER_DEPENDENCIES[key], key];
+      }, [] as providers[])
+    );
+
+    const isMissingDependency =
+      necessaryKeys.size < keys.length || ![...necessaryKeys].every((key) => keys.includes(key));
+
+    if (isMissingDependency) {
+      throw new Error(
+        `Some dependencies are missing for the provided keys. Provided keys: ${keys.join(
+          ', '
+        )}. Necessary keys: ${[...necessaryKeys].join(', ')}.`
+      );
+    }
+  })();
+
+  /**
+   * Sort providers in topological dependency order so that parents are always
+   * rendered as ancestors of the components that depend on them.
+   * composeProviders(reduceRight) makes the first element the outermost wrapper.
+   */
+  const sortedKeys = (() => {
+    const visited = new Set<providers>();
+    const result: providers[] = [];
+
+    const visit = (key: providers) => {
+      if (visited.has(key)) return;
+
+      visited.add(key);
+
+      for (const dependency of PROVIDER_DEPENDENCIES[key]) {
+        if ((keys as readonly providers[]).includes(dependency)) {
+          visit(dependency);
+        }
+      }
+
+      result.push(key);
+    };
+
+    for (const key of keys) {
+      visit(key);
+    }
+
+    return result;
+  })();
+
+  /**
+   * Create the providers wrappers and contexts for the provided keys
+   */
+  const providerWrappers = sortedKeys.map((key) => {
+    switch (key) {
+      case providers.runtime:
+        return makeRuntimeProviderWrapper(
+          (options as ProviderOptionsFor<[providers.runtime]> | undefined)?.runtimeContext
+        );
+      default:
+        throw new Error(`Unknown provider: ${key}`);
+    }
+  });
+
+  const wrapper = composeProviders(...providerWrappers.map(({ wrapper }) => wrapper));
+
+  return {
+    wrapper,
+    ...providerWrappers.reduce((acc, { context }, index) => {
+      const key = sortedKeys[index];
+
+      return {
+        ...acc,
+        [`${key}Context` as keyof ProviderContextsFor<Keys>]: context,
+      };
+    }, {} as ProviderContextsFor<Keys>),
+  };
+}
+
+/**
+ * All parameters
+ */
+export type ProviderOptions = {
+  [K in providers as `${Capitalize<K>}Context`]?: ProviderOptionsByKey[K];
+};
+
+export default makeTestProvider;

--- a/libs/core/test/providers/makersIndex.ts
+++ b/libs/core/test/providers/makersIndex.ts
@@ -1,0 +1,4 @@
+export {
+  default as makeRuntimeProviderWrapper,
+  type RuntimeProviderWrapperOptions,
+} from './makeRuntimeProviderWrapper';

--- a/libs/core/tsconfig.json
+++ b/libs/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "files": [],
-  "include": ["eslint.config.mjs", "./test/setup.ts"],
+  "include": ["eslint.config.mjs", "./test/setup.ts", "./test/**/*.ts", "./test/**/*.tsx"],
   "references": [
     {
       "path": "./tsconfig.lib.json"
@@ -13,6 +13,7 @@
   "compilerOptions": {
     "rootDir": "..",
     "baseUrl": "./",
+    "jsx": "react-jsx",
     "moduleResolution": "bundler",
     "composite": true,
     "paths": {
@@ -20,6 +21,8 @@
       "@common/*": ["../common/src/*"],
       "@core": ["./src"],
       "@core/*": ["./src/*"],
+      "@core-test": ["./test"],
+      "@core-test/*": ["./test/*"],
       "@web": ["../common/srcBrowser"],
       "@web/*": ["../common/srcBrowser/*"],
       "@common-test": ["../common/test"],

--- a/libs/core/tsconfig.spec.json
+++ b/libs/core/tsconfig.spec.json
@@ -7,6 +7,7 @@
   "include": [
     "vite.config.ts",
     "test/**/*.ts",
+    "test/**/*.tsx",
     "src/**/*.ts",
     "src/**/*.tsx",
     "../common/src/**/*.ts",

--- a/libs/core/vite.config.ts
+++ b/libs/core/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(() => ({
   resolve: {
     alias: {
       '@core': path.resolve(__dirname, './src'),
+      '@core-test': path.resolve(__dirname, './test'),
       '@common': path.resolve(__dirname, '../common/src'),
       '@web': path.resolve(__dirname, '../common/srcBrowser'),
       '@common-test': path.resolve(__dirname, '../common/test'),

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -20,6 +20,8 @@
       "@web-test/*": ["../common/testBrowser/*"],
       "@core": ["../core/src"],
       "@core/*": ["../core/src/*"],
+      "@core-test": ["../core/test"],
+      "@core-test/*": ["../core/test/*"],
 
       // video-router paths (this is just for linter and types)
       "@api-lib/*": ["../api/src/*"],

--- a/libs/ui/tsconfig.lib.json
+++ b/libs/ui/tsconfig.lib.json
@@ -28,5 +28,12 @@
     "../api/src/**/*.ts",
     "../common/srcNode/**/*.ts"
   ],
-  "exclude": ["**/*.spec.*", "**/*.test.*", "../api/**/*.test.*", "../api/**/*.spec.*"]
+  "exclude": [
+    "**/*.spec.*",
+    "**/*.test.*",
+    "../api/**/*.test.*",
+    "../api/**/*.spec.*",
+    "../core/**/*.test.*",
+    "../core/**/*.spec.*"
+  ]
 }


### PR DESCRIPTION
#### What is this PR doing?
We are moving archives retrieval to the core lib, this is an extra for having a simple to use sdk that customer can implement to develop video applications without having to lose time on the primives

#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-403](https://jira.vonage.com/browse/VIDSOL-403)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
