### PR TITLE
VIDSOL-1047: fix: verify archive/captions belong to the room before acting (#583)

### DIFF
--- a/backend/routes/session.ts
+++ b/backend/routes/session.ts
@@ -1,7 +1,7 @@
 import { Request, Response, Router } from 'express';
 import getSessionStorageService from '../sessionStorageService';
 import { makeVideoClient$ } from './video';
-import { makeInternalErrorHandler } from '@api-lib/errors';
+import { makeInternalErrorHandler, makeNotFoundErrorHandler } from '@api-lib/errors';
 import { getSessionKeyFromRoomName, getOrCreateSessionKeyFromRoomName } from '../helpers';
 
 const sessionRouter = Router();
@@ -64,11 +64,15 @@ sessionRouter.post(
 
       // Ensure the archive belongs to this room's session before stopping it — otherwise a
       // caller who knows any room name could stop an archive from another room by its id.
-      const { items } = await videoClient.searchArchives({ sessionKey });
+      // Request up to 1000 archives to avoid missing archives on subsequent pages.
+      const { items } = await videoClient.searchArchives({ sessionKey, count: 1000 });
       const archiveBelongsToRoom = items.some((archive) => archive.id === archiveId);
 
       if (!archiveBelongsToRoom) {
-        res.status(404).json({ message: 'Archive not found for this room.' });
+        const notFoundError = makeNotFoundErrorHandler('Archive not found for this room.')(
+          new Error('Archive not found for this room.')
+        );
+        res.status(notFoundError.statusCode).json(notFoundError.exportSafely());
         return;
       }
 
@@ -145,7 +149,10 @@ sessionRouter.post(
       const storedCaptionsId = await sessionService.getCaptionsId({ sessionId });
 
       if (!storedCaptionsId || storedCaptionsId !== captionsId) {
-        res.status(404).json({ message: 'Captions not found for this room.' });
+        const notFoundError = makeNotFoundErrorHandler('Captions not found for this room.')(
+          new Error('Captions not found for this room.')
+        );
+        res.status(notFoundError.statusCode).json(notFoundError.exportSafely());
         return;
       }
 

--- a/backend/routes/session.ts
+++ b/backend/routes/session.ts
@@ -62,6 +62,16 @@ sessionRouter.post(
       const { archiveId, room: roomName } = req.params;
       const sessionKey = await getSessionKeyFromRoomName({ roomName });
 
+      // Ensure the archive belongs to this room's session before stopping it — otherwise a
+      // caller who knows any room name could stop an archive from another room by its id.
+      const { items } = await videoClient.searchArchives({ sessionKey });
+      const archiveBelongsToRoom = items.some((archive) => archive.id === archiveId);
+
+      if (!archiveBelongsToRoom) {
+        res.status(404).json({ message: 'Archive not found for this room.' });
+        return;
+      }
+
       const archiveResponse = await videoClient.stopArchive({ sessionKey, archiveId });
 
       res.json({
@@ -129,6 +139,15 @@ sessionRouter.post(
       const { room: roomName, captionsId } = req.params;
       const sessionKey = await getSessionKeyFromRoomName({ roomName });
       const { sessionId } = videoClient.decodeSessionKey({ sessionKey });
+
+      // Only the captions actually associated with this room's session may be disabled —
+      // don't trust the captionsId from the URL (it could target another room's captions).
+      const storedCaptionsId = await sessionService.getCaptionsId({ sessionId });
+
+      if (!storedCaptionsId || storedCaptionsId !== captionsId) {
+        res.status(404).json({ message: 'Captions not found for this room.' });
+        return;
+      }
 
       const captionsUserCount = await sessionService.decrementCaptionsUserCount({ sessionKey });
 

--- a/backend/tests/session.test.ts
+++ b/backend/tests/session.test.ts
@@ -143,13 +143,25 @@ describe.each([['InMemorySessionStorage', new InMemorySessionStorage()]])(
           expect(res.statusCode).toEqual(404);
         });
 
-        it('returns a 502 when stopping an invalid archive in a room', async () => {
-          const archiveId = 'b8-c9-d10';
+        it('returns 404 when stopping an archive that does not belong to the room', async () => {
+          // 'b8-c9-d10' is not among the room's archives (searchArchives returns archive1/2),
+          // so the authorization check rejects it before ever calling stopArchive — otherwise
+          // any caller could stop another room's archive by id.
+          const foreignArchiveId = 'b8-c9-d10';
           const res = await request(server)
-            .post(`/session/${roomName}/${archiveId}/stopArchive`)
+            .post(`/session/${roomName}/${foreignArchiveId}/stopArchive`)
             .set('Content-Type', 'application/json')
             .set('Accept', 'application/json');
-          expect(res.statusCode).toEqual(502);
+          expect(res.statusCode).toEqual(404);
+        });
+
+        it('returns 200 when stopping an archive that belongs to the room', async () => {
+          const ownArchiveId = 'archive1'; // present in this session's searchArchives result
+          const res = await request(server)
+            .post(`/session/${roomName}/${ownArchiveId}/stopArchive`)
+            .set('Content-Type', 'application/json')
+            .set('Accept', 'application/json');
+          expect(res.statusCode).toEqual(200);
         });
       });
 
@@ -177,14 +189,16 @@ describe.each([['InMemorySessionStorage', new InMemorySessionStorage()]])(
           expect(res.statusCode).toEqual(404);
         });
 
-        it('returns a 502 when stopping an invalid caption in a room', async () => {
-          const invalidCaptionId = 'wrongCaptionId';
+        it('returns 404 when disabling captions that do not belong to the room', async () => {
+          // A captionsId that does not match this room's stored captionsId must be rejected
+          // before calling disableCaptions, so a caller can't disable another room's captions.
+          const foreignCaptionsId = 'wrongCaptionId';
           const res = await request(server)
-            .post(`/session/${roomName}/${invalidCaptionId}/disableCaptions`)
+            .post(`/session/${roomName}/${foreignCaptionsId}/disableCaptions`)
             .set('Content-Type', 'application/json')
             .set('Accept', 'application/json');
 
-          expect(res.statusCode).toEqual(502);
+          expect(res.statusCode).toEqual(404);
         });
 
         it('returns a 404 when stopping captions in a non-existent room', async () => {


### PR DESCRIPTION
## Summary

Fixes #583. `stopArchive` and `disableCaptions` took an `archiveId` / `captionsId` **straight from the URL** and passed it to the SDK with no check that the resource belongs to the room's session. Since archives/captions are application-wide, a caller who knows **any** room name could stop **another room's** archive, or disable another room's captions, by supplying a foreign id.

## Fix

- **`stopArchive`** — look up the room's archives via `searchArchives({ sessionKey })` and return `404` if the `archiveId` isn't one of them, before calling `stopArchive`.
- **`disableCaptions`** — return `404` unless the URL `captionsId` matches the session's **stored** `captionsId` (`getCaptionsId`), rather than trusting the URL value.

Both bind the privileged action to a resource the room actually owns.

## Scope notes

- **`startArchive` is intentionally left as-is** — it's already scoped to the room via `roomName → sessionKey` and takes no foreign id, so it has no cross-room abuse vector.
- **Per-user membership auth** (the issue's fix #1) is a separate **architectural** change: the reference app has no user-auth model — the room name *is* the credential — so proving "participant membership" is out of scope for a bug-fix PR. This PR closes the concrete cross-room *resource* abuse.
- Trade-off: `stopArchive` now makes one extra `searchArchives` call for the ownership check (acceptable for a privileged, infrequent operation).

## Testing

The two existing tests that asserted `502` for a foreign id were locking in the vulnerable pass-through; repurposed them as authorization tests (`404`), and added a positive "archive belongs to the room → 200" case. They fail on `develop` (foreign id reaches the SDK) and pass with the fix.

- Full suite green (`yarn test`); `yarn quality-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)