### PR TITLE
VIDSOL-1059: fix: usePublisherQuality leaks publisher listeners — inflated audioFallbacks on reconnect (#640)

### DIFF
--- a/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
@@ -58,4 +58,27 @@ describe('usePublisherQuality', () => {
     void act(() => mockPublisher.emit('videoDisableWarning'));
     await waitFor(() => expect(result.current).toBe('poor'));
   });
+
+  it('removes listeners from the previous publisher when the publisher is re-created', () => {
+    const oldPublisher = new EventEmitter();
+    const newPublisher = new EventEmitter();
+
+    const { rerender } = renderHook(
+      (publisher: EventEmitter) => usePublisherQuality(publisher as unknown as Publisher),
+      { initialProps: oldPublisher }
+    );
+
+    // Publisher re-created (reconnect/recovery, device change).
+    rerender(newPublisher);
+
+    // The old publisher must no longer be observed — otherwise its listeners leak.
+    expect(oldPublisher.listenerCount('videoDisabled')).toBe(0);
+
+    // A stale event from the old publisher must not inflate the shared fallback counter.
+    const audioFallbacksBefore = mockUserContext.user.issues.audioFallbacks;
+    act(() => {
+      oldPublisher.emit('videoDisabled');
+    });
+    expect(mockUserContext.user.issues.audioFallbacks).toBe(audioFallbacksBefore);
+  });
 });

--- a/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
@@ -30,33 +30,28 @@ describe('usePublisherQuality', () => {
     vi.mocked(useUserContext).mockImplementation(() => mockUserContext);
   });
 
-  it('should set quality to good on videoEnabled event', async () => {
-    const mockPublisher = new EventEmitter();
-    const { result } = renderHook(() => usePublisherQuality(mockPublisher as unknown as Publisher));
-    void act(() => mockPublisher.emit('videoEnabled'));
-    await waitFor(() => expect(result.current).toBe('good'));
-  });
+  it.each([
+    { publisherEvent: 'videoEnabled', expectedQuality: 'good' },
+    { publisherEvent: 'videoDisableWarningLifted', expectedQuality: 'good' },
+    { publisherEvent: 'videoDisableWarning', expectedQuality: 'poor' },
+  ])(
+    'should set quality to $expectedQuality on $publisherEvent event',
+    async ({ publisherEvent, expectedQuality }) => {
+      const mockPublisher = new EventEmitter();
+      const { result } = renderHook(() =>
+        usePublisherQuality(mockPublisher as unknown as Publisher)
+      );
+      void act(() => mockPublisher.emit(publisherEvent));
+      await waitFor(() => expect(result.current).toBe(expectedQuality));
+    }
+  );
 
