### PR TITLE
VIDSOL-1071: fix(devices): render a single audio-output empty state in MenuDevices

### DIFF
--- a/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.spec.tsx
+++ b/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.spec.tsx
@@ -135,28 +135,6 @@ describe('MenuDevices Component', () => {
     });
   });
 
-  it('renders exactly one empty state for audio output when supported and no devices exist', async () => {
-    vi.spyOn(util, 'isGetActiveAudioOutputDeviceSupported').mockReturnValue(true);
-
-    act(() => {
-      mediaDevices$.setState((state) => ({
-        ...state,
-        mediaDeviceInfo: someDevices.filter((d) => d.kind !== 'audiooutput'),
-        audiooutput: undefined,
-      }));
-    });
-
-    const anchorEl = document.createElement('div');
-
-    render(
-      <MenuDevices mediaDeviceKind="audiooutput" onClose={vi.fn()} open anchorEl={anchorEl} />
-    );
-
-    await waitFor(() => {
-      expect(screen.getAllByTestId('audiooutput-menu-empty-state')).toHaveLength(1);
-    });
-  });
-
   it('renders an empty state when no devices are available', async () => {
     const mockOnClose = vi.fn();
     const anchorEl = document.createElement('div');

--- a/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.spec.tsx
+++ b/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.spec.tsx
@@ -135,6 +135,28 @@ describe('MenuDevices Component', () => {
     });
   });
 
+  it('renders exactly one empty state for audio output when supported and no devices exist', async () => {
+    vi.spyOn(util, 'isGetActiveAudioOutputDeviceSupported').mockReturnValue(true);
+
+    act(() => {
+      mediaDevices$.setState((state) => ({
+        ...state,
+        mediaDeviceInfo: someDevices.filter((d) => d.kind !== 'audiooutput'),
+        audiooutput: undefined,
+      }));
+    });
+
+    const anchorEl = document.createElement('div');
+
+    render(
+      <MenuDevices mediaDeviceKind="audiooutput" onClose={vi.fn()} open anchorEl={anchorEl} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('audiooutput-menu-empty-state')).toHaveLength(1);
+    });
+  });
+
   it('renders an empty state when no devices are available', async () => {
     const mockOnClose = vi.fn();
     const anchorEl = document.createElement('div');

--- a/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.tsx
+++ b/frontend/src/components/WaitingRoom/MenuDevices/MenuDevices.tsx
@@ -80,7 +80,8 @@ const MenuDevices = ({
           </MenuItem>
         ))}
 
-      {shouldDisplayEmptyState && (
+      {/* audiooutput renders its own empty state below (with SoundTest), so exclude it here to avoid a duplicate */}
+      {shouldDisplayEmptyState && mediaDeviceKind !== 'audiooutput' && (
         <MenuItem disabled data-testid={`${mediaDeviceKind}-menu-empty-state`}>
           {t('waitingRoom.devices.noDevicesFound')}
         </MenuItem>


### PR DESCRIPTION
## Summary

Fixes #647.

When `mediaDeviceKind === 'audiooutput'`, the output-device API is supported, and there are **no** devices, `MenuDevices` rendered the "no devices found" empty state **twice** — once from the shared empty-state block and once from the audiooutput-specific block — producing a duplicate row and a **duplicate `data-testid="audiooutput-menu-empty-state"`** (which makes `getByTestId` throw).

## Fix

Exclude `audiooutput` from the shared empty-state block so the audiooutput branch (which already renders either `SoundTest` or the empty state) is its sole owner:

```diff
-{shouldDisplayEmptyState && (
+{shouldDisplayEmptyState && mediaDeviceKind !== 'audiooutput' && (
   <MenuItem disabled data-testid={`${mediaDeviceKind}-menu-empty-state`}>
```

## How the fix is proven (test-first)

Added a regression test to `MenuDevices.spec.tsx` **before** the fix:

- **Before** (on `develop`): `expected [ <li>, <li> ] to have a length of 1 but got 2` — the duplicate is reproduced.
- **After**: exactly one `audiooutput-menu-empty-state` renders; test passes.

Non-audiooutput kinds are unchanged (the existing `audioinput` empty-state test still passes).

## Testing

- `MenuDevices.spec.tsx`: 7/7 pass (the new test failed before the fix)
- `yarn test` (full suite) ✅ — 192 test files / 968 passed, 2 skipped
- `yarn quality-check` (ts-check + lint + prettier) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)