### PR TITLE
VIDSOL-1067: fix(token): set client-token expireTime in epoch seconds, not milliseconds (tokens never expire)

### DIFF
--- a/backend/routes/video/constants/joinSession.test.ts
+++ b/backend/routes/video/constants/joinSession.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from '@jest/globals';
+import joinSession from './joinSession';
+
+describe('joinSession defaults', () => {
+  it('sets the client token expireTime in epoch seconds (~3h from now), not milliseconds', () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    const addDefaults = joinSession.addDefaults as (payload: unknown) => {
+      clientTokenOptions: { expireTime: number };
+    };
+    const { expireTime } = addDefaults({}).clientTokenOptions;
+
+    // The SDK writes expireTime straight into the JWT `exp` (epoch seconds), so it
+    // must be ~now + 3h in seconds. The bug used Date.now() + milliseconds (~1.7e12).
+    expect(Math.abs(expireTime - (nowSeconds + 3 * 60 * 60))).toBeLessThan(5);
+    expect(expireTime).toBeLessThan(1e11);
+  });
+});

--- a/backend/routes/video/constants/joinSession.ts
+++ b/backend/routes/video/constants/joinSession.ts
@@ -1,14 +1,15 @@
 import type { HandlersConfig } from '@api-lib';
 import { TokenRole } from '@api-lib';
 
-const threeHoursInMilliseconds = 3 * 60 * 60 * 1000;
+const threeHoursInSeconds = 3 * 60 * 60;
 
 const joinSession: HandlersConfig['joinSession'] = {
   addDefaults: (payload) => ({
     ...payload,
     clientTokenOptions: {
       role: TokenRole.MODERATOR,
-      expireTime: Date.now() + threeHoursInMilliseconds,
+      // expireTime is an absolute UNIX time in seconds (the SDK writes it into the JWT `exp`).
+      expireTime: Math.floor(Date.now() / 1000) + threeHoursInSeconds,
       ...payload.clientTokenOptions,
     },
   }),

--- a/libs/api/src/handlers/createEphemeralToken.test.ts
+++ b/libs/api/src/handlers/createEphemeralToken.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import createEphemeralToken from './createEphemeralToken';
+import { TokenRole, type IVideoClient } from '@api-lib/types';
+import type { CreateEphemeralTokenPayload } from '@api-lib/schemas/CreateEphemeralTokenPayload.schema';
+
+describe('createEphemeralToken', () => {
+  it('passes an expireTime in epoch seconds (~30s from now), not milliseconds', () => {
+    const generateClientToken = vi.fn().mockReturnValue('token');
+    const client = {
+      decodeSessionKey: vi.fn().mockReturnValue({ sessionId: 'session-id' }),
+      video: { generateClientToken },
+    } as unknown as IVideoClient;
+
+    const token = createEphemeralToken.call(client, {
+      sessionKey: 'session-key',
+    } as CreateEphemeralTokenPayload);
+
+    expect(token).toBe('token');
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const tokenOptions = generateClientToken.mock.calls[0][1] as {
+      role: string;
+      expireTime: number;
+    };
+
+    expect(tokenOptions.role).toBe(TokenRole.MODERATOR);
+    // The SDK sets the JWT `exp` to this value directly (epoch seconds); the bug
+    // passed Date.now() + ms (~1.7e12), making tokens effectively never expire.
+    expect(Math.abs(tokenOptions.expireTime - (nowSeconds + 30))).toBeLessThan(5);
+    expect(tokenOptions.expireTime).toBeLessThan(1e11);
+  });
+});

--- a/libs/api/src/handlers/createEphemeralToken.ts
+++ b/libs/api/src/handlers/createEphemeralToken.ts
@@ -18,8 +18,9 @@ function createEphemeralToken(this: IVideoClient, payload: CreateEphemeralTokenP
     const tokenOptions: ClientTokenOptions = {
       role: TokenRole.MODERATOR,
 
+      // expireTime is an absolute UNIX time in seconds (the SDK writes it into the JWT `exp`).
       // Chosen 30s because our K8s probes use 10s timeouts; allows one retry + margin.
-      expireTime: Date.now() + 30 * 1000,
+      expireTime: Math.floor(Date.now() / 1000) + 30,
 
       ...clientTokenOptions,
     };


### PR DESCRIPTION
## Summary

Fixes #637 — a security bug: generated client tokens **never expire**.

`@vonage/video`'s `generateClientToken` writes `ClientTokenOptions.expireTime` **straight into the JWT `exp` claim**, which is an absolute UNIX time in **seconds**. Both token paths passed `Date.now() + <milliseconds>` (~`1.7e12`), so `exp` landed around the year **57000** — the tokens, including the server-to-server **MODERATOR** ephemeral token, effectively never expired, defeating the intended 30s / 3h TTLs.

## Fix

Pass an absolute epoch in **seconds** in both sites:

```diff
// libs/api/src/handlers/createEphemeralToken.ts
-      expireTime: Date.now() + 30 * 1000,
+      expireTime: Math.floor(Date.now() / 1000) + 30,
```
```diff
// backend/routes/video/constants/joinSession.ts
-const threeHoursInMilliseconds = 3 * 60 * 60 * 1000;
+const threeHoursInSeconds = 3 * 60 * 60;
-      expireTime: Date.now() + threeHoursInMilliseconds,
+      expireTime: Math.floor(Date.now() / 1000) + threeHoursInSeconds,
```

This matches how the codebase already computes token expiry elsewhere (`opentokVideoService.ts` uses `Math.floor(new Date().getTime() / 1000) + …`).

## How the fix is proven (test-first)

Regression tests at both sites assert the `expireTime` is within a few seconds of `now + ttl` **and** `< 1e11` (seconds, not milliseconds):

- **Before** (on `develop`): both fail — `expected 1781645355997 to be less than 5` (the ms / far-future value).
- **After**: both pass.

## Testing

- `createEphemeralToken.test.ts` (libs/api, vitest) ✅ · `joinSession.test.ts` (backend, jest) ✅ — both failed before the fix
- `yarn test` (full suite) ✅ — frontend 192 files / 967, backend 21 suites / 119, libs/api 28 files / 88
- ts-check + lint + prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)