### PR TITLE
VIDSOL-1049: fix: restrict credentialed CORS to an allowlist, not any origin (#582)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,11 @@
 # Get your Vonage Application ID and Private Key here: https://dashboard.nexmo.com/
 # If using OpenTok SDK and credentials make sure to remove this block and uncomment the block below with OT_ variables.
 
+# Comma-separated allowlist of origins permitted to make credentialed cross-origin (CORS)
+# requests — set this to the site(s) embedding <vera-room> against a remote API.
+# When unset, only same-origin / non-browser requests are allowed.
+# CORS_ALLOWED_ORIGINS='https://app.example.com,https://embed.example.com'
+
 VIDEO_SERVICE_PROVIDER='vonage'
 VONAGE_APP_ID=''
 # e.g. (this is an example application Id): 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -29,7 +29,31 @@ app.use(helmetMiddleware);
 app.use(rateLimitMiddleware);
 app.use(express.json({ limit: '20mb' }));
 app.use(express.urlencoded({ limit: '20mb', extended: true }));
-app.use(cors({ origin: true, credentials: true }));
+
+// Restrict credentialed CORS to an explicit allowlist instead of reflecting any origin.
+// Reflecting `origin: true` with credentials lets any site make authenticated cross-origin
+// requests. Configure CORS_ALLOWED_ORIGINS (comma-separated) with the origins that embed
+// <vera-room> against a remote API; when unset, only same-origin / non-browser requests
+// (no Origin header) are allowed.
+const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS ?? '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+      // Deny by not echoing the origin (no Access-Control-Allow-Origin header) rather than
+      // throwing, so the browser blocks the response without a 500.
+      callback(null, false);
+    },
+    credentials: true,
+  })
+);
 app.use(bodyParser.json());
 
 // Trust only the immediate reverse proxy.

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -35,15 +35,17 @@ app.use(express.urlencoded({ limit: '20mb', extended: true }));
 // requests. Configure CORS_ALLOWED_ORIGINS (comma-separated) with the origins that embed
 // <vera-room> against a remote API; when unset, only same-origin / non-browser requests
 // (no Origin header) are allowed.
-const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS ?? '')
-  .split(',')
-  .map((origin) => origin.trim())
-  .filter(Boolean);
+const allowedOrigins = new Set(
+  (process.env.CORS_ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+);
 
 app.use(
   cors({
     origin: (origin, callback) => {
-      if (!origin || allowedOrigins.includes(origin)) {
+      if (!origin || allowedOrigins.has(origin)) {
         callback(null, true);
         return;
       }

--- a/backend/tests/cors.test.ts
+++ b/backend/tests/cors.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import request from 'supertest';
+import { Server } from 'http';
+
+// Must be set before the server (and its cors middleware) is imported.
+process.env.CORS_ALLOWED_ORIGINS = 'https://allowed.example';
+process.env.VIDEO_SERVICE_PROVIDER = 'opentok';
+const startServer = (await import('../server')).default;
+
+describe('CORS allowlist', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    server = await startServer(0);
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  it('echoes the origin for an allowed origin', async () => {
+    const res = await request(server).get('/_/health').set('Origin', 'https://allowed.example');
+
+    expect(res.headers['access-control-allow-origin']).toBe('https://allowed.example');
+    expect(res.headers['access-control-allow-credentials']).toBe('true');
+  });
+
+  it('does not reflect a disallowed origin (no wildcard credentialed access)', async () => {
+    const res = await request(server).get('/_/health').set('Origin', 'https://evil.example');
+
+    // The disallowed origin must NOT be echoed back — otherwise any site could make
+    // credentialed cross-origin requests.
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('allows requests with no Origin header (same-origin / server-to-server)', async () => {
+    const res = await request(server).get('/_/health');
+
+    expect(res.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #582. `server.ts` used `cors({ origin: true, credentials: true })`, which **reflects any requesting origin** in `Access-Control-Allow-Origin` while sending credentials. That effectively disables the same-origin policy for authenticated requests — any malicious site can make credentialed cross-origin calls to the backend on behalf of a logged-in user.

## Fix

Drive allowed origins from a `CORS_ALLOWED_ORIGINS` env (comma-separated) and only echo listed origins:

```ts
const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS ?? '')
  .split(',').map((o) => o.trim()).filter(Boolean);

app.use(cors({
  origin: (origin, callback) => {
    if (!origin || allowedOrigins.includes(origin)) return callback(null, true);
    callback(null, false); // deny by omitting the header (browser blocks; no 500)
  },
  credentials: true,
}));
```

### Why this default is safe (and doesn't break embeds)
- **No `Origin` header** (same-origin browser requests, curl, server-to-server) → allowed. Browsers don't enforce CORS on same-origin, so the same-origin deployment is unaffected even with an empty allowlist.
- **Embedded `<vera-room>`** on a third-party page pointing at a **remote** API is genuinely cross-origin (the frontend's `API_URL` defaults to `window.location.origin` but is configurable). Those deployments set `CORS_ALLOWED_ORIGINS` to their host origin(s) — documented in `backend/.env.example`.
- **Secure by default:** unset → cross-origin credentialed requests are denied (fail-closed), vs. the previous fail-open reflect-all.

## Testing

Added `cors.test.ts`: allowed origin is echoed (+ `Allow-Credentials: true`), a **disallowed** origin is **not** reflected, and a no-`Origin` request still returns `200`. The disallowed-origin case **fails on `develop`** (it reflects `https://evil.example`) and passes with the fix.

- Full suite green (`yarn test`); `yarn quality-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)