### PR TITLE
VIDSOL-1057: fix: blockCallsForArgs waiter must not release a later owner's lock (#643)

### DIFF
--- a/backend/helpers/blockCallsForArgs.ts
+++ b/backend/helpers/blockCallsForArgs.ts
@@ -10,16 +10,28 @@ type PromiseMap = {
 const blockCallsForArgs = <T>(fn: (key: string, ...args: unknown[]) => T) => {
   const callsInProgress: PromiseMap = {};
   return async (key: string, ...args: unknown[]): Promise<ReturnType<typeof fn>> => {
-    if (callsInProgress[key]) {
-      await callsInProgress[key].promise;
-    } else {
-      const promiseWithResolvers = Promise.withResolvers<null>();
-      callsInProgress[key] = promiseWithResolvers;
+    const existing = callsInProgress[key];
+
+    // Waiter: wait for the current owner, then run — but never touch the lock.
+    // The previous implementation ran an unconditional resolve()/delete() for waiters
+    // too, which could release a *different, later* owner's lock (with 3+ concurrent
+    // calls), breaking mutual exclusion and allowing the duplicate work this guards.
+    if (existing) {
+      await existing.promise;
+      return fn(key, ...args);
     }
-    const res = await fn(key, ...args);
-    callsInProgress[key]?.resolve(null);
-    delete callsInProgress[key];
-    return res;
+
+    // Owner: hold the lock for the duration of fn. Callers stay waiters while
+    // callsInProgress[key] is set, so no second owner can appear until this entry is
+    // cleared here — meaning the delete only ever removes this owner's own lock.
+    const lock = Promise.withResolvers<null>();
+    callsInProgress[key] = lock;
+    try {
+      return await fn(key, ...args);
+    } finally {
+      delete callsInProgress[key];
+      lock.resolve(null);
+    }
   };
 };
 

--- a/backend/tests/blockCallsForArgs.test.ts
+++ b/backend/tests/blockCallsForArgs.test.ts
@@ -75,6 +75,57 @@ describe('blockCallsForArgs', () => {
     expect(fn).toHaveBeenCalledTimes(5);
   });
 
+  it('a waiter does not release a later owner lock (mutual exclusion holds for 3+ concurrent calls)', async () => {
+    // Orchestrate the interleaving A(owner) -> B(waiter) -> [A done] -> B runs ->
+    // D(new owner) -> [B done] -> E. With the bug, B's trailing cleanup deletes D's
+    // lock, so E starts running concurrently with the still-in-flight D — two owners
+    // at once. With the fix, E must wait for D.
+    const gates: Record<string, PromiseWithResolvers<null>> = {};
+    ['A', 'B', 'D', 'E'].forEach((id) => {
+      gates[id] = Promise.withResolvers<null>();
+    });
+
+    const started: string[] = [];
+    const fn = jest
+      .fn<(key: string, id: string) => Promise<string>>()
+      .mockImplementation(async (_key: string, id: string) => {
+        started.push(id);
+        await gates[id].promise;
+        return id;
+      });
+
+    const blockedFn = blockCallsForArgs(fn);
+    const key = 'room';
+
+    const promiseA = blockedFn(key, 'A'); // owner
+    const promiseB = blockedFn(key, 'B'); // waiter on A
+    await delay(0);
+
+    // A finishes -> B wakes and enters fn; the key lock is momentarily free.
+    gates.A.resolve(null);
+    await promiseA;
+    await delay(0);
+
+    // A new owner D arrives while B is still inside fn.
+    const promiseD = blockedFn(key, 'D');
+    await delay(0);
+
+    // B finishes -> with the bug this deletes D's lock.
+    gates.B.resolve(null);
+    await promiseB;
+    await delay(0);
+
+    // E arrives. It must observe D's lock and wait, not become a second owner.
+    const promiseE = blockedFn(key, 'E');
+    await delay(0);
+
+    expect(started).not.toContain('E');
+
+    gates.D.resolve(null);
+    gates.E.resolve(null);
+    await Promise.all([promiseD, promiseE]);
+  });
+
   it('does not block calls for other keys', async () => {
     const fn1Promise = Promise.withResolvers();
     const fn = jest

--- a/backend/tests/blockCallsForArgs.test.ts
+++ b/backend/tests/blockCallsForArgs.test.ts
@@ -87,8 +87,9 @@ describe('blockCallsForArgs', () => {
 
     const started: string[] = [];
     const fn = jest
-      .fn<(key: string, id: string) => Promise<string>>()
-      .mockImplementation(async (_key: string, id: string) => {
+      .fn<(key: string, ...args: unknown[]) => Promise<string>>()
+      .mockImplementation(async (_key: string, ...args: unknown[]) => {
+        const id = args[0] as string;
         started.push(id);
         await gates[id].promise;
         return id;


### PR DESCRIPTION
## Summary

Fixes #643. `blockCallsForArgs` deduplicates concurrent calls sharing a key. With **3+ concurrent calls**, a *waiter* ran an unconditional trailing `resolve()/delete()` that could clear a **different, later owner's** lock — so a subsequent call saw no lock and ran `fn` concurrently with the still-running owner, defeating the dedup (e.g. duplicate session creation).

## Fix

Only the **owner** manages the lock. Waiters await the owner's promise and then run `fn` without touching `callsInProgress`; the owner deletes in a `finally`. Since callers stay waiters while the entry is set, no second owner can appear until the current one clears it — so the delete only ever removes *this* owner's lock.

```ts
const existing = callsInProgress[key];
if (existing) {
  await existing.promise;
  return fn(key, ...args);   // waiter never touches the lock
}
const lock = Promise.withResolvers<null>();
callsInProgress[key] = lock;
try {
  return await fn(key, ...args);
} finally {
  delete callsInProgress[key];
  lock.resolve(null);
}
```

## Testing

Added a regression test orchestrating the A→B→D→E interleaving and asserting mutual exclusion holds (E must not run concurrently with D). It fails on `develop` and passes with the fix.

- Full suite green (`yarn test`); `yarn quality-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)