### PR TITLE
VIDSOL-1069: fix(recording): don't treat backdrop click / Escape as a recording-consent decline

### DIFF
--- a/frontend/src/components/MeetingRoom/PopupDialog/PopupDialog.tsx
+++ b/frontend/src/components/MeetingRoom/PopupDialog/PopupDialog.tsx
@@ -18,11 +18,6 @@ export type DialogProps = {
   handleClose: () => void;
   handleActionClick: () => void;
   actionText: DialogTexts;
-  /**
-   * When true, the dialog cannot be dismissed via backdrop click or Escape;
-   * only the explicit action buttons close it. Use for mandatory prompts (e.g.
-   * recording consent) where an accidental dismissal must not count as a choice.
-   */
   disableDismiss?: boolean;
 };
 
@@ -49,8 +44,6 @@ const PopupDialog = ({
     <Dialog
       open={isOpen}
       onClose={(_event, reason) => {
-        // For mandatory prompts, ignore the implicit dismiss gestures (backdrop click / Escape)
-        // so an accidental dismissal is not treated as an explicit choice.
         const isDismissGesture = reason === 'backdropClick' || reason === 'escapeKeyDown';
         if (disableDismiss && isDismissGesture) {
           return;

--- a/frontend/src/components/MeetingRoom/PopupDialog/PopupDialog.tsx
+++ b/frontend/src/components/MeetingRoom/PopupDialog/PopupDialog.tsx
@@ -18,6 +18,12 @@ export type DialogProps = {
   handleClose: () => void;
   handleActionClick: () => void;
   actionText: DialogTexts;
+  /**
+   * When true, the dialog cannot be dismissed via backdrop click or Escape;
+   * only the explicit action buttons close it. Use for mandatory prompts (e.g.
+   * recording consent) where an accidental dismissal must not count as a choice.
+   */
+  disableDismiss?: boolean;
 };
 
 /**
@@ -37,11 +43,20 @@ const PopupDialog = ({
   handleClose,
   handleActionClick,
   actionText,
+  disableDismiss = false,
 }: DialogProps): ReactElement => {
   return (
     <Dialog
       open={isOpen}
-      onClose={handleClose}
+      onClose={(_event, reason) => {
+        // For mandatory prompts, ignore the implicit dismiss gestures (backdrop click / Escape)
+        // so an accidental dismissal is not treated as an explicit choice.
+        const isDismissGesture = reason === 'backdropClick' || reason === 'escapeKeyDown';
+        if (disableDismiss && isDismissGesture) {
+          return;
+        }
+        handleClose();
+      }}
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
     >

--- a/frontend/src/components/MeetingRoom/RecordingPopupIndicator/RecordingPopupIndicator.spec.tsx
+++ b/frontend/src/components/MeetingRoom/RecordingPopupIndicator/RecordingPopupIndicator.spec.tsx
@@ -79,6 +79,23 @@ describe('RecordingPopUpIndicator', () => {
     );
   });
 
+  it('does not redirect when the dialog is dismissed via Escape or backdrop click', () => {
+    render(<RecordingPopUpIndicator shouldPromptRecordingConsent />);
+
+    // Escape key — must not be treated as an explicit decline
+    fireEvent.keyDown(screen.getByText(translationsByKey['recording.consent.dialog.title']), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+
+    // Backdrop click — likewise must not eject the participant
+    const backdrop = document.querySelector('.MuiBackdrop-root');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop as Element);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('closes the dialog without redirect when the user consents', async () => {
     render(<RecordingPopUpIndicator shouldPromptRecordingConsent />);
 

--- a/frontend/src/components/MeetingRoom/RecordingPopupIndicator/RecordingPopupIndicator.tsx
+++ b/frontend/src/components/MeetingRoom/RecordingPopupIndicator/RecordingPopupIndicator.tsx
@@ -63,6 +63,7 @@ const RecordingPopUpIndicator = ({
       handleClose={handleDecline}
       handleActionClick={handleActionClick}
       actionText={actionText}
+      disableDismiss
     />
   );
 };


### PR DESCRIPTION
## Summary

Fixes #653.

The recording-consent dialog wired **decline** (which navigates to `/goodbye` and leaves the meeting) to the dialog's `onClose`. MUI fires `onClose` for **backdrop click** and **Escape** — the most common way anyone dismisses a dialog — so those gestures **ejected the participant from the call** as if they'd explicitly declined recording. This hits every non-recording participant whenever anyone starts recording.

## Fix

Add an opt-in `disableDismiss` to the shared `PopupDialog` that ignores the implicit dismiss gestures (`backdropClick` / `escapeKeyDown`), and enable it on the consent prompt:

```diff
// PopupDialog.tsx
-onClose={handleClose}
+onClose={(_event, reason) => {
+  const isDismissGesture = reason === 'backdropClick' || reason === 'escapeKeyDown';
+  if (disableDismiss && isDismissGesture) return;
+  handleClose();
+}}
```
```diff
// RecordingPopupIndicator.tsx
 <PopupDialog … actionText={actionText} + disableDismiss />
```

Explicit **Accept**/**Decline** buttons are unaffected (they call their handlers directly). Other `PopupDialog` usages (archive start/stop, mute) are unchanged — `disableDismiss` defaults to `false`, so they keep dismiss-to-close.

## How the fix is proven (test-first)

Added a regression test to `RecordingPopupIndicator.spec.tsx` **before** the fix:

- **Before** (on `develop`): firing Escape and clicking the backdrop → `expected "spy" to not be called at all, but actually been called 2 times` — both gestures eject the user.
- **After**: neither redirects; `mockNavigate` is not called. The existing "redirects when the user declines" (explicit button) test still passes.

## Testing

- `RecordingPopupIndicator.spec.tsx` + `PopupDialog.spec.tsx`: all pass (new test failed before the fix)
- `yarn test` (full suite) ✅ — 192 test files / 968 passed, 2 skipped
- ts-check + lint + prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)