-  it('should set quality to good on videoDisableWarningLifted event', async () => {
-    const mockPublisher = new EventEmitter();
-    const { result } = renderHook(() => usePublisherQuality(mockPublisher as unknown as Publisher));
-    void act(() => mockPublisher.emit('videoDisableWarningLifted'));
-    await waitFor(() => expect(result.current).toBe('good'));
-  });
-
-  it('should set quality to good on videoDisabled event', async () => {
+  it('should set quality to bad and count an audio fallback on videoDisabled event', async () => {
     const mockPublisher = new EventEmitter();
     const { result } = renderHook(() => usePublisherQuality(mockPublisher as unknown as Publisher));
     void act(() => mockPublisher.emit('videoDisabled'));
     await waitFor(() => expect(result.current).toBe('bad'));
     expect(useUserContext().user.issues.audioFallbacks).toBe(1);
-  });
-
-  it('should set quality to good on videoDisableWarning event', async () => {
-    const mockPublisher = new EventEmitter();
-    const { result } = renderHook(() => usePublisherQuality(mockPublisher as unknown as Publisher));
-    void act(() => mockPublisher.emit('videoDisableWarning'));
-    await waitFor(() => expect(result.current).toBe('poor'));
   });
 
   it('removes listeners from the previous publisher when the publisher is re-created', () => {

--- a/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
@@ -63,22 +63,29 @@ describe('usePublisherQuality', () => {
     const oldPublisher = new EventEmitter();
     const newPublisher = new EventEmitter();
 
+    // Reset the shared counter so this test does not depend on other tests' order.
+    mockUserContext.user.issues.audioFallbacks = 0;
+
     const { rerender } = renderHook(
       (publisher: EventEmitter) => usePublisherQuality(publisher as unknown as Publisher),
       { initialProps: oldPublisher }
     );
 
+    // The initial effect must actually attach the listener (otherwise the removal
+    // assertion below would pass vacuously).
+    expect(oldPublisher.listenerCount('videoDisabled')).toBe(1);
+
     // Publisher re-created (reconnect/recovery, device change).
     rerender(newPublisher);
 
-    // The old publisher must no longer be observed — otherwise its listeners leak.
+    // The old publisher is no longer observed and the new one is now observed.
     expect(oldPublisher.listenerCount('videoDisabled')).toBe(0);
+    expect(newPublisher.listenerCount('videoDisabled')).toBe(1);
 
     // A stale event from the old publisher must not inflate the shared fallback counter.
-    const audioFallbacksBefore = mockUserContext.user.issues.audioFallbacks;
     act(() => {
       oldPublisher.emit('videoDisabled');
     });
-    expect(mockUserContext.user.issues.audioFallbacks).toBe(audioFallbacksBefore);
+    expect(mockUserContext.user.issues.audioFallbacks).toBe(0);
   });
 });

--- a/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.spec.tsx
@@ -54,7 +54,9 @@ describe('usePublisherQuality', () => {
     expect(useUserContext().user.issues.audioFallbacks).toBe(1);
   });
 
-  it('removes listeners from the previous publisher when the publisher is re-created', () => {
+  it('removes listeners from the previous publisher when the publisher is re-created', async () => {
+    expect.assertions(3);
+
     const oldPublisher = new EventEmitter();
     const newPublisher = new EventEmitter();
 
@@ -68,14 +70,20 @@ describe('usePublisherQuality', () => {
 
     // The initial effect must actually attach the listener (otherwise the removal
     // assertion below would pass vacuously).
-    expect(oldPublisher.listenerCount('videoDisabled')).toBe(1);
+    await waitFor(() => {
+      if (oldPublisher.listenerCount('videoDisabled') !== 1) {
+        throw new Error('Expected the initial publisher listener to be attached');
+      }
+    });
 
     // Publisher re-created (reconnect/recovery, device change).
     rerender(newPublisher);
 
     // The old publisher is no longer observed and the new one is now observed.
-    expect(oldPublisher.listenerCount('videoDisabled')).toBe(0);
-    expect(newPublisher.listenerCount('videoDisabled')).toBe(1);
+    await waitFor(() => {
+      expect(oldPublisher.listenerCount('videoDisabled')).toBe(0);
+      expect(newPublisher.listenerCount('videoDisabled')).toBe(1);
+    });
 
     // A stale event from the old publisher must not inflate the shared fallback counter.
     act(() => {

--- a/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherQuality/usePublisherQuality.tsx
@@ -36,12 +36,24 @@ const usePublisherQuality = (publisher: Publisher | null): NetworkQuality => {
   }, []);
 
   useEffect(() => {
-    if (publisher) {
-      publisher.on('videoDisabled', handleVideoDisabled);
-      publisher.on('videoEnabled', handleVideoEnabled);
-      publisher.on('videoDisableWarning', handleVideoWarning);
-      publisher.on('videoDisableWarningLifted', handleVideoWarningLifted);
+    if (!publisher) {
+      return undefined;
     }
+
+    publisher.on('videoDisabled', handleVideoDisabled);
+    publisher.on('videoEnabled', handleVideoEnabled);
+    publisher.on('videoDisableWarning', handleVideoWarning);
+    publisher.on('videoDisableWarningLifted', handleVideoWarningLifted);
+
+    // Remove the listeners when the publisher is re-created (reconnect/device change) or
+    // on unmount — otherwise stale publishers keep driving quality and the shared
+    // user.issues.audioFallbacks counter.
+    return () => {
+      publisher.off('videoDisabled', handleVideoDisabled);
+      publisher.off('videoEnabled', handleVideoEnabled);
+      publisher.off('videoDisableWarning', handleVideoWarning);
+      publisher.off('videoDisableWarningLifted', handleVideoWarningLifted);
+    };
   }, [
     handleVideoDisabled,
     handleVideoEnabled,


### PR DESCRIPTION
## Summary

Fixes #640. `usePublisherQuality` attaches four `publisher.on(...)` listeners inside a `useEffect` but **returns no cleanup**. When the publisher is re-created (reconnect/recovery, device change), the listeners on the old publisher are never removed — and `handleVideoDisabled` mutates a shared, monotonically-increasing counter:

```ts
const handleVideoDisabled = useCallback(() => {
  setQuality('bad');
  user.issues.audioFallbacks += 1; // shared counter
}, [user]);
```

So stale publishers keep driving the quality state and inflating `user.issues.audioFallbacks`.

## Fix

Early-return for the null publisher and return a cleanup that `off()`s the same four listeners:

```ts
useEffect(() => {
  if (!publisher) return undefined;
  publisher.on('videoDisabled', handleVideoDisabled);
  publisher.on('videoEnabled', handleVideoEnabled);
  publisher.on('videoDisableWarning', handleVideoWarning);
  publisher.on('videoDisableWarningLifted', handleVideoWarningLifted);
  return () => {
    publisher.off('videoDisabled', handleVideoDisabled);
    publisher.off('videoEnabled', handleVideoEnabled);
    publisher.off('videoDisableWarning', handleVideoWarning);
    publisher.off('videoDisableWarningLifted', handleVideoWarningLifted);
  };
}, [/* handlers */, publisher]);
```

## Testing

Added a regression test that renders the hook, re-creates the publisher via `rerender`, and asserts (a) the old publisher has no `videoDisabled` listener left, and (b) a stale `videoDisabled` event from the old publisher does not bump `audioFallbacks`. It **fails on `develop`** (`expected 1 to be 0` — listener leaked) and passes with the fix.

- New leak test fails without the fix, passes with it
- Existing usePublisherQuality tests still pass
- Full suite green across all 6 projects (`yarn test`); `yarn quality-check` clean

> Distinct from the previously-reported listener-cleanup issues (#586/#562) — those are different subscriptions; this hook had no cleanup at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)