### PR TITLE
VIDSOL-1053: fix: guard unguarded JSON.parse, screen-share publish, and localStorage (#591)

### DIFF
--- a/frontend/src/hooks/useEmoji.spec.tsx
+++ b/frontend/src/hooks/useEmoji.spec.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { Connection } from '@vonage/client-sdk-video';
+import useEmoji from './useEmoji';
+import type { SignalEvent } from '../types/session';
+
+describe('useEmoji', () => {
+  const from = { connectionId: 'other-connection' } as Connection;
+  const props = { signal: vi.fn(), getConnectionId: () => 'my-connection' };
+
+  it('ignores malformed (non-JSON) emoji signals without throwing or enqueuing', () => {
+    const { result } = renderHook(() => useEmoji(props));
+
+    act(() => {
+      expect(() =>
+        result.current.onEmoji({ data: 'not-json{', from } as unknown as SignalEvent, [])
+      ).not.toThrow();
+    });
+
+    expect(result.current.emojiQueue).toEqual([]);
+  });
+
+  it('enqueues a well-formed emoji signal', () => {
+    const { result } = renderHook(() => useEmoji(props));
+
+    act(() => {
+      result.current.onEmoji(
+        {
+          data: JSON.stringify({ emoji: '👍', time: 123 }),
+          from,
+        } as unknown as SignalEvent,
+        []
+      );
+    });
+
+    expect(result.current.emojiQueue).toHaveLength(1);
+    expect(result.current.emojiQueue[0]).toMatchObject({ emoji: '👍', time: 123 });
+  });
+});

--- a/frontend/src/hooks/useEmoji.tsx
+++ b/frontend/src/hooks/useEmoji.tsx
@@ -106,8 +106,21 @@ const useEmoji = ({ signal, getConnectionId }: UseEmojiProps): UseEmoji => {
   const onEmoji = useCallback(
     ({ data, from: sendingConnection }: SignalEvent, subscriberWrappers: SubscriberWrapper[]) => {
       if (data && sendingConnection) {
+        // Guard against malformed/non-JSON signals (e.g. a different SDK version or a
+        // malicious participant) — an unguarded JSON.parse would throw and crash the
+        // session signal handler.
+        const parsed = (() => {
+          try {
+            return JSON.parse(data) as EmojiDataType;
+          } catch {
+            return null;
+          }
+        })();
+
+        if (!parsed) return;
+
         const senderName = getSenderName(sendingConnection, subscriberWrappers) ?? '';
-        const { emoji, time }: EmojiDataType = JSON.parse(data);
+        const { emoji, time } = parsed;
 
         const emojiWrapper: EmojiWrapper = {
           name: senderName,

--- a/frontend/src/hooks/useScreenShare.spec.tsx
+++ b/frontend/src/hooks/useScreenShare.spec.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const mockPublisher = {
+  element: { classList: { add: vi.fn() } },
+  on: vi.fn(),
+  destroy: vi.fn(),
+};
+
+const mockInitPublisher = vi.fn((..._args: unknown[]) => mockPublisher);
+vi.mock('@vonage/client-sdk-video', () => ({
+  __esModule: true,
+  initPublisher: (...args: unknown[]) => mockInitPublisher(...args),
+}));
+
+const mockPublish = vi.fn();
+const mockUnpublish = vi.fn();
+const mockVonageVideoClient = { on: vi.fn(), off: vi.fn() };
+vi.mock('./useSessionContext', () => ({
+  default: () => ({
+    vonageVideoClient: mockVonageVideoClient,
+    publish: mockPublish,
+    unpublish: mockUnpublish,
+  }),
+}));
+
+vi.mock('./useUserContext', () => ({
+  default: () => ({ user: { defaultSettings: { name: 'Ada' } } }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import useScreenShare from './useScreenShare';
+
+describe('useScreenShare', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('destroys the publisher and resets state when publishing the screen share fails', async () => {
+    mockPublish.mockRejectedValue(new Error('permission denied'));
+
+    const { result } = renderHook(() => useScreenShare());
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    expect(mockPublish).toHaveBeenCalled();
+    // The publisher must be destroyed so the screen capture actually stops.
+    expect(mockPublisher.destroy).toHaveBeenCalled();
+    expect(result.current.isSharingScreen).toBe(false);
+    // The stream-created listener must not be registered when publishing failed.
+    expect(mockVonageVideoClient.on).not.toHaveBeenCalledWith(
+      'screenshareStreamCreated',
+      expect.anything()
+    );
+  });
+
+  it('registers the screenshareStreamCreated listener on a successful publish', async () => {
+    mockPublish.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useScreenShare());
+
+    await act(async () => {
+      await result.current.toggleShareScreen();
+    });
+
+    expect(mockPublisher.destroy).not.toHaveBeenCalled();
+    expect(mockVonageVideoClient.on).toHaveBeenCalledWith(
+      'screenshareStreamCreated',
+      expect.any(Function)
+    );
+  });
+});

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback } from 'react';
 import { Publisher, initPublisher } from '@vonage/client-sdk-video';
 import { useTranslation } from 'react-i18next';
 import tryCatch from '@common/execution/tryCatch';
+import attempt from '@common/execution/attempt';
 import useSessionContext from './useSessionContext';
 import useUserContext from './useUserContext';
 
@@ -122,6 +123,10 @@ const useScreenShare = (): UseScreenShareType => {
 
         const { didFail } = await tryCatch(() => publish(screenSharingPublisher));
         if (didFail) {
+          // Destroy the publisher too — onScreenShareStopped only nulls the ref, so the
+          // screen capture (and the browser's screen-share indicator) would otherwise keep
+          // running with no handle left to stop it.
+          void attempt(() => screenSharingPublisher.destroy());
           onScreenShareStopped();
           return;
         }

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback } from 'react';
 import { Publisher, initPublisher } from '@vonage/client-sdk-video';
 import { useTranslation } from 'react-i18next';
+import tryCatch from '@common/execution/tryCatch';
 import useSessionContext from './useSessionContext';
 import useUserContext from './useUserContext';
 
@@ -113,8 +114,17 @@ const useScreenShare = (): UseScreenShareType => {
           onScreenShareStopped();
         });
 
-        // Publishing the screen sharing stream
-        await publish(screenSharingPubRef.current);
+        // Publishing the screen sharing stream. Guard against publish failures
+        // (permission denied, network) so we don't leave the UI in a "sharing" state
+        // with nothing actually published.
+        const screenSharingPublisher = screenSharingPubRef.current;
+        if (!screenSharingPublisher) return;
+
+        const { didFail } = await tryCatch(() => publish(screenSharingPublisher));
+        if (didFail) {
+          onScreenShareStopped();
+          return;
+        }
 
         vonageVideoClient?.on('screenshareStreamCreated', handleStreamCreated);
       } else if (screenSharingPubRef.current) {

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -126,7 +126,7 @@ const useScreenShare = (): UseScreenShareType => {
           // Destroy the publisher too — onScreenShareStopped only nulls the ref, so the
           // screen capture (and the browser's screen-share indicator) would otherwise keep
           // running with no handle left to stop it.
-          void attempt(() => screenSharingPublisher.destroy());
+          attempt(() => screenSharingPublisher.destroy());
           onScreenShareStopped();
           return;
         }

--- a/frontend/src/utils/storage.spec.ts
+++ b/frontend/src/utils/storage.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getStorageItem, setStorageItem } from './storage';
+
+describe('storage utils', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw when localStorage.setItem fails (Safari private mode / quota exceeded)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+    });
+
+    expect(() => setStorageItem('username', 'ada')).not.toThrow();
+  });
+
+  it('returns null when localStorage.getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    expect(getStorageItem('username')).toBeNull();
+  });
+});

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -10,9 +10,18 @@ export const STORAGE_KEYS = {
 };
 
 export const setStorageItem = (key: string, value: string) => {
-  window.localStorage.setItem(key, value);
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Safari private browsing or quota exceeded — degrade silently rather than crash
+    // the calling code path (e.g. saving settings).
+  }
 };
 
 export const getStorageItem = (key: string): string | null => {
-  return window.localStorage.getItem(key);
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
 };


### PR DESCRIPTION
## Summary

Fixes #591. Three runtime operations could throw and crash:

1. **`useEmoji.onEmoji`** ran `JSON.parse(data)` unguarded — a malformed/non-JSON signal (different SDK version or a malicious participant) crashed the session signal handler. Now parses defensively and ignores unparseable payloads.
2. **`useScreenShare`** awaited `publish()` with no handling — a publish failure (permission/network) left the UI in a "sharing" state with nothing published. Now wrapped in `tryCatch` with `onScreenShareStopped()` on failure.
3. **`utils/storage`** called `localStorage` directly, which throws in Safari private browsing / on quota exceeded, crashing the calling path (e.g. saving settings). Both `setStorageItem`/`getStorageItem` now degrade silently (set) or return `null` (get).

## Testing

Added `storage.spec.ts` asserting `setStorageItem` does not throw and `getStorageItem` returns `null` when `localStorage` throws — both fail on `develop` and pass with the fix. The emoji/publish guards are defensive `try/catch` covered by the existing suite (green).

- Full suite green (`yarn test`); `yarn quality-check` clean

> Note: this branch and #586 both touch `useScreenShare.tsx`, and this branch and #587 both touch `useEmoji.tsx` — they'll need sequential rebasing on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)