### PR TITLE
VIDSOL-1048: fix: drop data: from CSP script-src (XSS bypass) (#593)

### DIFF
--- a/backend/middleware/helmetMiddleware/helmetMiddleware.test.ts
+++ b/backend/middleware/helmetMiddleware/helmetMiddleware.test.ts
@@ -36,6 +36,25 @@ describe('helmetMiddleware', () => {
     expect(helmetHandlerMock).toHaveBeenCalledWith(req, res, next);
   });
 
+  it('does not allow data: in script-src (XSS bypass) while keeping it where the SDK needs it', async () => {
+    process.env.NODE_ENV = 'production';
+
+    await import('./helmetMiddleware');
+
+    const config = helmetMock.mock.calls[0][0] as {
+      contentSecurityPolicy: { directives: Record<string, string[]> };
+    };
+    const directives = config.contentSecurityPolicy.directives;
+
+    // data: in script-src allows <script src="data:text/javascript,...">, negating CSP.
+    expect(directives['script-src']).not.toContain('data:');
+    expect(directives['script-src']).toContain("'self'");
+    // The SDK's data: usage is a fallback Worker (worker-src) and inline images (img-src),
+    // not scripts — those must keep data:.
+    expect(directives['worker-src']).toContain('data:');
+    expect(directives['img-src']).toContain('data:');
+  });
+
   it('should disable contentSecurityPolicy in development', async () => {
     process.env.NODE_ENV = 'development';
 

--- a/backend/middleware/helmetMiddleware/helmetMiddleware.ts
+++ b/backend/middleware/helmetMiddleware/helmetMiddleware.ts
@@ -11,12 +11,15 @@ const helmetHandler = helmet({
           // Allow scripts from self and Vonage/OpenTok static assets.
           // Needed by the Vonage/OpenTok SDK to load MediaPipe transformer assets,
           // including task-vision.js and worker-side scripts loaded through importScripts(...).
+          // Note: 'data:' is intentionally NOT allowed here — it would permit
+          // <script src="data:text/javascript,...">, negating CSP as an XSS defense. The SDK's
+          // data: usage is a fallback Worker (see 'worker-src') and inline images ('img-src'),
+          // not scripts.
           'script-src': [
             "'self'",
             // required for web assembly
             "'unsafe-eval'",
             'blob:',
-            'data:',
             'https://static.opentok.com',
           ],
 


### PR DESCRIPTION
## Summary

Fixes #593. The production CSP listed `data:` in `script-src`, which permits `<script src="data:text/javascript,maliciousCode()">` — so any HTML-injection point can execute arbitrary JS, negating CSP as an XSS defense.

## Is it safe to remove? (verified against the SDK)

Yes. I checked the SDK's `data:` JS usage in `@vonage/client-sdk-video/dist/js/opentok.js`:

```js
try { return new Worker(objURL); }
catch (e) { return new Worker("data:application/javascript;base64," + encodedJs); }
```

That's a **fallback Worker** — governed by **`worker-src`** (which keeps `data:`), not `script-src`. MediaPipe/task-vision assets load from `https://static.opentok.com` and `blob:` (both retained). So removing `data:` from `script-src` doesn't affect the SDK; `worker-src` and `img-src` keep their legitimate `data:`.

`'unsafe-eval'` is kept (WASM needs it, and it preserves broad browser support). Swapping to `'wasm-unsafe-eval'` is a possible follow-up but risks the SDK's non-WASM eval paths, so I left it out here.

## Testing

Added a regression test asserting `script-src` no longer contains `data:` while `worker-src`/`img-src` still do. It **fails on `develop`** (`script-src` includes `data:`) and passes with the fix.

- Full suite green (`yarn test`); `yarn quality-check` clean

> Touches `helmetMiddleware.ts` like #666 (which adds `data:`/`blob:` to `connect-src`) — different directives, so a trivial rebase at most on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)