### PR TITLE
VIDSOL-1060: fix: WaitingRoomStage redirect guard is a dead contradiction — crashes at /waiting-room (#660)

### DIFF
--- a/frontend/src/VeraRoom/stages/WaitingRoomStage/WaitingRoomStage.spec.tsx
+++ b/frontend/src/VeraRoom/stages/WaitingRoomStage/WaitingRoomStage.spec.tsx
@@ -144,4 +144,13 @@ describe('WaitingRoomStage', () => {
     render(<WaitingRoomStage />, { sessionIdentifier: 'bridge-room' });
     expect(screen.getByTestId('video-container')).toBeInTheDocument();
   });
+
+  it('redirects to /waiting-room/:roomIdentifier at the fallback route when bridge has a sessionIdentifier', () => {
+    // Mounted at the fallback /waiting-room (no :roomIdentifier param) but bridge has a
+    // sessionIdentifier: the stage must redirect to /waiting-room/my-room so the room param
+    // resolves. Without the redirect it renders with an empty room param, which throws in
+    // useDecodedSessionKey (crashed/blank waiting room).
+    render(<WaitingRoomStage />, { initialRoute: '/waiting-room', sessionIdentifier: 'my-room' });
+    expect(screen.getByTestId('video-container')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/VeraRoom/stages/WaitingRoomStage/WaitingRoomStage.tsx
+++ b/frontend/src/VeraRoom/stages/WaitingRoomStage/WaitingRoomStage.tsx
@@ -1,5 +1,5 @@
 import { type FC } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 import Typography from '@mui/material/Typography';
 import bridge$ from '../../stores/bridge';
 import { PreviewPublisherProvider } from '@Context/PreviewPublisherProvider';
@@ -29,9 +29,10 @@ import { PageLayoutEmbed } from '@ui';
  * redirects to /waiting-room/:sessionIdentifier so useRoomName() resolves correctly.
  */
 const WaitingRoomStage: FC = () => {
+  const { roomIdentifier = '' } = useParams<{ roomIdentifier: string }>();
   const sessionIdentifier = bridge$.use.select((state) => state.sessionIdentifier);
 
-  const missingRoomIdentifier = !sessionIdentifier;
+  const missingRoomIdentifier = !roomIdentifier;
   const canRedirect = missingRoomIdentifier && !!sessionIdentifier;
   const isConfigError = missingRoomIdentifier && !sessionIdentifier;
 


### PR DESCRIPTION
## Summary

Fixes #660. `WaitingRoomStage`'s redirect guard derived **both** booleans from the same `sessionIdentifier`:

```ts
const missingRoomIdentifier = !sessionIdentifier;
const canRedirect   = missingRoomIdentifier && !!sessionIdentifier; // (!x && !!x) === always false
const isConfigError = missingRoomIdentifier && !sessionIdentifier;  // (!x && !x)  === !x
```

So `canRedirect` is **always `false`** — the documented auto-redirect is dead code. At the fallback `/waiting-room` route (no `:roomIdentifier` param) with a truthy bridge `sessionIdentifier` (e.g. `session-identifier` set dynamically after the MemoryRouter already navigated to plain `/waiting-room`), both branches are skipped and the stage renders with an empty room param → `useSessionKeyParam` returns status `invalid` → `useDecodedSessionKey` throws `Invalid sessionKey:` → crashed / blank waiting room.

## Fix

Branch `missingRoomIdentifier` on the **actual URL param** via `useParams`, not on `sessionIdentifier` twice, so the redirect to `/waiting-room/:sessionIdentifier` can fire:

```ts
const { roomIdentifier = '' } = useParams<{ roomIdentifier: string }>();
const sessionIdentifier = bridge$.use.select((state) => state.sessionIdentifier);

const missingRoomIdentifier = !roomIdentifier;
const canRedirect   = missingRoomIdentifier && !!sessionIdentifier;
const isConfigError = missingRoomIdentifier && !sessionIdentifier;
```

## Testing

Added a spec covering the redirect branch (previously untested — which is how the contradiction rotted): mounted at `/waiting-room` with a bridge `sessionIdentifier`, it asserts the waiting-room content renders (i.e. the redirect landed on `/waiting-room/:roomIdentifier`). It **fails on `develop`** with `Invalid sessionKey:` and passes with the fix.

- New redirect test fails without the fix, passes with it
- Existing WaitingRoomStage tests still pass
- Full suite green across all 6 projects; `yarn quality-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)