### PR TITLE
VIDSOL-882: Seeing multiple errors in console when hitting Cancel button on a screenshare

### DIFF
--- a/frontend/src/hooks/tests/useScreenShare.spec.tsx
+++ b/frontend/src/hooks/tests/useScreenShare.spec.tsx
@@ -46,6 +46,7 @@ describe('useScreenSharing', () => {
     } as unknown as MediaStream);
 
     // JSDOM does not provide navigator.mediaDevices; define the whole property.
+    originalMediaDevices = navigator.mediaDevices;
     Object.defineProperty(navigator, 'mediaDevices', {
       value: { getDisplayMedia: mockGetDisplayMedia },
       writable: true,

--- a/frontend/src/hooks/tests/useScreenShare.spec.tsx
+++ b/frontend/src/hooks/tests/useScreenShare.spec.tsx
@@ -18,9 +18,11 @@ describe('useScreenSharing', () => {
   let mockVideoTrack: MediaStreamTrack;
   let originalMediaDevices: MediaDevices | undefined;
   let handlers: Record<string, (...args: unknown[]) => void>;
-  const mockPublish = vi.fn();
-  const mockUnpublish = vi.fn();
-  const mockGetDisplayMedia = vi.fn();
+  const mockPublish = vi.fn((_publisher: Publisher) => Promise.resolve());
+  const mockUnpublish = vi.fn((_publisher: Publisher) => undefined);
+  const mockGetDisplayMedia = vi.fn(() =>
+    Promise.resolve({ getVideoTracks: () => [] } as unknown as MediaStream)
+  );
   beforeEach(() => {
     handlers = {};
     mockVonageVideoClient = Object.assign(new EventEmitter(), {
@@ -53,10 +55,16 @@ describe('useScreenSharing', () => {
       configurable: true,
     });
 
-    (initPublisher as ReturnType<typeof vi.fn>).mockReturnValue(mockPublisher as Publisher);
+    vi.mocked(initPublisher).mockReturnValue(mockPublisher as Publisher);
   });
 
   afterEach(() => {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: originalMediaDevices,
+      writable: true,
+      configurable: true,
+    });
+
     vi.clearAllMocks();
   });
 
@@ -71,8 +79,10 @@ describe('useScreenSharing', () => {
         __interceptor: (context) => {
           if (context) {
             context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
-            context.publish = mockPublish;
-            context.unpublish = mockUnpublish;
+            context.publish = async (publisher) => mockPublish(publisher);
+            context.unpublish = (publisher) => {
+              mockUnpublish(publisher);
+            };
           }
         },
       },
@@ -109,8 +119,10 @@ describe('useScreenSharing', () => {
         __interceptor: (context) => {
           if (context) {
             context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
-            context.publish = mockPublish;
-            context.unpublish = mockUnpublish;
+            context.publish = async (publisher) => mockPublish(publisher);
+            context.unpublish = (publisher) => {
+              mockUnpublish(publisher);
+            };
           }
         },
       },
@@ -119,11 +131,24 @@ describe('useScreenSharing', () => {
     await act(async () => {
       // toggling screen share on
       await result.current.toggleShareScreen();
+    });
+
+    act(() => {
+      handlers['streamCreated']();
+    });
+
+    await act(async () => {
       // toggling screen share off
       await result.current.toggleShareScreen();
     });
 
     expect(result.current.isSharingScreen).toBe(false);
+    expect(mockUnpublish).toHaveBeenCalledWith(mockPublisher);
+    expect(mockPublisher.destroy).toHaveBeenCalledTimes(1);
+    expect(mockVonageVideoClient.off).toHaveBeenCalledWith(
+      'screenshareStreamCreated',
+      expect.any(Function)
+    );
   });
 
   it('sets isEntireScreen to true when displaySurface is monitor', async () => {
@@ -137,8 +162,10 @@ describe('useScreenSharing', () => {
         __interceptor: (context) => {
           if (context) {
             context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
-            context.publish = mockPublish;
-            context.unpublish = mockUnpublish;
+            context.publish = async (publisher) => mockPublish(publisher);
+            context.unpublish = (publisher) => {
+              mockUnpublish(publisher);
+            };
           }
         },
       },
@@ -173,8 +200,10 @@ describe('useScreenSharing', () => {
         __interceptor: (context) => {
           if (context) {
             context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
-            context.publish = mockPublish;
-            context.unpublish = mockUnpublish;
+            context.publish = async (publisher) => mockPublish(publisher);
+            context.unpublish = (publisher) => {
+              mockUnpublish(publisher);
+            };
           }
         },
       },
@@ -208,8 +237,10 @@ describe('useScreenSharing', () => {
         __interceptor: (context) => {
           if (context) {
             context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
-            context.publish = mockPublish;
-            context.unpublish = mockUnpublish;
+            context.publish = async (publisher) => mockPublish(publisher);
+            context.unpublish = (publisher) => {
+              mockUnpublish(publisher);
+            };
           }
         },
       },
@@ -252,8 +283,10 @@ describe('useScreenSharing', () => {
         __interceptor: (context) => {
           if (context) {
             context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
-            context.publish = mockPublish;
-            context.unpublish = mockUnpublish;
+            context.publish = async (publisher) => mockPublish(publisher);
+            context.unpublish = (publisher) => {
+              mockUnpublish(publisher);
+            };
           }
         },
       },
@@ -295,8 +328,10 @@ describe('useScreenSharing', () => {
         __interceptor: (context) => {
           if (context) {
             context.vonageVideoClient = null;
-            context.publish = mockPublish;
-            context.unpublish = mockUnpublish;
+            context.publish = async (publisher) => mockPublish(publisher);
+            context.unpublish = (publisher) => {
+              mockUnpublish(publisher);
+            };
           }
         },
       },
@@ -327,8 +362,10 @@ describe('useScreenSharing', () => {
         __interceptor: (context) => {
           if (context) {
             context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
-            context.publish = mockPublish;
-            context.unpublish = mockUnpublish;
+            context.publish = async (publisher) => mockPublish(publisher);
+            context.unpublish = (publisher) => {
+              mockUnpublish(publisher);
+            };
           }
         },
       },
@@ -341,6 +378,138 @@ describe('useScreenSharing', () => {
     // initPublisher must never be called – the SDK should not be involved in the cancel path.
     expect(initPublisher).not.toHaveBeenCalled();
     expect(result.current.isSharingScreen).toBe(false);
+  });
+
+  it('does not initialize publisher when getDisplayMedia returns no video tracks', async () => {
+    mockGetDisplayMedia.mockResolvedValueOnce({
+      getVideoTracks: () => [],
+    } as unknown as MediaStream);
+
+    const { result } = render(
+      makeRenderOptions({ mockVonageVideoClient, mockPublish, mockUnpublish })
+    );
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    expect(initPublisher).not.toHaveBeenCalled();
+    expect(mockPublish).not.toHaveBeenCalled();
+    expect(result.current.isSharingScreen).toBe(false);
+  });
+
+  it('stops the track and resets state when initPublisher reports an error', async () => {
+    expect.assertions(4);
+
+    const { result } = render(
+      makeRenderOptions({ mockVonageVideoClient, mockPublish, mockUnpublish })
+    );
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    const publisherErrorCallback = vi.mocked(initPublisher).mock.calls[0]?.[2];
+
+    act(() => {
+      publisherErrorCallback?.(new Error('publisher failed'));
+    });
+
+    expect(publisherErrorCallback).toEqual(expect.any(Function));
+    expect(mockVideoTrack.stop).toHaveBeenCalledTimes(1);
+    expect(result.current.isSharingScreen).toBe(false);
+    expect(result.current.screensharingPublisher).toBe(null);
+  });
+
+  it('destroys the publisher and stops the track when publish fails', async () => {
+    expect.assertions(6);
+
+    mockPublish.mockRejectedValueOnce(new Error('publish failed'));
+
+    const { result } = render(
+      makeRenderOptions({ mockVonageVideoClient, mockPublish, mockUnpublish })
+    );
+
+    await act(async () => {
+      await expect(result.current.toggleShareScreen()).resolves.toBeUndefined();
+    });
+
+    expect(mockPublish).toHaveBeenCalledWith(mockPublisher);
+    expect(mockVideoTrack.stop).toHaveBeenCalledTimes(1);
+    expect(mockPublisher.destroy).toHaveBeenCalledTimes(1);
+    expect(result.current.isSharingScreen).toBe(false);
+    expect(result.current.screensharingPublisher).toBe(null);
+  });
+
+  it('unpublishes the current share when another screenshare stream is created', async () => {
+    const { result } = render(
+      makeRenderOptions({ mockVonageVideoClient, mockPublish, mockUnpublish })
+    );
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    act(() => {
+      handlers['streamCreated']();
+    });
+
+    const streamCreatedHandlerCall = vi
+      .mocked(mockVonageVideoClient.on!)
+      .mock.calls.find(([eventName]) => eventName === 'screenshareStreamCreated');
+    const streamCreatedHandler = streamCreatedHandlerCall?.[1] as (() => void) | undefined;
+
+    act(() => {
+      streamCreatedHandler?.();
+    });
+
+    expect(streamCreatedHandler).toEqual(expect.any(Function));
+    expect(mockUnpublish).toHaveBeenCalledWith(mockPublisher);
+    expect(result.current.isSharingScreen).toBe(false);
+  });
+
+  it('keeps entire-screen detection false when video metadata is unavailable', async () => {
+    const { result } = render(
+      makeRenderOptions({ mockVonageVideoClient, mockPublish, mockUnpublish })
+    );
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    const mockVideoElement = {
+      srcObject: null,
+    } as unknown as HTMLVideoElement;
+
+    act(() => {
+      handlers['videoElementCreated']({ element: mockVideoElement });
+    });
+
+    expect(result.current.screenshareVideoElement).toBe(mockVideoElement);
+    expect(result.current.isEntireScreen).toBe(false);
+  });
+
+  it('stops the track and clears state when media sharing stops', async () => {
+    const { result } = render(
+      makeRenderOptions({ mockVonageVideoClient, mockPublish, mockUnpublish })
+    );
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    act(() => {
+      handlers['streamCreated']();
+      handlers['mediaStopped']();
+    });
+
+    expect(mockVideoTrack.stop).toHaveBeenCalledTimes(1);
+    expect(mockVonageVideoClient.off).toHaveBeenCalledWith(
+      'screenshareStreamCreated',
+      expect.any(Function)
+    );
+    expect(result.current.isSharingScreen).toBe(false);
+    expect(result.current.screensharingPublisher).toBe(null);
   });
 });
 
@@ -364,5 +533,34 @@ function render({ userContext, sessionContext }: RenderOptions = {}) {
     ...renderHookBase(() => useScreenShare(), {
       wrapper,
     }),
+  };
+}
+
+function makeRenderOptions({
+  mockVonageVideoClient,
+  mockPublish,
+  mockUnpublish,
+}: {
+  mockVonageVideoClient: Partial<VonageVideoClient>;
+  mockPublish: (publisher: Publisher) => Promise<void>;
+  mockUnpublish: (publisher: Publisher) => void;
+}): RenderOptions {
+  return {
+    userContext: {
+      __interceptor: (context: UserContextType | null) => {
+        context!.user.defaultSettings.name = 'TestUser';
+      },
+    },
+    sessionContext: {
+      __interceptor: (context) => {
+        if (context) {
+          context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
+          context.publish = async (publisher) => mockPublish(publisher);
+          context.unpublish = (publisher) => {
+            mockUnpublish(publisher);
+          };
+        }
+      },
+    },
   };
 }

--- a/frontend/src/hooks/tests/useScreenShare.spec.tsx
+++ b/frontend/src/hooks/tests/useScreenShare.spec.tsx
@@ -15,9 +15,11 @@ vi.mock('@vonage/client-sdk-video', () => ({
 describe('useScreenSharing', () => {
   let mockVonageVideoClient: Partial<VonageVideoClient>;
   let mockPublisher: Partial<Publisher>;
+  let mockVideoTrack: MediaStreamTrack;
   let handlers: Record<string, (...args: unknown[]) => void>;
   const mockPublish = vi.fn();
   const mockUnpublish = vi.fn();
+  const mockGetDisplayMedia = vi.fn();
 
   beforeEach(() => {
     handlers = {};
@@ -32,6 +34,23 @@ describe('useScreenSharing', () => {
       }),
       destroy: vi.fn(),
     } as unknown as Partial<Publisher>;
+
+    mockVideoTrack = {
+      kind: 'video',
+      stop: vi.fn(),
+      getSettings: vi.fn().mockReturnValue({}),
+    } as unknown as MediaStreamTrack;
+
+    mockGetDisplayMedia.mockResolvedValue({
+      getVideoTracks: () => [mockVideoTrack],
+    } as unknown as MediaStream);
+
+    // JSDOM does not provide navigator.mediaDevices; define the whole property.
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: { getDisplayMedia: mockGetDisplayMedia },
+      writable: true,
+      configurable: true,
+    });
 
     (initPublisher as ReturnType<typeof vi.fn>).mockReturnValue(mockPublisher as Publisher);
   });
@@ -66,7 +85,7 @@ describe('useScreenSharing', () => {
     expect(initPublisher).toHaveBeenCalledWith(
       undefined,
       {
-        videoSource: 'screen',
+        videoSource: mockVideoTrack,
         insertDefaultUI: false,
         videoContentHint: 'detail',
         name: "TestUser's screen",
@@ -287,6 +306,40 @@ describe('useScreenSharing', () => {
     });
 
     expect(initPublisher).not.toHaveBeenCalled();
+  });
+
+  it('handles canceled screen share prompt without throwing', async () => {
+    expect.assertions(3);
+
+    // Simulate the user cancelling the browser screen-picker before the SDK is involved.
+    mockGetDisplayMedia.mockRejectedValueOnce(
+      new DOMException('Permission denied', 'NotAllowedError')
+    );
+
+    const { result } = render({
+      userContext: {
+        __interceptor: (context: UserContextType | null) => {
+          context!.user.defaultSettings.name = 'TestUser';
+        },
+      },
+      sessionContext: {
+        __interceptor: (context) => {
+          if (context) {
+            context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
+            context.publish = mockPublish;
+            context.unpublish = mockUnpublish;
+          }
+        },
+      },
+    });
+
+    await act(async () => {
+      await expect(result.current.toggleShareScreen()).resolves.toBeUndefined();
+    });
+
+    // initPublisher must never be called – the SDK should not be involved in the cancel path.
+    expect(initPublisher).not.toHaveBeenCalled();
+    expect(result.current.isSharingScreen).toBe(false);
   });
 });
 

--- a/frontend/src/hooks/tests/useScreenShare.spec.tsx
+++ b/frontend/src/hooks/tests/useScreenShare.spec.tsx
@@ -16,11 +16,11 @@ describe('useScreenSharing', () => {
   let mockVonageVideoClient: Partial<VonageVideoClient>;
   let mockPublisher: Partial<Publisher>;
   let mockVideoTrack: MediaStreamTrack;
+  let originalMediaDevices: MediaDevices | undefined;
   let handlers: Record<string, (...args: unknown[]) => void>;
   const mockPublish = vi.fn();
   const mockUnpublish = vi.fn();
   const mockGetDisplayMedia = vi.fn();
-
   beforeEach(() => {
     handlers = {};
     mockVonageVideoClient = Object.assign(new EventEmitter(), {

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -64,7 +64,6 @@ const useScreenShare = (): UseScreenShareType => {
     if (isSharingScreen) {
       if (screenSharingPubRef.current) {
         unpublishScreenshare();
-        screenSharingPubRef.current.getVideoSource()?.track?.stop();
         screenSharingPubRef.current.destroy();
         vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
       }

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -149,7 +149,9 @@ const useScreenShare = (): UseScreenShareType => {
       await publish(screenSharingPubRef.current);
     } catch {
       videoTrack.stop();
+      screenSharingPubRef.current?.destroy();
       onScreenShareStopped();
+      return;
     }
 
     vonageVideoClient.on('screenshareStreamCreated', handleStreamCreated);

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -65,9 +65,9 @@ const useScreenShare = (): UseScreenShareType => {
       if (screenSharingPubRef.current) {
         unpublishScreenshare();
         screenSharingPubRef.current.destroy();
-        screenSharingPubRef.current = null;
         vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
       }
+      onScreenShareStopped();
       return;
     }
 

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -57,71 +57,100 @@ const useScreenShare = (): UseScreenShareType => {
 
   // Using useCallback to memoize the function to avoid unnecessary re-renders
   const toggleShareScreen = useCallback(async () => {
-    if (vonageVideoClient) {
-      if (!isSharingScreen) {
-        // Initializing the publisher for screen sharing
-        screenSharingPubRef.current = initPublisher(
-          undefined,
-          {
-            videoSource: 'screen',
-            insertDefaultUI: false,
-            videoContentHint: 'detail',
-            name: t('participants.screen', { participantName: user.defaultSettings.name }),
-          },
-          (err) => {
-            if (err) {
-              onScreenShareStopped();
-            }
-          }
-        );
-
-        // Adding class for screen sharing styling
-        screenSharingPubRef.current?.element?.classList.add('OT_big');
-
-        // Handling stream creation event
-        screenSharingPubRef.current?.on('streamCreated', () => {
-          setIsSharingScreen(true);
-        });
-
-        screenSharingPubRef.current?.on('videoElementCreated', (e) => {
-          const videoEl = e.element as HTMLVideoElement;
-          setScreenshareVideoElement(videoEl);
-          const mediaStream = videoEl.srcObject as MediaStream | null;
-          const track = mediaStream?.getVideoTracks?.()[0];
-          const settings = track?.getSettings?.();
-          const displaySurface = settings?.displaySurface;
-
-          const width = settings?.width;
-          const height = settings?.height;
-
-          const isMonitor =
-            displaySurface === 'monitor' ||
-            (!displaySurface &&
-              width !== undefined &&
-              height !== undefined &&
-              width * height >= window.screen.width * window.screen.height);
-
-          setIsEntireScreen(isMonitor);
-        });
-
-        screenSharingPubRef.current?.on('streamDestroyed', () => {
-          onScreenShareStopped();
-        });
-
-        // Handling media stopped event
-        screenSharingPubRef.current?.on('mediaStopped', () => {
-          onScreenShareStopped();
-        });
-
-        // Publishing the screen sharing stream
-        await publish(screenSharingPubRef.current);
-
-        vonageVideoClient?.on('screenshareStreamCreated', handleStreamCreated);
-      } else if (screenSharingPubRef.current) {
-        unpublishScreenshare();
-        vonageVideoClient?.off('screenshareStreamCreated', handleStreamCreated);
-      }
+    if (!vonageVideoClient) {
+      return;
     }
+
+    if (isSharingScreen) {
+      if (screenSharingPubRef.current) {
+        unpublishScreenshare();
+        vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
+      }
+      return;
+    }
+
+    // We are calling display media before initializing the publisher to avoid SDK log errors.
+    // By calling getDisplayMedia ourselves first, we can handle the cancel case avoiding unwanted error logs.
+    let videoTrack: MediaStreamTrack;
+    try {
+      const displayStream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: false,
+      });
+      const videoTracks = displayStream.getVideoTracks();
+      if (videoTracks.length === 0) {
+        return;
+      }
+      videoTrack = videoTracks[0];
+    } catch {
+      // User cancelled the screen picker or permission was denied – exit silently.
+      return;
+    }
+
+    // Initializing the publisher for screen sharing
+    screenSharingPubRef.current = initPublisher(
+      undefined,
+      {
+        videoSource: videoTrack,
+        insertDefaultUI: false,
+        videoContentHint: 'detail',
+        name: t('participants.screen', { participantName: user.defaultSettings.name }),
+      },
+      (err) => {
+        if (err) {
+          videoTrack.stop();
+          onScreenShareStopped();
+        }
+      }
+    );
+
+    // Adding class for screen sharing styling
+    screenSharingPubRef.current?.element?.classList.add('OT_big');
+
+    // Handling stream creation event
+    screenSharingPubRef.current?.on('streamCreated', () => {
+      setIsSharingScreen(true);
+    });
+
+    screenSharingPubRef.current?.on('videoElementCreated', (e) => {
+      const videoEl = e.element as HTMLVideoElement;
+      setScreenshareVideoElement(videoEl);
+      const mediaStream = videoEl.srcObject as MediaStream | null;
+      const track = mediaStream?.getVideoTracks?.()[0];
+      const settings = track?.getSettings?.();
+      const displaySurface = settings?.displaySurface;
+
+      const width = settings?.width;
+      const height = settings?.height;
+
+      const isMonitor =
+        displaySurface === 'monitor' ||
+        (!displaySurface &&
+          width !== undefined &&
+          height !== undefined &&
+          width * height >= window.screen.width * window.screen.height);
+
+      setIsEntireScreen(isMonitor);
+    });
+
+    screenSharingPubRef.current?.on('streamDestroyed', () => {
+      onScreenShareStopped();
+    });
+
+    // Handling media stopped event
+    screenSharingPubRef.current?.on('mediaStopped', () => {
+      onScreenShareStopped();
+    });
+
+    // Publishing the screen sharing stream
+    try {
+      await publish(screenSharingPubRef.current);
+    } catch {
+      videoTrack.stop();
+      onScreenShareStopped();
+    }
+
+    vonageVideoClient.on('screenshareStreamCreated', handleStreamCreated);
   }, [
     vonageVideoClient,
     isSharingScreen,

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -64,6 +64,8 @@ const useScreenShare = (): UseScreenShareType => {
     if (isSharingScreen) {
       if (screenSharingPubRef.current) {
         unpublishScreenshare();
+        screenSharingPubRef.current.destroy();
+        screenSharingPubRef.current = null;
         vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
       }
       return;

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -64,6 +64,7 @@ const useScreenShare = (): UseScreenShareType => {
     if (isSharingScreen) {
       if (screenSharingPubRef.current) {
         unpublishScreenshare();
+        screenSharingPubRef.current.getVideoSource()?.track?.stop();
         screenSharingPubRef.current.destroy();
         vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
       }

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -144,6 +144,9 @@ const useScreenShare = (): UseScreenShareType => {
 
     // Handling media stopped event
     screenSharingPubRef.current?.on('mediaStopped', () => {
+      videoTrack.stop();
+      vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
+      screenSharingPubRef.current?.destroy();
       onScreenShareStopped();
     });
 

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -136,6 +136,9 @@ const useScreenShare = (): UseScreenShareType => {
     });
 
     screenSharingPubRef.current?.on('streamDestroyed', () => {
+      videoTrack.stop();
+      vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
+      screenSharingPubRef.current?.destroy();
       onScreenShareStopped();
     });
 

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -135,20 +135,23 @@ const useScreenShare = (): UseScreenShareType => {
       setIsEntireScreen(isMonitor);
     });
 
-    screenSharingPubRef.current?.on('streamDestroyed', () => {
+    const screensharingPublisher = screenSharingPubRef.current;
+
+    const handleScreenshareStopped = () => {
       videoTrack.stop();
+
+      if (screenSharingPubRef.current !== screensharingPublisher) {
+        return;
+      }
+
       vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
-      screenSharingPubRef.current?.destroy();
       onScreenShareStopped();
-    });
+    };
+
+    screensharingPublisher?.on('streamDestroyed', handleScreenshareStopped);
 
     // Handling media stopped event
-    screenSharingPubRef.current?.on('mediaStopped', () => {
-      videoTrack.stop();
-      vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
-      screenSharingPubRef.current?.destroy();
-      onScreenShareStopped();
-    });
+    screensharingPublisher?.on('mediaStopped', handleScreenshareStopped);
 
     // Publishing the screen sharing stream
     try {


### PR DESCRIPTION
#### What is this PR doing?
Fix seeing multiple errors in console when hitting Cancel button on a screen-share.

#### How should this be manually tested?
Check console and try to screen share and cancel.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-882](https://jira.vonage.com/browse/VIDSOL-882)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
