### PR TITLE
VIDSOL-1066: fix(session): don't mutate state when moving the active speaker to the top

### DIFF
--- a/frontend/src/Context/SessionProvider/session.spec.tsx
+++ b/frontend/src/Context/SessionProvider/session.spec.tsx
@@ -197,15 +197,19 @@ describe('SessionProvider', () => {
       useEffect(() => {
         if (joinRoom) void joinRoom({ sessionKey: validSessionKey });
       }, [joinRoom]);
-      capturedArrays.push(subscriberWrappers);
+      // Capture committed values in an effect (not during render) so concurrent/StrictMode
+      // re-renders can't record aborted or duplicate references.
+      useEffect(() => {
+        capturedArrays.push(subscriberWrappers);
+      }, [subscriberWrappers]);
       return (
         <div>
           <span data-testid="connected">{String(connected)}</span>
-          <span data-testid="subscriberWrappers">
+          <div data-testid="subscriberWrappers">
             {subscriberWrappers.map((wrapper) => (
               <div key={wrapper.id}>{wrapper.id}</div>
             ))}
-          </span>
+          </div>
         </div>
       );
     };

--- a/frontend/src/Context/SessionProvider/session.spec.tsx
+++ b/frontend/src/Context/SessionProvider/session.spec.tsx
@@ -229,7 +229,7 @@ describe('SessionProvider', () => {
       } as unknown as SubscriberWrapper);
     });
 
-    await waitFor(() => expect(getByTestId('subscriberWrappers').children.length).toBe(3));
+    await waitFor(() => expect(getByTestId('subscriberWrappers').children).toHaveLength(3));
 
     // The array currently held in state (which the reorder updater receives as `prev`).
     const arrayBeforeReorder = capturedArrays[capturedArrays.length - 1];
@@ -381,35 +381,31 @@ describe('SessionProvider', () => {
       expect(vonageVideoClient.disconnect).toHaveBeenCalledTimes(1);
     });
 
