### PR TITLE
VIDSOL-1056: fix: roll back captions user count when enableCaptions fails (#639)

### DIFF
--- a/backend/routes/session.ts
+++ b/backend/routes/session.ts
@@ -108,13 +108,13 @@ sessionRouter.post(
       const newCaptionCount = await sessionService.incrementCaptionsUserCount({ sessionKey });
 
       if (newCaptionCount === 1) {
-        const { result: captionsId, error } = await tryCatch(async () => {
+        const { result: captionsId, error, didFail } = await tryCatch(async () => {
           const { captionsId } = await videoClient.enableCaptions({ sessionKey });
           await sessionService.setCaptionsId({ sessionId, captionsId });
           return captionsId;
         });
 
-        if (error) {
+        if (didFail) {
           // Roll back the increment so a transient failure can't wedge captions for the
           // whole room: otherwise the count stays >= 1 and the "=== 1" enable branch
           // (the only path that actually calls enableCaptions) never runs again.

--- a/backend/routes/session.ts
+++ b/backend/routes/session.ts
@@ -3,6 +3,7 @@ import getSessionStorageService from '../sessionStorageService';
 import { makeVideoClient$ } from './video';
 import { makeInternalErrorHandler } from '@api-lib/errors';
 import { getSessionKeyFromRoomName, getOrCreateSessionKeyFromRoomName } from '../helpers';
+import tryCatch from '@common/execution/tryCatch';
 
 const sessionRouter = Router();
 const sessionService = getSessionStorageService();
@@ -107,8 +108,20 @@ sessionRouter.post(
       const newCaptionCount = await sessionService.incrementCaptionsUserCount({ sessionKey });
 
       if (newCaptionCount === 1) {
-        const { captionsId } = await videoClient.enableCaptions({ sessionKey });
-        await sessionService.setCaptionsId({ sessionId, captionsId });
+        const { result: captionsId, error } = await tryCatch(async () => {
+          const { captionsId } = await videoClient.enableCaptions({ sessionKey });
+          await sessionService.setCaptionsId({ sessionId, captionsId });
+          return captionsId;
+        });
+
+        if (error) {
+          // Roll back the increment so a transient failure can't wedge captions for the
+          // whole room: otherwise the count stays >= 1 and the "=== 1" enable branch
+          // (the only path that actually calls enableCaptions) never runs again.
+          await sessionService.decrementCaptionsUserCount({ sessionKey });
+          throw error;
+        }
+
         res.status(200).json({ captionsId, status: 200 });
       } else {
         const captionsId = await sessionService.getCaptionsId({ sessionId });

--- a/backend/tests/session.test.ts
+++ b/backend/tests/session.test.ts
@@ -12,6 +12,10 @@ const validSessionId = '1_Mn52b25hZ2VBcHBJZH4wLjAuMC4wfjIwMjQtMDEtMDE=';
 const validSessionKey =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uSWQiOiIxX01YNWtNVEkxWWpGbU1DMWtZMkl5TFRRM05EY3RZamxrWVMxa09ESTVOMkk0WkdFME9UZC1makUzTnpVM09UWXhOVGd3TWpkLWFqaElOU3RYZEV4VU5sYzBZbE5vZGs5UVNYVllVRmRDZm41LSIsInJvb21OYW1lIjoiYXdlc29tZS1yb29tLW5hbWUiLCJpYXQiOjE3NzU5NjMzMjh9.QcNVXp6gatPTV82IJa8VgDG6rOLBkFjU3r7j_BcxM-c';
 
+const mockEnableCaptions = jest
+  .fn<() => Promise<{ captionsId: string }>>()
+  .mockResolvedValue({ captionsId: '123e4567-a12b-41a2-a123-123456789012' });
+
 await jest.unstable_mockModule('../helpers/config', mockOpentokConfig);
 
 // Mock third-party Vonage SDKs only
@@ -48,9 +52,7 @@ await jest.unstable_mockModule('@vonage/video', () => ({
         items: [{ id: 'archive1' }, { id: 'archive2' }] as unknown as Archive[],
         count: 2,
       }),
-    enableCaptions: jest
-      .fn<() => Promise<{ captionsId: string }>>()
-      .mockResolvedValue({ captionsId: '123e4567-a12b-41a2-a123-123456789012' }),
+    enableCaptions: mockEnableCaptions,
     disableCaptions: jest
       .fn<(captionsId: string) => Promise<void>>()
       .mockImplementation((captionsId: string) => {
@@ -203,6 +205,30 @@ describe.each([['InMemorySessionStorage', new InMemorySessionStorage()]])(
             .post(`/session/${invalidRoomName}/${captionsId}/disableCaptions`)
             .set('Content-Type', 'application/json');
           expect(res.statusCode).toEqual(404);
+        });
+
+        it('rolls back the captions user count when enabling fails so captions are not wedged', async () => {
+          // Seed the session the route resolves for this room, which zeroes the count.
+          await sessionService.setSession({
+            roomName,
+            sessionKey: validSessionKey,
+            sessionId: validSessionId,
+          });
+
+          // First user requests captions (0 -> 1) but the SDK enable transiently fails.
+          mockEnableCaptions.mockRejectedValueOnce(new Error('transient enable failure'));
+          const failed = await request(server)
+            .post(`/session/${roomName}/enableCaptions`)
+            .set('Content-Type', 'application/json');
+          expect(failed.statusCode).toBeGreaterThanOrEqual(400);
+
+          // With the rollback the count is back to 0, so the next increment returns 1
+          // (the "=== 1" branch that actually calls enableCaptions runs again). Without
+          // it the count is stuck at 1 and this would return 2 — captions never re-enable.
+          const nextCount = await sessionService.incrementCaptionsUserCount({
+            sessionKey: validSessionKey,
+          });
+          expect(nextCount).toBe(1);
         });
       });
 


### PR DESCRIPTION
## Summary

Fixes #639. The captions user-count is incremented **before** captions are enabled and was **never rolled back** on failure. A single transient `enableCaptions`/`setCaptionsId` error left the count stuck at `>= 1`, so the `=== 1` "actually enable" branch never runs again — **captions become permanently un-enableable** for that room, and later requests return a never-set captions id.

## Fix

Wrap the enable in `tryCatch` and decrement the count on failure before rethrowing (the outer `catch` still maps it to an HTTP response):

```ts
if (newCaptionCount === 1) {
  const { result: captionsId, error } = await tryCatch(async () => {
    const { captionsId } = await videoClient.enableCaptions({ sessionKey });
    await sessionService.setCaptionsId({ sessionId, captionsId });
    return captionsId;
  });
  if (error) {
    await sessionService.decrementCaptionsUserCount({ sessionKey }); // roll back
    throw error;
  }
  res.status(200).json({ captionsId, status: 200 });
}
```

## Testing

Added a regression test that fails the SDK `enableCaptions` once and asserts the count returns to 0 (the next increment is 1, not 2). It fails on `develop` (count stuck at 2) and passes with the fix.

- Full suite green (`yarn test`); `yarn quality-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)