### PR TITLE
VIDSOL-1054: fix: stop the precall NetworkTest on timeout/error, not only on cancel (#642)

### DIFF
--- a/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.spec.tsx
+++ b/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.spec.tsx
@@ -146,6 +146,21 @@ describe('useNetworkTest', () => {
     });
   });
 
+  it('stops the network test when the quality test errors (no leaked camera/mic)', async () => {
+    const { result } = render(() => useNetworkTest());
+    const mockError = new Error('Network test failed');
+    mockError.name = 'NetworkError';
+    mockNetworkTest.testQuality.mockRejectedValue(mockError);
+
+    await act(async () => {
+      await expect(result.current.testQuality('test-room')).rejects.toThrow('Network test failed');
+    });
+
+    // On the error path the test must be stopped too — otherwise its OT session and
+    // publisher (camera/mic) keep running in the background.
+    expect(mockNetworkTest.stop).toHaveBeenCalled();
+  });
+
   /**
    * TODO: We need to find a way of tell vitest that the unhandled reject is actually expected here.
    */

--- a/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.spec.tsx
+++ b/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.spec.tsx
@@ -144,19 +144,7 @@ describe('useNetworkTest', () => {
       message: 'Network test failed',
       name: 'NetworkError',
     });
-  });
-
-  it('stops the network test when the quality test errors (no leaked camera/mic)', async () => {
-    const { result } = render(() => useNetworkTest());
-    const mockError = new Error('Network test failed');
-    mockError.name = 'NetworkError';
-    mockNetworkTest.testQuality.mockRejectedValue(mockError);
-
-    await act(async () => {
-      await expect(result.current.testQuality('test-room')).rejects.toThrow('Network test failed');
-    });
-
-    // On the error path the test must be stopped too — otherwise its OT session and
+    // On the error path the test must also be stopped — otherwise its OT session and
     // publisher (camera/mic) keep running in the background.
     expect(mockNetworkTest.stop).toHaveBeenCalled();
   });

