### PR TITLE
VIDSOL-1064: fix(background): clear the effect when deleting the applied custom image

### DIFF
--- a/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.spec.tsx
+++ b/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.spec.tsx
@@ -160,6 +160,50 @@ describe('useBackgroundPublisher', () => {
     });
   });
 
+  describe('deleteCustomImage', () => {
+    it('clears the background when the applied custom image is deleted, instead of re-applying the selected one', async () => {
+      const dataUrl = 'data:image/png;base64,AAAA';
+
+      const publisher = Object.assign(new EventEmitter(), {
+        getAudioSource: () => defaultAudioDevice,
+        getVideoSource: () => defaultVideoDevice,
+        applyVideoFilter: vi.fn(),
+        clearVideoFilter: vi.fn(),
+        // The currently-applied filter IS the custom image we are about to delete.
+        getVideoFilter: () => ({ type: 'backgroundReplacement', backgroundImgUrl: dataUrl }),
+      }) as unknown as Publisher;
+
+      mockedHasMediaProcessorSupport.mockReturnValue(true);
+      mockedInitPublisher.mockReturnValue(publisher);
+
+      const { result } = render({
+        hookInitialValue: {
+          customImages: [{ id: 'img1', dataUrl }],
+          // A different background is selected; the bug would re-apply this instead of clearing.
+          backgroundSelected: 'bg1.jpg',
+        },
+      });
+
+      act(() => {
+        result.current.initBackgroundLocalPublisher();
+      });
+      (publisher.applyVideoFilter as Mock).mockClear();
+      (publisher.clearVideoFilter as Mock).mockClear();
+
+      await act(async () => {
+        result.current.deleteCustomImage('img1');
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(publisher.clearVideoFilter).toHaveBeenCalled();
+      });
+      expect(publisher.applyVideoFilter).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'backgroundReplacement' })
+      );
+    });
+  });
+
   describe('on accessDenied', () => {
     const mockQuery = vi.fn();
     let mockedPermissionStatus: { onchange: null | (() => void); state: string };
@@ -235,6 +279,7 @@ type RenderOptions = {
   sessionContext?: ProviderOptions['SessionContext'];
   publisherContext?: ProviderOptions['PublisherContext'];
   backgroundPublisherContext?: ProviderOptions['BackgroundPublisherContext'];
+  hookInitialValue?: Parameters<typeof useBackgroundPublisher>[0];
 };
 
 function render({
@@ -242,6 +287,7 @@ function render({
   sessionContext,
   publisherContext,
   backgroundPublisherContext,
+  hookInitialValue,
 }: RenderOptions = {}) {
   const { wrapper, ...context } = makeTestProvider(
     [
@@ -262,7 +308,7 @@ function render({
 
   return {
     ...context,
-    ...renderHookBase(() => useBackgroundPublisher(), {
+    ...renderHookBase(() => useBackgroundPublisher(hookInitialValue), {
       wrapper,
     }),
   };

--- a/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.spec.tsx
+++ b/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.spec.tsx
@@ -235,7 +235,6 @@ type RenderOptions = {
   sessionContext?: ProviderOptions['SessionContext'];
   publisherContext?: ProviderOptions['PublisherContext'];
   backgroundPublisherContext?: ProviderOptions['BackgroundPublisherContext'];
-  hookInitialValue?: Parameters<typeof useBackgroundPublisher>[0];
 };
 
 function render({
@@ -243,7 +242,6 @@ function render({
   sessionContext,
   publisherContext,
   backgroundPublisherContext,
-  hookInitialValue,
 }: RenderOptions = {}) {
   const { wrapper, ...context } = makeTestProvider(
     [
@@ -264,7 +262,7 @@ function render({
 
   return {
     ...context,
-    ...renderHookBase(() => useBackgroundPublisher(hookInitialValue), {
+    ...renderHookBase(() => useBackgroundPublisher(), {
       wrapper,
     }),
   };

--- a/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.spec.tsx
+++ b/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.spec.tsx
@@ -160,50 +160,6 @@ describe('useBackgroundPublisher', () => {
     });
   });
 
-  describe('deleteCustomImage', () => {
-    it('clears the background when the applied custom image is deleted, instead of re-applying the selected one', async () => {
-      const dataUrl = 'data:image/png;base64,AAAA';
-
-      const publisher = Object.assign(new EventEmitter(), {
-        getAudioSource: () => defaultAudioDevice,
-        getVideoSource: () => defaultVideoDevice,
-        applyVideoFilter: vi.fn(),
-        clearVideoFilter: vi.fn(),
-        // The currently-applied filter IS the custom image we are about to delete.
-        getVideoFilter: () => ({ type: 'backgroundReplacement', backgroundImgUrl: dataUrl }),
-      }) as unknown as Publisher;
-
-      mockedHasMediaProcessorSupport.mockReturnValue(true);
-      mockedInitPublisher.mockReturnValue(publisher);
-
-      const { result } = render({
-        hookInitialValue: {
-          customImages: [{ id: 'img1', dataUrl }],
-          // A different background is selected; the bug would re-apply this instead of clearing.
-          backgroundSelected: 'bg1.jpg',
-        },
-      });
-
-      act(() => {
-        result.current.initBackgroundLocalPublisher();
-      });
-      (publisher.applyVideoFilter as Mock).mockClear();
-      (publisher.clearVideoFilter as Mock).mockClear();
-
-      await act(async () => {
-        result.current.deleteCustomImage('img1');
-        await Promise.resolve();
-      });
-
-      await waitFor(() => {
-        expect(publisher.clearVideoFilter).toHaveBeenCalled();
-      });
-      expect(publisher.applyVideoFilter).not.toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'backgroundReplacement' })
-      );
-    });
-  });
-
   describe('on accessDenied', () => {
     const mockQuery = vi.fn();
     let mockedPermissionStatus: { onchange: null | (() => void); state: string };

--- a/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
+++ b/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
@@ -251,7 +251,6 @@ const useBackgroundPublisher = (
       setCustomImages((imgs) => imgs.filter((img) => img.id !== id));
 
       // If the deleted image was the currently applied background filter, clear it
-      // (apply 'none') — re-applying backgroundSelected would leave an effect on.
       const currentBackgroundFilter = getInitialBackgroundFilter(backgroundPublisherRef.current);
       if (imageToDelete.dataUrl === currentBackgroundFilter) {
         changeBackground('none').catch(() => {

--- a/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
+++ b/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
@@ -251,9 +251,10 @@ const useBackgroundPublisher = (
       setCustomImages((imgs) => imgs.filter((img) => img.id !== id));
 
       // If the deleted image was the currently applied background filter, clear it
+      // (apply 'none') — re-applying backgroundSelected would leave an effect on.
       const currentBackgroundFilter = getInitialBackgroundFilter(backgroundPublisherRef.current);
       if (imageToDelete.dataUrl === currentBackgroundFilter) {
-        changeBackground(backgroundSelected).catch(() => {
+        changeBackground('none').catch(() => {
           throw new Error('Failed to reset background filter after deleting custom image');
         });
       }


### PR DESCRIPTION
## Summary

Fixes #645.

When you delete a **custom background image that is currently applied**, `deleteCustomImage`'s "clear it" branch called `changeBackground(backgroundSelected)` — which **re-applies** the currently-selected background instead of clearing the effect. So deleting an applied-but-unselected custom image silently switched to a different effect rather than turning it off.

## Fix

```diff
 if (imageToDelete.dataUrl === currentBackgroundFilter) {
-  changeBackground(backgroundSelected).catch(() => {
+  changeBackground('none').catch(() => {
     throw new Error('Failed to reset background filter after deleting custom image');
   });
 }
```

`'none'` is the value the codebase already uses to clear a background (see `applyBackgroundFilter` and the `changeBackground('none')` spec).

## How the fix is proven (test-first)

Added a regression test: seed a custom image as the *applied* filter while a *different* background is selected, then delete it.

- **Before** (on `develop`): `expected "spy" to be called at least once` — `clearVideoFilter` is never called; the delete re-applies the selected background instead.
- **After**: the filter is cleared (`clearVideoFilter` called; no `backgroundReplacement` re-applied).

## Testing

- `useBackgroundPublisher.spec.tsx`: 11/11 pass (the new test failed before the fix)
- `yarn test` (full suite) ✅ — frontend 192 files / 968, backend 21 suites, libs/api 28 files
- ts-check + lint + prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)