### PR TITLE
VIDSOL-1044: perf: generate downscaled thumbnails for custom background uploads (#566)

### DIFF
--- a/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
+++ b/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
@@ -221,8 +221,8 @@ const useBackgroundPublisher = (
    * @returns {void}
    */
   const addCustomImage = useCallback(
-    (dataUrl: string) => {
-      addImageToStorage(dataUrl);
+    async (dataUrl: string) => {
+      await addImageToStorage(dataUrl);
       setCustomImages(getImagesFromStorage());
     },
     [getImagesFromStorage, addImageToStorage]
@@ -283,7 +283,9 @@ const useBackgroundPublisher = (
    */
   const handleAddCustomImage = useCallback(
     (dataUrl: string) => {
-      addCustomImage(dataUrl);
+      // Persist + refresh the gallery list in the background; the full-size image is applied
+      // immediately below so the effect is visible without waiting on thumbnail generation.
+      void addCustomImage(dataUrl);
       handleBackgroundChange(dataUrl);
     },
     [addCustomImage, handleBackgroundChange]

--- a/frontend/src/components/BackgroundEffects/BackgroundGallery/BackgroundGallery.spec.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundGallery/BackgroundGallery.spec.tsx
@@ -15,7 +15,12 @@ import { mediaDevices$ } from '@core/stores';
 const mockDevices = makeMediaDeviceInfos();
 
 const customImages = [
-  { id: 'custom1', dataUrl: 'data:image/png;base64,custom1' },
+  {
+    id: 'custom1',
+    dataUrl: 'data:image/png;base64,custom1',
+    thumbnailDataUrl: 'data:image/jpeg;base64,custom1-thumb',
+  },
+  // custom2 has no thumbnailDataUrl to represent an image stored by an earlier app version.
   { id: 'custom2', dataUrl: 'data:image/png;base64,custom2' },
 ];
 
@@ -95,6 +100,31 @@ describe('BackgroundGallery', () => {
       // /background/plane.jpg (~170KB), and defer offscreen loads.
       expect(previewImage?.getAttribute('src')).toBe('/background/thumbnails/plane.jpg');
       expect(previewImage?.getAttribute('loading')).toBe('lazy');
+    });
+  });
+
+  it('previews a custom image with its downscaled thumbnail, not the full-size upload', async () => {
+    render(<BackgroundGallery />);
+
+    await waitFor(() => {
+      const customOption = screen.getByTestId('background-custom1');
+      const previewImage = customOption.querySelector('img');
+
+      // The grid preview must render the small generated thumbnail, not the full-size
+      // uploaded image (which is only applied to the SDK when the background is selected).
+      expect(previewImage?.getAttribute('src')).toBe('data:image/jpeg;base64,custom1-thumb');
+      expect(previewImage?.getAttribute('loading')).toBe('lazy');
+    });
+  });
+
+  it('falls back to the full image for custom images stored without a thumbnail', async () => {
+    render(<BackgroundGallery />);
+
+    await waitFor(() => {
+      const customOption = screen.getByTestId('background-custom2');
+      const previewImage = customOption.querySelector('img');
+
+      expect(previewImage?.getAttribute('src')).toBe('data:image/png;base64,custom2');
     });
   });
 

--- a/frontend/src/components/BackgroundEffects/BackgroundGallery/BackgroundGallery.tsx
+++ b/frontend/src/components/BackgroundEffects/BackgroundGallery/BackgroundGallery.tsx
@@ -37,8 +37,11 @@ const BackgroundGallery = (): ReactElement => {
 
   return (
     <>
-      {customImages.map(({ id, dataUrl }) => {
+      {customImages.map(({ id, dataUrl, thumbnailDataUrl }) => {
         const isSelected = backgroundSelected === dataUrl;
+        // Preview the lightweight thumbnail; fall back to the full image for entries stored by
+        // earlier app versions. Selection below still applies the full-size dataUrl via the SDK.
+        const previewImage = thumbnailDataUrl ?? dataUrl;
         return (
           <Box
             key={id}
@@ -52,7 +55,7 @@ const BackgroundGallery = (): ReactElement => {
               title={t('backgroundEffects.yourBackground')}
               isSelected={isSelected}
               onClick={() => handleBackgroundChange(dataUrl)}
-              image={dataUrl}
+              image={previewImage}
             >
               <Tooltip
                 title={

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -135,6 +135,19 @@ export const BACKGROUNDS_PATH = '/background';
 export const BACKGROUND_THUMBNAILS_PATH = '/background/thumbnails';
 
 /**
+ * @constant {number} BACKGROUND_THUMBNAIL_MAX_DIMENSION - The maximum length (in pixels) of the
+ * longest side when generating a downscaled preview for a user-uploaded custom background.
+ * Mirrors the 400px used for the built-in preset thumbnails so custom and preset previews match.
+ */
+export const BACKGROUND_THUMBNAIL_MAX_DIMENSION = 400;
+
+/**
+ * @constant {number} BACKGROUND_THUMBNAIL_QUALITY - The JPEG quality (0-1) used when encoding a
+ * downscaled custom-background thumbnail. 0.8 keeps previews visually crisp while staying small.
+ */
+export const BACKGROUND_THUMBNAIL_QUALITY = 0.8;
+
+/**
  * @constant {number} MAX_SIZE_MB - The maximum file size (in megabytes) allowed for image uploads.
  * Used to validate image uploads in components like AddBackgroundEffectLayout.
  */

--- a/frontend/src/utils/createImageThumbnail/createImageThumbnail.spec.ts
+++ b/frontend/src/utils/createImageThumbnail/createImageThumbnail.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import createImageThumbnail from './createImageThumbnail';
+
+const originalImage = global.Image;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  global.Image = originalImage;
+});
+
+/**
+ * Replaces the global Image with a stub that resolves onload/onerror on the next microtask,
+ * since jsdom does not actually decode data URLs.
+ */
+function stubImage({
+  width,
+  height,
+  fail = false,
+}: {
+  width: number;
+  height: number;
+  fail?: boolean;
+}) {
+  class FakeImage {
+    onload: (() => void) | null = null;
+
+    onerror: (() => void) | null = null;
+
+    width = width;
+
+    height = height;
+
+    set src(_value: string) {
+      queueMicrotask(() => (fail ? this.onerror?.() : this.onload?.()));
+    }
+  }
+
+  global.Image = FakeImage as unknown as typeof Image;
+}
+
+describe('createImageThumbnail', () => {
+  it('returns the original data URL when no canvas 2d context is available', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    const source = 'data:image/png;base64,original';
+
+    await expect(createImageThumbnail(source)).resolves.toBe(source);
+  });
+
+  it('downscales a large image to the max dimension, preserving aspect ratio', async () => {
+    const drawImage = vi.fn();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage,
+    } as unknown as CanvasRenderingContext2D);
+    const toDataURL = vi
+      .spyOn(HTMLCanvasElement.prototype, 'toDataURL')
+      .mockReturnValue('data:image/jpeg;base64,thumb');
+    stubImage({ width: 1600, height: 900 });
+
+    const result = await createImageThumbnail('data:image/png;base64,original');
+
+    expect(result).toBe('data:image/jpeg;base64,thumb');
+    // 1600x900 clamped so the longest side is 400 -> 400x225 (aspect preserved).
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 400, 225);
+    expect(toDataURL).toHaveBeenCalledWith('image/jpeg', 0.8);
+  });
+
+  it('does not upscale images already smaller than the max dimension', async () => {
+    const drawImage = vi.fn();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage,
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
+      'data:image/jpeg;base64,thumb'
+    );
+    stubImage({ width: 120, height: 80 });
+
+    await createImageThumbnail('data:image/png;base64,original');
+
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 120, 80);
+  });
+
+  it('returns the original data URL when the image fails to decode', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    stubImage({ width: 10, height: 10, fail: true });
+    const source = 'data:image/png;base64,broken';
+
+    await expect(createImageThumbnail(source)).resolves.toBe(source);
+  });
+});

--- a/frontend/src/utils/createImageThumbnail/createImageThumbnail.ts
+++ b/frontend/src/utils/createImageThumbnail/createImageThumbnail.ts
@@ -1,0 +1,59 @@
+import { BACKGROUND_THUMBNAIL_MAX_DIMENSION, BACKGROUND_THUMBNAIL_QUALITY } from '../constants';
+
+/**
+ * Creates a small downscaled thumbnail from an image data URL, preserving the aspect ratio (no
+ * cropping).
+ *
+ * Used to render lightweight previews in the background gallery instead of decoding the full-size
+ * uploaded image into a ~68px tile. The full-size image is still kept for applying the background.
+ *
+ * This never rejects: on any failure (no canvas support such as jsdom in tests, a decode error, or
+ * an encode error) it resolves with the original `dataUrl`, so uploading a custom background can
+ * never be broken by thumbnail generation.
+ * @param {string} dataUrl - The source image data URL.
+ * @returns {Promise<string>} A downscaled JPEG thumbnail data URL, or the original on failure.
+ */
+const createImageThumbnail = (dataUrl: string): Promise<string> => {
+  return new Promise((resolve) => {
+    const canvas = document.createElement('canvas');
+    const context = (() => {
+      try {
+        return canvas.getContext('2d');
+      } catch {
+        return null;
+      }
+    })();
+
+    // Environments without canvas support (e.g. jsdom under test) — keep the original image.
+    if (!context) {
+      resolve(dataUrl);
+      return;
+    }
+
+    const image = new Image();
+
+    image.onload = () => {
+      try {
+        const longestSide = Math.max(image.width, image.height);
+        const scale =
+          longestSide > BACKGROUND_THUMBNAIL_MAX_DIMENSION
+            ? BACKGROUND_THUMBNAIL_MAX_DIMENSION / longestSide
+            : 1;
+
+        canvas.width = Math.round(image.width * scale);
+        canvas.height = Math.round(image.height * scale);
+        context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+        const thumbnailDataUrl = canvas.toDataURL('image/jpeg', BACKGROUND_THUMBNAIL_QUALITY);
+        resolve(thumbnailDataUrl.startsWith('data:image') ? thumbnailDataUrl : dataUrl);
+      } catch {
+        resolve(dataUrl);
+      }
+    };
+
+    image.onerror = () => resolve(dataUrl);
+    image.src = dataUrl;
+  });
+};
+
+export default createImageThumbnail;

--- a/frontend/src/utils/useImageStorage/useImageStorage.ts
+++ b/frontend/src/utils/useImageStorage/useImageStorage.ts
@@ -2,10 +2,16 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getStorageItem, setStorageItem, STORAGE_KEYS } from '../storage';
 import { MAX_LOCAL_STORAGE_BYTES } from '../constants';
+import createImageThumbnail from '../createImageThumbnail/createImageThumbnail';
 
 export type StoredImage = {
   id: string;
   dataUrl: string;
+  /**
+   * Downscaled preview used for gallery thumbnails. Optional because images persisted by earlier
+   * app versions predate this field; readers fall back to `dataUrl` when it is absent.
+   */
+  thumbnailDataUrl?: string;
 };
 
 /**
@@ -42,7 +48,11 @@ const useImageStorage = () => {
    */
   const saveImagesToStorage = (images: StoredImage[]): boolean => {
     try {
-      const totalSize = images.reduce((acc, img) => acc + estimateSizeInBytes(img.dataUrl), 0);
+      const totalSize = images.reduce(
+        (acc, img) =>
+          acc + estimateSizeInBytes(img.dataUrl) + estimateSizeInBytes(img.thumbnailDataUrl ?? ''),
+        0
+      );
       if (totalSize > MAX_LOCAL_STORAGE_BYTES) {
         setStorageError(t('imageStorage.imagesExceedSize'));
         return false;
@@ -57,11 +67,11 @@ const useImageStorage = () => {
   };
 
   /**
-   * Adds an image to storage.
+   * Adds an image to storage, generating a downscaled preview thumbnail alongside the full image.
    * @param {string} dataUrl - The data URL of the image to add.
-   * @returns {StoredImage | null} The added image object, or null if duplicate or error.
+   * @returns {Promise<StoredImage | null>} The added image object, or null if duplicate or error.
    */
-  const addImageToStorage = (dataUrl: string): StoredImage | null => {
+  const addImageToStorage = async (dataUrl: string): Promise<StoredImage | null> => {
     const images = getImagesFromStorage();
 
     const isDuplicate = images.some((img) => img.dataUrl === dataUrl);
@@ -80,9 +90,12 @@ const useImageStorage = () => {
       return Array.from(array, (n) => n.toString(16)).join('');
     };
 
+    const thumbnailDataUrl = await createImageThumbnail(dataUrl);
+
     const newImage: StoredImage = {
       id: generateId(),
       dataUrl,
+      thumbnailDataUrl,
     };
     images.push(newImage);
     const success = saveImagesToStorage(images);
@@ -102,9 +115,9 @@ const useImageStorage = () => {
   const handleImageFromFile = (file: File): Promise<StoredImage | null> => {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
-      reader.onload = () => {
+      reader.onload = async () => {
         const dataUrl = reader.result as string;
-        const newImage = addImageToStorage(dataUrl);
+        const newImage = await addImageToStorage(dataUrl);
         if (newImage) {
           resolve(newImage);
         } else {
@@ -142,7 +155,7 @@ const useImageStorage = () => {
 
       const img = new Image();
       img.crossOrigin = 'Anonymous';
-      img.onload = () => {
+      img.onload = async () => {
         try {
           const canvas = document.createElement('canvas');
           canvas.width = img.width;
@@ -150,7 +163,7 @@ const useImageStorage = () => {
           const ctx = canvas.getContext('2d');
           ctx?.drawImage(img, 0, 0);
           const dataUrl = canvas.toDataURL('image/png');
-          const newImage = addImageToStorage(dataUrl);
+          const newImage = await addImageToStorage(dataUrl);
           if (newImage) {
             resolve(newImage);
           } else {


### PR DESCRIPTION
## Summary

Follow-up to #696 (stacked on it). That PR shrank the **8 built-in preset** previews; this one covers **user-uploaded custom backgrounds**, which have the same problem: they're stored and rendered as **full-resolution** data URLs (up to `MAX_SIZE_MB`; the paste-link path even re-encodes to PNG, often *larger* than the source) and then decoded into ~68px preview tiles.

Since there's no build-time asset for a user upload, the thumbnail is generated **client-side at upload**.

## Change (logic/plumbing only — no visual change)

- **`createImageThumbnail`** (new util): canvas downscale to a **400px max long-side, aspect ratio preserved (no cropping)**, JPEG q0.8 — mirrors the preset thumbnails so custom and preset previews match. It **never rejects**: on any failure (no canvas support such as jsdom in tests, decode/encode error) it resolves with the original data URL, so uploading can never be broken by thumbnail generation.
- **`StoredImage`** gains an optional `thumbnailDataUrl` (optional for backward-compat: images persisted by earlier app versions predate the field). `addImageToStorage` now generates it, and the `localStorage` quota check counts it.
- **`BackgroundGallery`** previews `thumbnailDataUrl ?? dataUrl`; **selection still applies the full-size `dataUrl`** via the SDK. `loading="lazy"` (from #696) already covers these tiles.

`objectFit: cover` and all styling are **untouched** — this is storage/plumbing only.

> Note: this does not reduce `localStorage` (the full image is still stored — the SDK needs full resolution when a background is applied); the thumbnail is small additional bytes. The win is the same as #696 — the gallery stops decoding full-size images into tiny tiles (render memory + decode + layout).

## Testing

Test-first:
- `BackgroundGallery.spec` asserts the custom preview renders the generated thumbnail (**fails on base**, which uses the full data URL) and **falls back** to the full image for legacy entries stored without a thumbnail.
- `createImageThumbnail.spec` covers downscale-with-aspect, no-upscale, and both fallback paths (no-canvas, decode failure).

Full suite green (`yarn test`); `yarn quality-check` clean.

> Stacked on #696 — review/merge that first; base will retarget to `develop` once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)