--- a/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.tsx
+++ b/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.tsx
@@ -138,12 +138,16 @@ const useNetworkTest = () => {
 
       return (testPromiseRef.current = new CancelablePromise<QualityResults>(
         async (resolve, reject, { isCanceled, reportProgress, onCancel }) => {
+          // Hoisted so the catch below can stop it on timeout/error too — otherwise the
+          // NetworkTest's OT session, publisher (camera/mic) and bandwidth probing keep
+          // running in the background after a failed test.
+          let networkTest: NetworkTest | undefined;
           try {
             const { applicationId, sessionId, token } = await videoClient.createSessionAndJoin();
 
             if (isCanceled()) return;
 
-            const networkTest = new NetworkTest(
+            networkTest = new NetworkTest(
               OT,
               {
                 applicationId,
@@ -196,6 +200,10 @@ const useNetworkTest = () => {
             return resolve(qualityResults);
           } catch (error) {
             if (isCanceled()) return;
+
+            // Stop the test on timeout/error too (mirrors the onCancel path), so the
+            // camera/mic and bandwidth probing don't keep running in the background.
+            void attempt(() => networkTest?.stop());
 
             const networkError: NetworkTestError = {
               message:

--- a/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.tsx
+++ b/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.tsx
@@ -125,6 +125,15 @@ const useNetworkTest = () => {
     void testPromiseRef.current?.cancel();
   }, []);
 
+  const createTimeout = useCallback(
+    (reject: (error: Error) => void, timeoutMs: number) =>
+      setTimeout(
+        () => reject(new Error(t('waitingRoom.precallNetworkTest.error.timeout'))),
+        timeoutMs
+      ),
+    [t]
+  );
+
   const testQuality = useCallback(
     (roomName: string, options: NetworkTestOptions = {}): CancelablePromise<QualityResults> => {
       const isPending = testPromiseRef.current?.status === 'pending';
@@ -171,10 +180,7 @@ const useNetworkTest = () => {
             // timeout after 60s
 
             const qualityResults = await new Promise<QualityTestResults>((res, rej) => {
-              const timeout = setTimeout(
-                () => rej(new Error(t('waitingRoom.precallNetworkTest.error.timeout'))),
-                options.timeout || 60000
-              );
+              const timeout = createTimeout(rej, options.timeout || 60000);
 
               networkTest
                 .testQuality((qualityUpdateStats) => {
@@ -203,7 +209,7 @@ const useNetworkTest = () => {
 
             // Stop the test on timeout/error too (mirrors the onCancel path), so the
             // camera/mic and bandwidth probing don't keep running in the background.
-            void attempt(() => networkTest?.stop());
+            attempt(() => networkTest?.stop());
 
             const networkError: NetworkTestError = {
               message:
@@ -222,7 +228,7 @@ const useNetworkTest = () => {
         }
       ));
     },
-    [t, videoClient]
+    [t, videoClient, createTimeout]
   );
 
   useMountEffect(() => {

--- a/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.tsx
+++ b/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.tsx
@@ -167,9 +167,7 @@ const useNetworkTest = () => {
             );
 
             onCancel(() => {
-              attempt(() => {
-                networkTest!.stop();
-              });
+              stopNetworkTest(networkTest);
 
               setState((prev) => ({
                 ...prev,
@@ -209,7 +207,7 @@ const useNetworkTest = () => {
 
             // Stop the test on timeout/error too (mirrors the onCancel path), so the
             // camera/mic and bandwidth probing don't keep running in the background.
-            attempt(() => networkTest?.stop());
+            stopNetworkTest(networkTest);
 
             const networkError: NetworkTestError = {
               message:
@@ -244,6 +242,12 @@ const useNetworkTest = () => {
     clearResults,
   };
 };
+
+// Releases the NetworkTest's OT session, publisher (camera/mic) and bandwidth probing.
+// Kept at module scope so the call sites stay within Sonar's function-nesting limit.
+function stopNetworkTest(networkTest: NetworkTest | undefined) {
+  attempt(() => networkTest?.stop());
+}
 
 export { ErrorNames };
 export default useNetworkTest;

--- a/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.tsx
+++ b/frontend/src/components/WaitingRoom/PrecallNetworkTestDialog/hooks/useNetworkTest.tsx
@@ -122,7 +122,7 @@ const useNetworkTest = () => {
   }, []);
 
   const stopTest = useCallback(() => {
-    void testPromiseRef.current?.cancel();
+    testPromiseRef.current?.cancel()?.catch(() => {});
   }, []);
 
   const createTimeout = useCallback(
@@ -167,8 +167,8 @@ const useNetworkTest = () => {
             );
 
             onCancel(() => {
-              void attempt(() => {
-                networkTest.stop();
+              attempt(() => {
+                networkTest!.stop();
               });
 
               setState((prev) => ({
@@ -182,7 +182,7 @@ const useNetworkTest = () => {
             const qualityResults = await new Promise<QualityTestResults>((res, rej) => {
               const timeout = createTimeout(rej, options.timeout || 60000);
 
-              networkTest
+              networkTest!
                 .testQuality((qualityUpdateStats) => {
                   if (isCanceled()) return;
 


### PR DESCRIPTION
## Summary

Fixes #642. `useNetworkTest.testQuality` created the `NetworkTest` as a local `const` and only called `stop()` in the `onCancel` handler. A 60s **timeout** or any `testQuality` **rejection** propagated to the outer `catch` and rejected **without stopping the test** — so its OT session, publisher (camera/mic) and bandwidth probing kept running in the background until navigation. Retrying could stack more.

## Fix

Hoist `networkTest` so the `catch` can stop it too (mirroring `onCancel`):

```ts
let networkTest: NetworkTest | undefined;
try {
  ...
  networkTest = new NetworkTest(OT, { applicationId, sessionId, token }, options);
  ...
} catch (error) {
  if (isCanceled()) return;
  void attempt(() => networkTest?.stop()); // stop on timeout / error too
  ...
}
```

## Testing

Added a regression test asserting `stop()` is called when the quality test errors. It fails on `develop` (`stop` never called) and passes with the fix.

- Full suite green (`yarn test`); `yarn quality-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)