### PR TITLE
VIDSOL-882: Seeing multiple errors in console when hitting Cancel button on a screenshare

### DIFF
--- a/frontend/src/hooks/tests/useScreenShare.spec.tsx
+++ b/frontend/src/hooks/tests/useScreenShare.spec.tsx
@@ -15,9 +15,11 @@ vi.mock('@vonage/client-sdk-video', () => ({
 describe('useScreenSharing', () => {
   let mockVonageVideoClient: Partial<VonageVideoClient>;
   let mockPublisher: Partial<Publisher>;
+  let mockVideoTrack: MediaStreamTrack;
   let handlers: Record<string, (...args: unknown[]) => void>;
   const mockPublish = vi.fn();
   const mockUnpublish = vi.fn();
+  const mockGetDisplayMedia = vi.fn();
 
   beforeEach(() => {
     handlers = {};
@@ -32,6 +34,23 @@ describe('useScreenSharing', () => {
       }),
       destroy: vi.fn(),
     } as unknown as Partial<Publisher>;
+
+    mockVideoTrack = {
+      kind: 'video',
+      stop: vi.fn(),
+      getSettings: vi.fn().mockReturnValue({}),
+    } as unknown as MediaStreamTrack;
+
+    mockGetDisplayMedia.mockResolvedValue({
+      getVideoTracks: () => [mockVideoTrack],
+    } as unknown as MediaStream);
+
+    // JSDOM does not provide navigator.mediaDevices; define the whole property.
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: { getDisplayMedia: mockGetDisplayMedia },
+      writable: true,
+      configurable: true,
+    });
 
     (initPublisher as ReturnType<typeof vi.fn>).mockReturnValue(mockPublisher as Publisher);
   });
@@ -66,7 +85,7 @@ describe('useScreenSharing', () => {
     expect(initPublisher).toHaveBeenCalledWith(
       undefined,
       {
-        videoSource: 'screen',
+        videoSource: mockVideoTrack,
         insertDefaultUI: false,
         videoContentHint: 'detail',
         name: "TestUser's screen",
@@ -287,6 +306,40 @@ describe('useScreenSharing', () => {
     });
 
     expect(initPublisher).not.toHaveBeenCalled();
+  });
+
+  it('handles canceled screen share prompt without throwing', async () => {
+    expect.assertions(3);
+
+    // Simulate the user cancelling the browser screen-picker before the SDK is involved.
+    mockGetDisplayMedia.mockRejectedValueOnce(
+      new DOMException('Permission denied', 'NotAllowedError')
+    );
+
+    const { result } = render({
+      userContext: {
+        __interceptor: (context: UserContextType | null) => {
+          context!.user.defaultSettings.name = 'TestUser';
+        },
+      },
+      sessionContext: {
+        __interceptor: (context) => {
+          if (context) {
+            context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
+            context.publish = mockPublish;
+            context.unpublish = mockUnpublish;
+          }
+        },
+      },
+    });
+
+    await act(async () => {
+      await expect(result.current.toggleShareScreen()).resolves.toBeUndefined();
+    });
+
+    // initPublisher must never be called – the SDK should not be involved in the cancel path.
+    expect(initPublisher).not.toHaveBeenCalled();
+    expect(result.current.isSharingScreen).toBe(false);
   });
 });
 

--- a/frontend/src/hooks/tests/useScreenShare.spec.tsx
+++ b/frontend/src/hooks/tests/useScreenShare.spec.tsx
@@ -341,6 +341,139 @@ describe('useScreenSharing', () => {
     expect(initPublisher).not.toHaveBeenCalled();
     expect(result.current.isSharingScreen).toBe(false);
   });
+
+  it('returns early when display stream contains no video tracks', async () => {
+    mockGetDisplayMedia.mockResolvedValueOnce({
+      getVideoTracks: () => [],
+    } as unknown as MediaStream);
+
+    const { result } = render({
+      userContext: {
+        __interceptor: (context: UserContextType | null) => {
+          context!.user.defaultSettings.name = 'TestUser';
+        },
+      },
+      sessionContext: {
+        __interceptor: (context) => {
+          if (context) {
+            context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
+            context.publish = mockPublish;
+            context.unpublish = mockUnpublish;
+          }
+        },
+      },
+    });
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    expect(initPublisher).not.toHaveBeenCalled();
+    expect(mockPublish).not.toHaveBeenCalled();
+    expect(result.current.isSharingScreen).toBe(false);
+  });
+
+  it('stops video track when initPublisher callback receives an error', async () => {
+    let publisherCallback: ((err?: Error) => void) | undefined;
+
+    (initPublisher as ReturnType<typeof vi.fn>).mockImplementation(
+      (_target, _options, callback) => {
+        publisherCallback = callback;
+        return mockPublisher as Publisher;
+      }
+    );
+
+    const { result } = render({
+      userContext: {
+        __interceptor: (context: UserContextType | null) => {
+          context!.user.defaultSettings.name = 'TestUser';
+        },
+      },
+      sessionContext: {
+        __interceptor: (context) => {
+          if (context) {
+            context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
+            context.publish = mockPublish;
+            context.unpublish = mockUnpublish;
+          }
+        },
+      },
+    });
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    act(() => {
+      publisherCallback?.(new Error('publisher failed'));
+    });
+
+    expect(mockVideoTrack.stop).toHaveBeenCalled();
+    expect(result.current.isSharingScreen).toBe(false);
+    expect(result.current.isEntireScreen).toBe(false);
+    expect(result.current.screenshareVideoElement).toBeUndefined();
+  });
+
+  it('stops video track when publish fails', async () => {
+    mockPublish.mockRejectedValueOnce(new Error('publish failed'));
+
+    const { result } = render({
+      userContext: {
+        __interceptor: (context: UserContextType | null) => {
+          context!.user.defaultSettings.name = 'TestUser';
+        },
+      },
+      sessionContext: {
+        __interceptor: (context) => {
+          if (context) {
+            context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
+            context.publish = mockPublish;
+            context.unpublish = mockUnpublish;
+          }
+        },
+      },
+    });
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    expect(mockVideoTrack.stop).toHaveBeenCalled();
+    expect(result.current.isSharingScreen).toBe(false);
+    expect(result.current.isEntireScreen).toBe(false);
+    expect(result.current.screenshareVideoElement).toBeUndefined();
+  });
+
+  it('resets state when mediaStopped event fires', async () => {
+    const { result } = render({
+      userContext: {
+        __interceptor: (context: UserContextType | null) => {
+          context!.user.defaultSettings.name = 'TestUser';
+        },
+      },
+      sessionContext: {
+        __interceptor: (context) => {
+          if (context) {
+            context.vonageVideoClient = mockVonageVideoClient as unknown as VonageVideoClient;
+            context.publish = mockPublish;
+            context.unpublish = mockUnpublish;
+          }
+        },
+      },
+    });
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    act(() => {
+      handlers['mediaStopped']();
+    });
+
+    expect(result.current.isSharingScreen).toBe(false);
+    expect(result.current.isEntireScreen).toBe(false);
+    expect(result.current.screenshareVideoElement).toBeUndefined();
+  });
 });
 
 type RenderOptions = {

--- a/frontend/src/hooks/tests/useScreenShare.spec.tsx
+++ b/frontend/src/hooks/tests/useScreenShare.spec.tsx
@@ -43,7 +43,7 @@ describe('useScreenSharing', () => {
 
     mockGetDisplayMedia.mockResolvedValue({
       getVideoTracks: () => [mockVideoTrack],
-    } as unknown as MediaStream);
+    });
 
     // JSDOM does not provide navigator.mediaDevices; define the whole property.
     Object.defineProperty(navigator, 'mediaDevices', {
@@ -345,7 +345,7 @@ describe('useScreenSharing', () => {
   it('returns early when display stream contains no video tracks', async () => {
     mockGetDisplayMedia.mockResolvedValueOnce({
       getVideoTracks: () => [],
-    } as unknown as MediaStream);
+    });
 
     const { result } = render({
       userContext: {
@@ -379,7 +379,7 @@ describe('useScreenSharing', () => {
     (initPublisher as ReturnType<typeof vi.fn>).mockImplementation(
       (_target, _options, callback) => {
         publisherCallback = callback;
-        return mockPublisher as Publisher;
+        return mockPublisher;
       }
     );
 

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -57,71 +57,100 @@ const useScreenShare = (): UseScreenShareType => {
 
   // Using useCallback to memoize the function to avoid unnecessary re-renders
   const toggleShareScreen = useCallback(async () => {
-    if (vonageVideoClient) {
-      if (!isSharingScreen) {
-        // Initializing the publisher for screen sharing
-        screenSharingPubRef.current = initPublisher(
-          undefined,
-          {
-            videoSource: 'screen',
-            insertDefaultUI: false,
-            videoContentHint: 'detail',
-            name: t('participants.screen', { participantName: user.defaultSettings.name }),
-          },
-          (err) => {
-            if (err) {
-              onScreenShareStopped();
-            }
-          }
-        );
-
-        // Adding class for screen sharing styling
-        screenSharingPubRef.current?.element?.classList.add('OT_big');
-
-        // Handling stream creation event
-        screenSharingPubRef.current?.on('streamCreated', () => {
-          setIsSharingScreen(true);
-        });
-
-        screenSharingPubRef.current?.on('videoElementCreated', (e) => {
-          const videoEl = e.element as HTMLVideoElement;
-          setScreenshareVideoElement(videoEl);
-          const mediaStream = videoEl.srcObject as MediaStream | null;
-          const track = mediaStream?.getVideoTracks?.()[0];
-          const settings = track?.getSettings?.();
-          const displaySurface = settings?.displaySurface;
-
-          const width = settings?.width;
-          const height = settings?.height;
-
-          const isMonitor =
-            displaySurface === 'monitor' ||
-            (!displaySurface &&
-              width !== undefined &&
-              height !== undefined &&
-              width * height >= window.screen.width * window.screen.height);
-
-          setIsEntireScreen(isMonitor);
-        });
-
-        screenSharingPubRef.current?.on('streamDestroyed', () => {
-          onScreenShareStopped();
-        });
-
-        // Handling media stopped event
-        screenSharingPubRef.current?.on('mediaStopped', () => {
-          onScreenShareStopped();
-        });
-
-        // Publishing the screen sharing stream
-        await publish(screenSharingPubRef.current);
-
-        vonageVideoClient?.on('screenshareStreamCreated', handleStreamCreated);
-      } else if (screenSharingPubRef.current) {
-        unpublishScreenshare();
-        vonageVideoClient?.off('screenshareStreamCreated', handleStreamCreated);
-      }
+    if (!vonageVideoClient) {
+      return;
     }
+
+    if (isSharingScreen) {
+      if (screenSharingPubRef.current) {
+        unpublishScreenshare();
+        vonageVideoClient.off('screenshareStreamCreated', handleStreamCreated);
+      }
+      return;
+    }
+
+    // We are calling display media before initializing the publisher to avoid SDK log errors.
+    // By calling getDisplayMedia ourselves first, we can handle the cancel case avoiding unwanted error logs.
+    let videoTrack: MediaStreamTrack;
+    try {
+      const displayStream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: false,
+      });
+      const videoTracks = displayStream.getVideoTracks();
+      if (videoTracks.length === 0) {
+        return;
+      }
+      videoTrack = videoTracks[0];
+    } catch {
+      // User cancelled the screen picker or permission was denied – exit silently.
+      return;
+    }
+
+    // Initializing the publisher for screen sharing
+    screenSharingPubRef.current = initPublisher(
+      undefined,
+      {
+        videoSource: videoTrack,
+        insertDefaultUI: false,
+        videoContentHint: 'detail',
+        name: t('participants.screen', { participantName: user.defaultSettings.name }),
+      },
+      (err) => {
+        if (err) {
+          videoTrack.stop();
+          onScreenShareStopped();
+        }
+      }
+    );
+
+    // Adding class for screen sharing styling
+    screenSharingPubRef.current?.element?.classList.add('OT_big');
+
+    // Handling stream creation event
+    screenSharingPubRef.current?.on('streamCreated', () => {
+      setIsSharingScreen(true);
+    });
+
+    screenSharingPubRef.current?.on('videoElementCreated', (e) => {
+      const videoEl = e.element as HTMLVideoElement;
+      setScreenshareVideoElement(videoEl);
+      const mediaStream = videoEl.srcObject as MediaStream | null;
+      const track = mediaStream?.getVideoTracks?.()[0];
+      const settings = track?.getSettings?.();
+      const displaySurface = settings?.displaySurface;
+
+      const width = settings?.width;
+      const height = settings?.height;
+
+      const isMonitor =
+        displaySurface === 'monitor' ||
+        (!displaySurface &&
+          width !== undefined &&
+          height !== undefined &&
+          width * height >= window.screen.width * window.screen.height);
+
+      setIsEntireScreen(isMonitor);
+    });
+
+    screenSharingPubRef.current?.on('streamDestroyed', () => {
+      onScreenShareStopped();
+    });
+
+    // Handling media stopped event
+    screenSharingPubRef.current?.on('mediaStopped', () => {
+      onScreenShareStopped();
+    });
+
+    // Publishing the screen sharing stream
+    try {
+      await publish(screenSharingPubRef.current);
+    } catch {
+      videoTrack.stop();
+      onScreenShareStopped();
+    }
+
+    vonageVideoClient.on('screenshareStreamCreated', handleStreamCreated);
   }, [
     vonageVideoClient,
     isSharingScreen,

--- a/integration-tests/tests/multiparty.spec.ts
+++ b/integration-tests/tests/multiparty.spec.ts
@@ -123,6 +123,7 @@ test.describe('display name for screenshare', () => {
   test('should display username on screenshare publisher and subscribers', async ({
     page: pageOne,
     context,
+    browserName,
   }) => {
     const roomName = crypto.randomBytes(5).toString('hex');
 
@@ -131,7 +132,7 @@ test.describe('display name for screenshare', () => {
       username: 'User One',
       roomName,
     });
-    await waitUntilReady(pageOne, 'chromium');
+    await waitUntilReady(pageOne, browserName);
 
     const pageTwo = await context.newPage();
 
@@ -140,7 +141,7 @@ test.describe('display name for screenshare', () => {
       username: 'User Two',
       roomName,
     });
-    await waitUntilReady(pageTwo, 'chromium');
+    await waitUntilReady(pageTwo, browserName);
 
     await pageOne.waitForSelector('.publisher', { state: 'visible' });
     await pageTwo.waitForSelector('.subscriber', { state: 'visible' });

--- a/integration-tests/tests/multiparty.spec.ts
+++ b/integration-tests/tests/multiparty.spec.ts
@@ -123,34 +123,33 @@ test.describe('display name for screenshare', () => {
   test('should display username on screenshare publisher and subscribers', async ({
     page: pageOne,
     context,
-    browserName,
   }) => {
     const roomName = crypto.randomBytes(5).toString('hex');
-
     await openMeetingRoomWithSettings({
       page: pageOne,
       username: 'User One',
       roomName,
     });
-    await waitUntilReady(pageOne, browserName);
 
     const pageTwo = await context.newPage();
-
     await openMeetingRoomWithSettings({
       page: pageTwo,
       username: 'User Two',
       roomName,
     });
-    await waitUntilReady(pageTwo, browserName);
 
     await pageOne.waitForSelector('.publisher', { state: 'visible' });
     await pageTwo.waitForSelector('.subscriber', { state: 'visible' });
-    const screenshareButton = await pageOne.getByTestId('ScreenShareIcon');
+    const screenshareButton = pageOne.getByTestId('ScreenShareIcon');
     await screenshareButton.click();
 
     await expect(
       pageOne.getByTestId('screen-publisher-container').getByText(`You are sharing your screen.`)
     ).toBeVisible();
+
+    await expect
+      .poll(async () => await pageTwo.locator('.video__element').count(), { timeout: 10000 })
+      .toBe(2);
 
     // Wait for the screen-subscriber to appear
     await pageTwo.waitForSelector('.screen-subscriber', { state: 'visible' });

--- a/integration-tests/tests/multiparty.spec.ts
+++ b/integration-tests/tests/multiparty.spec.ts
@@ -125,18 +125,22 @@ test.describe('display name for screenshare', () => {
     context,
   }) => {
     const roomName = crypto.randomBytes(5).toString('hex');
+
     await openMeetingRoomWithSettings({
       page: pageOne,
       username: 'User One',
       roomName,
     });
+    await waitUntilReady(pageOne, 'chromium');
 
     const pageTwo = await context.newPage();
+
     await openMeetingRoomWithSettings({
       page: pageTwo,
       username: 'User Two',
       roomName,
     });
+    await waitUntilReady(pageTwo, 'chromium');
 
     await pageOne.waitForSelector('.publisher', { state: 'visible' });
     await pageTwo.waitForSelector('.subscriber', { state: 'visible' });
@@ -144,16 +148,14 @@ test.describe('display name for screenshare', () => {
     await screenshareButton.click();
 
     await expect(
-      await pageOne
-        .getByTestId('screen-publisher-container')
-        .getByText(`You are sharing your screen.`)
+      pageOne.getByTestId('screen-publisher-container').getByText(`You are sharing your screen.`)
     ).toBeVisible();
 
     // Wait for the screen-subscriber to appear
     await pageTwo.waitForSelector('.screen-subscriber', { state: 'visible' });
 
     await expect(
-      await pageTwo.locator('.screen-subscriber').getByText(`User One's screen`)
+      pageTwo.locator('.screen-subscriber').getByText(`User One's screen`)
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
#### What is this PR doing?
Fix seeing multiple errors in console when hitting Cancel button on a screen-share.

#### How should this be manually tested?
Check console and try to screen share and cancel.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-882](https://jira.vonage.com/browse/VIDSOL-882)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
