### PR TITLE
VIDSOL-1050: fix: cap /feedback/report body with a route-scoped 2mb limit (#664)

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,7 +1,7 @@
 // loads environment variables from .env file
 import './helpers/config';
 
-import express, { Express, Request, Response } from 'express';
+import express, { Express, Request, Response, NextFunction } from 'express';
 import path from 'path';
 import bodyParser from 'body-parser';
 import cors from 'cors';
@@ -27,6 +27,26 @@ const app: Express = express();
 
 app.use(helmetMiddleware);
 app.use(rateLimitMiddleware);
+
+// Parse the unauthenticated /feedback endpoint with a small limit BEFORE the global 20mb
+// parser. body-parser skips re-parsing once req._body is set, so this scoped limit caps the
+// base64-attachment -> Buffer -> form-data memory amplification (a DoS vector) before the
+// handler ever runs. Reject oversized bodies with a clean 413 instead of the generic 500.
+app.use('/feedback', express.json({ limit: '2mb' }));
+app.use('/feedback', (error: unknown, _req: Request, res: Response, next: NextFunction) => {
+  const isPayloadTooLarge =
+    !!error &&
+    typeof error === 'object' &&
+    (error as { type?: string }).type === 'entity.too.large';
+
+  if (isPayloadTooLarge) {
+    res.status(413).json({ message: 'Feedback payload too large.' });
+    return;
+  }
+
+  next(error);
+});
+
 app.use(express.json({ limit: '20mb' }));
 app.use(express.urlencoded({ limit: '20mb', extended: true }));
 app.use(cors({ origin: true, credentials: true }));

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -32,7 +32,11 @@ app.use(rateLimitMiddleware);
 // parser. body-parser skips re-parsing once req._body is set, so this scoped limit caps the
 // base64-attachment -> Buffer -> form-data memory amplification (a DoS vector) before the
 // handler ever runs. Reject oversized bodies with a clean 413 instead of the generic 500.
+// Apply CORS first so 413 responses include the expected headers (the global cors() middleware
+// runs later and would otherwise never execute for error responses).
+app.use('/feedback', cors({ origin: true, credentials: true }));
 app.use('/feedback', express.json({ limit: '2mb' }));
+app.use('/feedback', express.urlencoded({ limit: '2mb', extended: true }));
 app.use('/feedback', (error: unknown, _req: Request, res: Response, next: NextFunction) => {
   const isPayloadTooLarge =
     !!error &&

--- a/backend/tests/feedback.test.ts
+++ b/backend/tests/feedback.test.ts
@@ -47,6 +47,24 @@ describe('POST /feedback/report', () => {
     mockReportIssue.mockClear();
   });
 
+  it('rejects an oversized feedback payload before invoking the feedback service (DoS guard)', async () => {
+    const res = await request(server)
+      .post('/feedback/report')
+      .set('Content-Type', 'application/json')
+      .send({
+        title: 'x',
+        name: 'y',
+        issue: 'z',
+        // ~3 MB base64 attachment, over the route's 2 MB limit.
+        attachment: 'A'.repeat(3_000_000),
+      });
+
+    // The body must be rejected before it reaches the handler/service, so the base64 ->
+    // Buffer -> form-data amplification never happens.
+    expect(res.statusCode).toBe(413);
+    expect(mockReportIssue).not.toHaveBeenCalled();
+  });
+
   it('Posting a feedback should pass correct values to the feedback service', async () => {
     const res = await request(server)
       .post('/feedback/report')


### PR DESCRIPTION
## Summary

Fixes #664. `POST /feedback/report` is unauthenticated and inherited the **global** `express.json({ limit: '20mb' })` (`server.ts`). A client could POST a ~20MB base64 `attachment`, which is then base64-decoded into a `Buffer` and re-buffered by `form-data` for the Jira upload — **~3× resident per request**. At 500 req/min/IP that's a memory-exhaustion (DoS) vector.

## Why the "obvious" fix doesn't work

Adding `express.json({ limit: '2mb' })` as **route** middleware (as the issue and `logger.ts` do) is a **no-op here**: the global parser at `server.ts:30` runs first and sets `req._body`, so body-parser skips any later parser. (Worth noting the existing `/client-logs` route-scoped limits are ineffective for the same reason.)

## Fix

Mount a small parser for `/feedback` **before** the global one, so the feedback body is parsed at 2MB first and the global 20MB parser skips it. Reject oversized bodies with a clean `413` (instead of the generic `500` the shared error handler would produce):

```ts
app.use('/feedback', express.json({ limit: '2mb' }));
app.use('/feedback', (error, _req, res, next) => {
  if (error?.type === 'entity.too.large') {
    return res.status(413).json({ message: 'Feedback payload too large.' });
  }
  next(error);
});
app.use(express.json({ limit: '20mb' }));
```

This is a `server.ts`-only change and complements the **field-level schema validation added in #671** — together they close both halves of #664 (schema + body limit). No conflict: #671 touches `feedback.ts`, this touches `server.ts`.

## Testing

Added a regression test posting a ~3MB attachment and asserting a `413` **and** that the feedback service is never invoked (so the base64→Buffer→form-data amplification never runs). It **fails on `develop`** (`200`, service called) and passes with the fix.

- Full suite green across all projects (`yarn test`); `yarn quality-check` clean

> Follow-up worth considering separately: the same global-parser-precedence issue makes the `/client-logs` route-scoped limits ineffective too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)