-    it('when reconnecting session, sets reconnecting to true', async () => {
-      const { getByTestId } = await renderAndWaitForConnection();
+    it.each([
+      {
+        sessionState: 'reconnecting',
+        emitSessionEvent: () => vonageVideoClient.emit('sessionReconnecting'),
+        expectedReconnecting: 'true',
+      },
+      {
+        sessionState: 'reconnected',
+        emitSessionEvent: () => vonageVideoClient.emit('sessionReconnected'),
+        expectedReconnecting: 'false',
+      },
+    ])(
+      'when the session is $sessionState, sets reconnecting to $expectedReconnecting',
+      async ({ emitSessionEvent, expectedReconnecting }) => {
+        const { getByTestId } = await renderAndWaitForConnection();
 
-      act(() => {
-        vonageVideoClient.emit('sessionReconnecting');
-      });
+        act(() => {
+          emitSessionEvent();
+        });
 
-      await waitFor(() => expect(getByTestId('reconnecting')).toHaveTextContent('true'));
-    });
-
-    it('when reconnected, sets reconnecting to false', async () => {
-      const { getByTestId } = await renderAndWaitForConnection();
-
-      act(() => {
-        vonageVideoClient.emit('sessionReconnected');
-      });
-
-      await waitFor(() => expect(getByTestId('reconnecting')).toHaveTextContent('false'));
-    });
-
-    it('when re-connected, sets reconnecting to false', async () => {
-      const { getByTestId } = await renderAndWaitForConnection();
-
-      act(() => {
-        vonageVideoClient.emit('sessionReconnected');
-      });
-
-      await waitFor(() => expect(getByTestId('reconnecting')).toHaveTextContent('false'));
-    });
+        await waitFor(() =>
+          expect(getByTestId('reconnecting')).toHaveTextContent(expectedReconnecting)
+        );
+      }
+    );
 
     it('when disconnected, sets connected to false', async () => {
       const { getByTestId } = await renderAndWaitForConnection();

--- a/frontend/src/Context/SessionProvider/session.spec.tsx
+++ b/frontend/src/Context/SessionProvider/session.spec.tsx
@@ -189,6 +189,63 @@ describe('SessionProvider', () => {
     await waitFor(() => expect(getByTestId('activeSpeaker')).toHaveTextContent('sub2'));
   });
 
+  it('moving the active speaker to the top must not mutate the previous subscriberWrappers array', async () => {
+    const capturedArrays: SubscriberWrapper[][] = [];
+
+    const CaptureComponent = () => {
+      const { joinRoom, connected, subscriberWrappers } = useSessionContext();
+      useEffect(() => {
+        if (joinRoom) void joinRoom({ sessionKey: validSessionKey });
+      }, [joinRoom]);
+      capturedArrays.push(subscriberWrappers);
+      return (
+        <div>
+          <span data-testid="connected">{String(connected)}</span>
+          <span data-testid="subscriberWrappers">
+            {subscriberWrappers.map((wrapper) => (
+              <div key={wrapper.id}>{wrapper.id}</div>
+            ))}
+          </span>
+        </div>
+      );
+    };
+
+    const { getByTestId } = render(<CaptureComponent />);
+    await waitFor(() => expect(getByTestId('connected')).toHaveTextContent('true'));
+
+    act(() => {
+      vonageVideoClient.emit('subscriberVideoElementCreated', {
+        id: 'sub1',
+      } as unknown as SubscriberWrapper);
+      vonageVideoClient.emit('subscriberVideoElementCreated', {
+        id: 'sub2',
+      } as unknown as SubscriberWrapper);
+      vonageVideoClient.emit('subscriberVideoElementCreated', {
+        id: 'sub3',
+      } as unknown as SubscriberWrapper);
+    });
+
+    await waitFor(() => expect(getByTestId('subscriberWrappers').children.length).toBe(3));
+
+    // The array currently held in state (which the reorder updater receives as `prev`).
+    const arrayBeforeReorder = capturedArrays[capturedArrays.length - 1];
+    const orderBeforeReorder = arrayBeforeReorder.map((wrapper) => wrapper.id);
+
+    void act(() =>
+      activeSpeakerTracker.emit('activeSpeakerChanged', {
+        previousActiveSpeaker: { subscriberId: undefined, movingAvg: 0 },
+        newActiveSpeaker: { subscriberId: 'sub1', movingAvg: 0.4 },
+      })
+    );
+
+    await waitFor(() =>
+      expect(getByTestId('subscriberWrappers').children[0]).toHaveTextContent('sub1')
+    );
+
+    // The reorder must produce a new array; the previous one must be left untouched.
+    expect(arrayBeforeReorder.map((wrapper) => wrapper.id)).toEqual(orderBeforeReorder);
+  });
+
   describe('publish', () => {
     it('should call publish on VonageVideoClient when connected', async () => {
       const { getByTestId } = await renderAndWaitForConnection();

--- a/frontend/src/Context/SessionProvider/session.tsx
+++ b/frontend/src/Context/SessionProvider/session.tsx
@@ -274,7 +274,10 @@ const SessionProvider = ({
         // When passing the sort function callback, the initial value of activeSpeakerId is captured when the listener is added. Updates to the
         // activeSpeakerId are not reflected when it is accessed. A workaround is to use useRef to store state.
         // See: https://stackoverflow.com/questions/53845595/wrong-react-hooks-behaviour-with-event-listener
-        return prevSubscriberWrappers.sort(sortByDisplayPriority(id));
+        // toSorted (not sort) so we return a new array instead of mutating state in
+        // place — an in-place sort returns the same reference, so setState bails and
+        // the reorder is applied inconsistently. Matches handleSubscriberVideoElementCreated.
+        return prevSubscriberWrappers.toSorted(sortByDisplayPriority(id));
       }
       return prevSubscriberWrappers;
     });


### PR DESCRIPTION
## Summary

Fixes #663.

`moveSubscriberToTopOfDisplayOrder` returned `prevSubscriberWrappers.sort(...)`. `Array.prototype.sort` sorts **in place** and returns the **same array reference**, so `setSubscriberWrappers` bails out (unchanged reference) and the active-speaker reorder is applied inconsistently — it only rendered at all because the co-firing `activeSpeakerId` change forced a render over the already-mutated array. Mutating prior state also breaks StrictMode double-render, concurrent rendering, and reference-equality memoization downstream.

## Fix

```diff
-return prevSubscriberWrappers.sort(sortByDisplayPriority(id));
+return prevSubscriberWrappers.toSorted(sortByDisplayPriority(id));
```

`toSorted` returns a new array — matching the sibling handler `handleSubscriberVideoElementCreated`, which already uses `.toSorted(...)`.

## How the fix is proven (test-first)

A naive "did it reorder?" assertion passes even with the bug (the `activeSpeakerId` change forces a render over the mutated array), so the regression test asserts **immutability** instead: it captures the array held in state, triggers an active-speaker change, and asserts the captured array was **not mutated in place**.

- **Before** (on `develop`): `expected [ 'sub1', 'sub3', 'sub2' ] to deeply equal [ 'sub3', 'sub2', 'sub1' ]` — the previous array was sorted in place.
- **After**: the previous array is untouched; a new sorted array is produced (and `sub1` still renders at the top).

## Testing

- `session.spec.tsx`: 21/21 pass (the new test failed before the fix)
- `yarn test` (full suite) ✅ — frontend 192 files / 968, backend 21 suites, libs/api 28 files
- ts-check + lint + prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)