### PR TITLE
VIDSOL-1052: fix: remove ActiveSpeakerTracker and screenshareStreamCreated listeners on cleanup (#586)

### DIFF
--- a/frontend/src/Context/SessionProvider/session.tsx
+++ b/frontend/src/Context/SessionProvider/session.tsx
@@ -16,6 +16,7 @@ import useUserContext from '@hooks/useUserContext';
 import useChat from '@hooks/useChat';
 import useEmoji, { EmojiWrapper } from '@hooks/useEmoji';
 import ActiveSpeakerTracker from '@utils/ActiveSpeakerTracker';
+import type { ActiveSpeakerChangedPayload } from '@utils/ActiveSpeakerTracker/activeSpeakerTracker';
 import {
   Credential,
   LocalCaptionReceived,
@@ -304,13 +305,22 @@ const SessionProvider = ({
 
   // hook to keep track of the active speaker during the call and move it to the top of the display order
   useEffect(() => {
-    activeSpeakerTracker.current.on('activeSpeakerChanged', ({ newActiveSpeaker }) => {
+    const tracker = activeSpeakerTracker.current;
+    const handleActiveSpeakerChanged = ({ newActiveSpeaker }: ActiveSpeakerChangedPayload) => {
       const { subscriberId } = newActiveSpeaker;
       setActiveSpeakerIdAndRef(subscriberId);
       if (subscriberId) {
         moveSubscriberToTopOfDisplayOrder(subscriberId);
       }
-    });
+    };
+
+    tracker.on('activeSpeakerChanged', handleActiveSpeakerChanged);
+
+    // Remove the listener when the effect re-runs or the provider unmounts, otherwise a
+    // new listener is stacked on every dep change and duplicates fire per event.
+    return () => {
+      tracker.off('activeSpeakerChanged', handleActiveSpeakerChanged);
+    };
   }, [moveSubscriberToTopOfDisplayOrder, setActiveSpeakerIdAndRef]);
 
   const { user } = useUserContext();

--- a/frontend/src/hooks/useScreenShare.tsx
+++ b/frontend/src/hooks/useScreenShare.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { Publisher, initPublisher } from '@vonage/client-sdk-video';
 import { useTranslation } from 'react-i18next';
 import useSessionContext from './useSessionContext';
@@ -54,6 +54,15 @@ const useScreenShare = (): UseScreenShareType => {
   const handleStreamCreated = useCallback(() => {
     unpublishScreenshare();
   }, [unpublishScreenshare]);
+
+  // The toggleShareScreen else-branch only removes the screenshareStreamCreated listener when
+  // the user stops sharing via the button. If the component unmounts while sharing, the
+  // listener on vonageVideoClient would leak (and stack duplicates on remount + re-share).
+  useEffect(() => {
+    return () => {
+      vonageVideoClient?.off('screenshareStreamCreated', handleStreamCreated);
+    };
+  }, [vonageVideoClient, handleStreamCreated]);
 
   // Using useCallback to memoize the function to avoid unnecessary re-renders
   const toggleShareScreen = useCallback(async () => {


### PR DESCRIPTION
## Summary

Fixes #586. Two event listeners were registered without ever being removed:

1. **`session.tsx`** registered `activeSpeakerTracker.on('activeSpeakerChanged')` in a `useEffect` with **no cleanup**, so every dep change stacked another listener and duplicates fired per event. Now the handler is named and `off()`'d in the effect cleanup.
2. **`useScreenShare`** registered `vonageVideoClient.on('screenshareStreamCreated')` in `toggleShareScreen` but only removed it in the else-branch (user stops via the button). Unmounting mid-share leaked it (and stacked duplicates on remount + re-share). Now an effect `off()`s it on unmount.

## Testing

Cleanup-only change (listener removal on unmount / effect re-run). Verified by the **full frontend suite passing with no regressions**; a bespoke mount/unmount leak assertion can be added if preferred.

- Full suite green (`yarn test`); `yarn quality-check` clean

> Note: this branch and #591 both touch `useScreenShare.tsx` — they'll need sequential rebasing on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)