### PR TITLE
VIDSOL-1073: fix(csp): allow data: and blob: in connect-src so custom background images load in production

### DIFF
--- a/backend/middleware/helmetMiddleware/helmetMiddleware.test.ts
+++ b/backend/middleware/helmetMiddleware/helmetMiddleware.test.ts
@@ -36,19 +36,6 @@ describe('helmetMiddleware', () => {
     expect(helmetHandlerMock).toHaveBeenCalledWith(req, res, next);
   });
 
-  it('should allow data: and blob: in connect-src so MediaProcessor can load background images', async () => {
-    process.env.NODE_ENV = 'production';
-
-    await import('./helmetMiddleware');
-
-    const config = helmetMock.mock.calls[0]?.[0] as {
-      contentSecurityPolicy: { directives: Record<string, string[]> };
-    };
-    const connectSrc = config.contentSecurityPolicy.directives['connect-src'];
-
-    expect(connectSrc).toEqual(expect.arrayContaining(['data:', 'blob:']));
-  });
-
   it('should disable contentSecurityPolicy in development', async () => {
     process.env.NODE_ENV = 'development';
 

--- a/backend/middleware/helmetMiddleware/helmetMiddleware.test.ts
+++ b/backend/middleware/helmetMiddleware/helmetMiddleware.test.ts
@@ -36,6 +36,19 @@ describe('helmetMiddleware', () => {
     expect(helmetHandlerMock).toHaveBeenCalledWith(req, res, next);
   });
 
+  it('should allow data: and blob: in connect-src so MediaProcessor can load background images', async () => {
+    process.env.NODE_ENV = 'production';
+
+    await import('./helmetMiddleware');
+
+    const config = helmetMock.mock.calls[0]?.[0] as {
+      contentSecurityPolicy: { directives: Record<string, string[]> };
+    };
+    const connectSrc = config.contentSecurityPolicy.directives['connect-src'];
+
+    expect(connectSrc).toEqual(expect.arrayContaining(['data:', 'blob:']));
+  });
+
   it('should disable contentSecurityPolicy in development', async () => {
     process.env.NODE_ENV = 'development';
 

--- a/backend/middleware/helmetMiddleware/helmetMiddleware.ts
+++ b/backend/middleware/helmetMiddleware/helmetMiddleware.ts
@@ -22,6 +22,11 @@ const helmetHandler = helmet({
 
           // Allow connections to self and Vonage/OpenTok backend services.
           // Needed for signaling, logging, REST calls, and WebSocket traffic.
+          // `data:` and `blob:` are required because the MediaProcessor (background
+          // replacement) loads background images via fetch() — including custom
+          // uploaded images stored as data: URLs — which is governed by connect-src,
+          // not img-src. Without them, applying a custom background fails in
+          // production with "Refused to connect … TypeError: Failed to fetch".
           'connect-src': [
             "'self'",
             'https://*.opentok.com',
@@ -31,6 +36,8 @@ const helmetHandler = helmet({
             'wss://*.tokbox.com',
             'wss://*.vonage.com',
             'https://static.opentok.com',
+            'data:',
+            'blob:',
           ],
 
           // Allow images from self, inline/base64 images, blob URLs, and any HTTPS image source.


### PR DESCRIPTION
## Summary

Fixes #665.

In production, applying a **custom (uploaded) background image** silently fails — the background-replacement effect never applies and the console shows:

```
Refused to connect to 'data:image/png;base64,…' because it violates the document's
Content Security Policy directive: "connect-src 'self' https://*.opentok.com …"
OpenTok:MediaProcessor:error — Error setting media stream: TypeError: Failed to fetch
```

## Root cause

Custom backgrounds are stored as `data:` URLs and passed to `publisher.applyVideoFilter({ type: 'backgroundReplacement', backgroundImgUrl })` (`frontend/src/utils/backgroundFilter/applyBackgroundFilter/applyBackgroundFilter.ts`). The SDK MediaProcessor loads that URL via **`fetch()`**, which is governed by **`connect-src`** — not `img-src`. The production CSP `connect-src` listed only `'self'` + Vonage/OpenTok origins, with no `data:`/`blob:`, so the fetch was refused.

- Only affects **custom uploaded images** (data: URLs). Built-in gallery backgrounds resolve to `${BACKGROUNDS_PATH}/<file>` under `'self'`, and blur needs no fetch — both already work.
- **Production-only**: CSP is disabled in development (`isDevelopment ? false : …`), so it never surfaced in dev.

## Fix

Add `'data:'` and `'blob:'` to `connect-src` in `backend/middleware/helmetMiddleware/helmetMiddleware.ts` — consistent with how `img-src`, `worker-src`, and `media-src` in the same config already allow these schemes (data URLs are self-contained; blob URLs are same-origin, so the security cost is minimal). Added a regression test asserting both are present in the production `connect-src`.

## Testing

- `yarn quality-check` (ts-check + lint + prettier, workspace-wide) ✅
- `yarn test` (full suite, all projects) ✅ — 192 test files / 967 passed, incl. the new `helmetMiddleware` regression test
- Manual: the failure is runtime-reproduced on a production build (see #665); with this change `connect-src` permits the `data:` fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)