### PR TITLE
VIDSOL-1061: fix: clean up failed subscribes — no leaked subscribers or ghost streams (#661, #662)

### DIFF
--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
@@ -305,6 +305,37 @@ describe('VonageVideoClient', () => {
       // A stream that never subscribed must not linger and trigger spurious resubscribe.
       expect(vonageVideoClient?.hasStream(streamId)).toBe(false);
     });
+
+    it('removes the stream from bookkeeping when subscribe fails with a recoverable error', async () => {
+      const streamId = 'recoverable-stream';
+      await vonageVideoClient?.connect();
+
+      const subscriber = Object.assign(new EventEmitter(), {
+        id: 'sub',
+      }) as unknown as TestSubscriber;
+
+      // A recoverable error (stream destroyed before subscribe completed) → the catch
+      // takes the recoverable early-return, which must still drop the stale bookkeeping.
+      vi.spyOn(vonageVideoClient!.clientSession, 'subscribe').mockImplementation(
+        (_a, _b, _c, callback) => {
+          queueMicrotask(() =>
+            (callback as unknown as (error: unknown) => void)({
+              name: 'OT_STREAM_DESTROYED',
+              message: 'stream was destroyed',
+            })
+          );
+          return subscriber;
+        }
+      );
+
+      mockSession.emit('streamCreated', {
+        stream: { streamId, videoType: 'camera' } as unknown as Stream,
+      });
+
+      await wait(600);
+
+      expect(vonageVideoClient?.hasStream(streamId)).toBe(false);
+    });
   });
 
   it('disconnect should disconnect from the session and cleanup', async () => {

--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.spec.ts
@@ -55,6 +55,7 @@ describe('VonageVideoClient', () => {
     mockSession = Object.assign(new EventEmitter(), {
       connect: mockConnect,
       subscribe: mockSubscribe,
+      unsubscribe: vi.fn(),
       disconnect: mockDisconnect,
       forceMuteStream: vi.fn(),
       publish: mockPublish,
@@ -226,6 +227,83 @@ describe('VonageVideoClient', () => {
       expect(nullSubscriber.listenerCount('videoElementCreated')).toBe(0);
       expect(nullSubscriber.listenerCount('destroyed')).toBe(0);
       expect(nullSubscriber.listenerCount('audioLevelUpdated')).toBe(0);
+    });
+  });
+
+  describe('subscribe failure cleanup', () => {
+    it('unsubscribes a failed subscribe attempt before retrying (no leaked duplicate subscribers)', async () => {
+      const streamId = 'flaky-stream';
+      await vonageVideoClient?.connect();
+
+      const failedSubscriber = Object.assign(new EventEmitter(), {
+        id: 'failed',
+      }) as unknown as TestSubscriber;
+      const okSubscriber = Object.assign(new EventEmitter(), {
+        id: 'ok',
+      }) as unknown as TestSubscriber;
+
+      let attempt = 0;
+      vi.spyOn(vonageVideoClient!.clientSession, 'subscribe').mockImplementation(
+        (_a, _b, _c, callback) => {
+          attempt += 1;
+          if (attempt === 1) {
+            // First attempt fails after the subscriber object already exists.
+            queueMicrotask(() =>
+              (callback as unknown as (error: unknown) => void)({
+                name: 'OT_UNEXPECTED',
+                message: 'transient subscribe failure',
+              })
+            );
+            return failedSubscriber;
+          }
+          queueMicrotask(() => callback!());
+          return okSubscriber;
+        }
+      );
+
+      const unsubscribeSpy = vi.spyOn(vonageVideoClient!.clientSession, 'unsubscribe');
+
+      mockSession.emit('streamCreated', {
+        stream: { streamId, videoType: 'camera' } as unknown as Stream,
+      });
+
+      // Allow the 200ms retry delay plus the succeeding retry to run.
+      await wait(300);
+
+      // The orphaned first subscriber must be torn down, not left decoding.
+      expect(unsubscribeSpy).toHaveBeenCalledWith(failedSubscriber);
+    });
+
+    it('removes the stream from bookkeeping when subscribe fails critically (no ghost stream)', async () => {
+      const streamId = 'ghost-stream';
+      await vonageVideoClient?.connect();
+
+      const subscriber = Object.assign(new EventEmitter(), {
+        id: 'sub',
+      }) as unknown as TestSubscriber;
+
+      // Every attempt fails with a non-recoverable error → exhausts retries → critical path.
+      vi.spyOn(vonageVideoClient!.clientSession, 'subscribe').mockImplementation(
+        (_a, _b, _c, callback) => {
+          queueMicrotask(() =>
+            (callback as unknown as (error: unknown) => void)({
+              name: 'OT_UNEXPECTED',
+              message: 'critical subscribe failure',
+            })
+          );
+          return subscriber;
+        }
+      );
+
+      mockSession.emit('streamCreated', {
+        stream: { streamId, videoType: 'camera' } as unknown as Stream,
+      });
+
+      // 3 attempts with 200ms between each, plus the error handling.
+      await wait(600);
+
+      // A stream that never subscribed must not linger and trigger spurious resubscribe.
+      expect(vonageVideoClient?.hasStream(streamId)).toBe(false);
     });
   });
 

--- a/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
+++ b/frontend/src/utils/VonageVideoClient/vonageVideoClient.ts
@@ -156,6 +156,12 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
             subscriberOptions,
             (error) => {
               if (error) {
+                // Tear down this failed attempt before the retry creates a new
+                // Subscriber, otherwise the orphaned one keeps decoding and emitting
+                // audioLevelUpdated for the same stream until session disconnect.
+                if (subscriber) {
+                  this.clientSession.unsubscribe(subscriber);
+                }
                 reject(error);
                 return;
               }
@@ -195,11 +201,16 @@ class VonageVideoClient extends EventEmitter<VonageVideoClientEvents> {
       if (isRecoverableError) {
         // Don't emit subscriptionError for recoverable errors
         // The stream was likely destroyed before subscription completed (e.g., user refreshed)
+        // Drop the stale bookkeeping so getActiveStreams()/hasStream() don't over-report it.
+        this.streams.delete(streamId);
         return;
       }
 
       // Only emit subscriptionError for critical errors
       console.error('[SUBSCRIBER] Critical subscription error:', syncError);
+      // The subscribe never succeeded, so remove the stream to avoid a ghost entry that
+      // makes handleSubscriberDestroyed take the resubscribe path for a dead stream.
+      this.streams.delete(streamId);
       this.handleSubscriptionError(syncError);
     }
   };


### PR DESCRIPTION
## Summary

Two related resource leaks in `VonageVideoClient`'s subscribe path, both surfacing on flaky first-subscribe (congestion / reconnect). Fixed together because they share the same `subscribeToStream` `try/catch`.

### #661 — retry leaks duplicate `Subscriber` objects

`subscribeToStream` attaches subscriber listeners inside a **retried** promise executor, and `idempotentCallbackWithRetry` (up to 3 attempts) creates a brand-new `Subscriber` on each attempt. A failed attempt was never unsubscribed, so orphaned `Subscriber`s kept decoding video/audio and emitting `audioLevelUpdated` — double-feeding `ActiveSpeakerTracker` — until session disconnect.

**Fix:** unsubscribe the failed attempt in the completion callback before rejecting, so the retry doesn't stack a second live subscriber on the same stream. Listeners stay attached synchronously, so `videoElementCreated` is still caught.

```ts
(error) => {
  if (error) {
    if (subscriber) this.clientSession.unsubscribe(subscriber);
    reject(error);
    return;
  }
  resolve(subscriber);
}
```

### #662 — ghost stream after failed subscribe

`handleStreamCreated` records the stream in `this.streams` **before** subscribing, and it was only ever removed on `streamDestroyed`. A subscribe that failed (recoverable early-return or critical error) left the entry behind, so `getActiveStreams()` / `hasStream()` over-reported live streams, and `handleSubscriberDestroyed` took the **resubscribe** path for a stream that never subscribed.

**Fix:** delete the stream entry on both the recoverable and critical failure paths, keeping the map consistent with subscription outcome.

## Testing

Added two regression tests in `vonageVideoClient.spec.ts`:
- A flaky-then-successful subscribe asserts the failed `Subscriber` is passed to `unsubscribe` before the retry.
- A critically-failing subscribe (retries exhausted) asserts `hasStream(streamId)` is `false` afterward.

Both **fail on `develop`** (no unsubscribe / stream lingers) and pass with the fix.

- New regression tests fail without the fix, pass with it
- Existing VonageVideoClient tests still pass
- Full suite green across all 6 projects (`yarn test`); `yarn quality-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)