### PR TITLE
VIDSOL-1055: fix: redact sensitive headers in ApplicationServerError log details (#594)

### DIFF
--- a/libs/api/src/errors/ApplicationServerError.test.ts
+++ b/libs/api/src/errors/ApplicationServerError.test.ts
@@ -31,6 +31,50 @@ describe('ApplicationServerError', () => {
     expect(() => error.assert()).toThrow(ApplicationServerError);
   });
 
+  it('redacts sensitive request/response headers in the log details', () => {
+    const source = Object.assign(new Error('Upstream 401'), {
+      code: 'ERR_BAD_REQUEST',
+      config: {
+        data: undefined,
+        headers: {
+          Authorization: 'Basic super-secret-jira-token',
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        type: 'https',
+        url: 'https://api.jira.example/issue',
+      },
+      response: {
+        body: undefined,
+        bodyUsed: false,
+        headers: { 'set-cookie': 'session=super-secret' },
+        ok: false,
+        redirected: false,
+        size: 0,
+        status: 401,
+        statusText: 'Unauthorized',
+        timeout: 0,
+        url: 'https://api.jira.example/issue',
+      },
+    });
+
+    const error = new ApplicationServerError({
+      src: source,
+      fallbackConfig: {
+        fallbackMessage: 'Something went wrong',
+        statusCode: StatusCodeEnum.ServerErrorInternal,
+      },
+    });
+
+    const details = error.retrieveErrorLogDetails();
+
+    expect(details.configHeaders).toEqual({
+      Authorization: '[REDACTED]',
+      'content-type': 'application/json',
+    });
+    expect(details.headers).toEqual({ 'set-cookie': '[REDACTED]' });
+  });
+
   it('should hide sensitive information in production mode', () => {
     process.env.NODE_ENV = 'production';
 

--- a/libs/api/src/errors/ApplicationServerError.ts
+++ b/libs/api/src/errors/ApplicationServerError.ts
@@ -76,7 +76,7 @@ export class ApplicationServerError extends ApplicationError {
    * Replaces sensitive header values (Jira Basic token, Vonage JWT, cookies) with a
    * placeholder so credentials are not leaked to logs on upstream 4xx/5xx.
    */
-  private static redactSensitiveHeaders = (headers?: Record<string, unknown>) => {
+  private static readonly redactSensitiveHeaders = (headers?: Record<string, unknown>) => {
     if (!headers) return headers;
 
     return Object.fromEntries(

--- a/libs/api/src/errors/ApplicationServerError.ts
+++ b/libs/api/src/errors/ApplicationServerError.ts
@@ -63,6 +63,32 @@ export class ApplicationServerError extends ApplicationError {
   }
 
   /**
+   * Header names whose values must never be written to logs.
+   */
+  private static readonly SENSITIVE_HEADERS = [
+    'authorization',
+    'x-api-key',
+    'cookie',
+    'set-cookie',
+  ];
+
+  /**
+   * Replaces sensitive header values (Jira Basic token, Vonage JWT, cookies) with a
+   * placeholder so credentials are not leaked to logs on upstream 4xx/5xx.
+   */
+  private static redactSensitiveHeaders = (headers?: Record<string, unknown>) => {
+    if (!headers) return headers;
+
+    return Object.fromEntries(
+      Object.entries(headers).map(([key, value]) =>
+        ApplicationServerError.SENSITIVE_HEADERS.includes(key.toLowerCase())
+          ? [key, '[REDACTED]']
+          : [key, value]
+      )
+    );
+  };
+
+  /**
    * Extracts and returns detailed information from the error for logging purposes.
    */
   public retrieveErrorLogDetails = () => {
@@ -94,11 +120,11 @@ export class ApplicationServerError extends ApplicationError {
       body,
       bodyUsed,
       code,
-      configHeaders,
+      configHeaders: ApplicationServerError.redactSensitiveHeaders(configHeaders),
       configUrl,
       data,
       fallbackConfig,
-      headers,
+      headers: ApplicationServerError.redactSensitiveHeaders(headers),
       issues,
       message,
       method,


### PR DESCRIPTION
## Summary

Fixes #594. `retrieveErrorLogDetails()` returned the captured request/response headers verbatim, so on any upstream 4xx/5xx (Vonage Video API or Jira) the error handler's `console.error` wrote the **Jira Basic token / Vonage JWT** (and cookies) to server logs. If logs ship to a centralized system, credentials are persisted and accessible to anyone with log access.

## Fix

Add a static redactor that replaces `authorization` / `x-api-key` / `cookie` / `set-cookie` values with `[REDACTED]`, applied to both `configHeaders` (request) and response `headers`:

```ts
private static redactSensitiveHeaders = (headers?: Record<string, unknown>) => {
  if (!headers) return headers;
  return Object.fromEntries(
    Object.entries(headers).map(([key, value]) =>
      SENSITIVE_HEADERS.includes(key.toLowerCase()) ? [key, '[REDACTED]'] : [key, value]
    )
  );
};
```

## Testing

Added a regression test constructing an HTTP-like error with an `Authorization` request header and a `set-cookie` response header, asserting both are redacted while non-sensitive headers are preserved. It fails on `develop` and passes with the fix.

- Full suite green (`yarn test`); `yarn quality-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)