### PR TITLE
VIDSOL-1042: perf(session): stop replacing subscriberWrappers on every emoji (#565)

### DIFF
--- a/frontend/src/Context/SessionProvider/session.spec.tsx
+++ b/frontend/src/Context/SessionProvider/session.spec.tsx
@@ -6,7 +6,7 @@ import { Publisher, Stream } from '@vonage/client-sdk-video';
 import useSessionContext from '@hooks/useSessionContext';
 import ActiveSpeakerTracker from '@utils/ActiveSpeakerTracker';
 import VonageVideoClient from '@utils/VonageVideoClient';
-import { StreamPropertyChangedEvent, SubscriberWrapper } from '@app-types/session';
+import { SignalEvent, StreamPropertyChangedEvent, SubscriberWrapper } from '@app-types/session';
 import { makeTestProvider, ProviderOptions, providers } from '@test/providers';
 import type { VideoClient } from '@core/services';
 
@@ -17,6 +17,7 @@ vi.mock('@utils/VonageVideoClient');
 vi.mock('@utils/constants', () => ({
   MAX_PIN_COUNT_MOBILE: 1,
   MAX_PIN_COUNT_DESKTOP: 1,
+  EMOJI_DISPLAY_DURATION: 5000,
 }));
 
 vi.mock('@api/fetchCredentials');
@@ -29,6 +30,10 @@ const mockVideoClient = {
 // A valid fake JWT containing sessionId: '1_MX4xMjM0NTY3OH4-VGh1IEZlYiAyNyAwODozMjozNCBQU1QgMjAyMH4wLjI0NDYxMjE'
 const validSessionKey =
   'eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOiIxX01YNHhNak0wTlRZM09INC1WR2gxSUVabFlpQXlOeUF3T0Rvek1qb3pOQ0JRVTFRZ01qQXlNSDR3TGpJME5EWXhNakUiLCJyb29tTmFtZSI6IlRlc3RDb21wb25lbnRSb29tIn0.fakesig';
+
+// Records each distinct subscriberWrappers array reference the context exposes, so tests can
+// assert whether an update replaced the array (new reference) or bailed out (same reference).
+const subscriberWrappersRefHistory: SubscriberWrapper[][] = [];
 
 describe('SessionProvider', () => {
   let activeSpeakerTracker: ActiveSpeakerTracker;
@@ -49,6 +54,7 @@ describe('SessionProvider', () => {
       pinSubscriber,
       isMaxPinned,
       lastStreamUpdate,
+      emojiQueue,
     } = useSessionContext();
 
     useEffect(() => {
@@ -56,6 +62,10 @@ describe('SessionProvider', () => {
         void joinRoom({ sessionKey: validSessionKey });
       }
     }, [joinRoom]);
+
+    useEffect(() => {
+      subscriberWrappersRefHistory.push(subscriberWrappers);
+    }, [subscriberWrappers]);
 
     return (
       <div>
@@ -122,6 +132,7 @@ describe('SessionProvider', () => {
         <span data-testid="reconnecting">{String(reconnecting)}</span>
         <span data-testid="archiveId">{String(archiveId)}</span>
         <span data-testid="isMaxPinned">{String(isMaxPinned)}</span>
+        <span data-testid="emojiCount">{emojiQueue.length}</span>
         <span data-testid="streamPropertyChanged">
           {lastStreamUpdate ? JSON.stringify(lastStreamUpdate) : 'No updates'}
         </span>
@@ -130,6 +141,8 @@ describe('SessionProvider', () => {
   };
 
   beforeEach(() => {
+    subscriberWrappersRefHistory.length = 0;
+
     activeSpeakerTracker = Object.assign(new EventEmitter(), {
       onSubscriberDestroyed: vi.fn(),
       onSubscriberAudioLevelUpdated: vi.fn(),
@@ -275,6 +288,41 @@ describe('SessionProvider', () => {
         expect(getByTestId('subscriberWrappers')).toHaveTextContent('sub2');
         expect(getByTestId('subscriberWrappers').children.length).toBe(2);
       });
+    });
+
+    it('does not replace the subscriberWrappers array when an emoji signal is received', async () => {
+      const { getByTestId } = await renderAndWaitForConnection();
+
+      act(() => {
+        vonageVideoClient.emit('subscriberVideoElementCreated', {
+          id: 'sub1',
+          isScreenshare: false,
+          subscriber: {
+            stream: { connection: { connectionId: 'sub1-connection' }, name: 'Sub One' },
+          },
+        } as unknown as SubscriberWrapper);
+      });
+      await waitFor(() => expect(getByTestId('subscriberWrappers')).toHaveTextContent('sub1'));
+
+      const wrappersBeforeEmoji = subscriberWrappersRefHistory.at(-1);
+      const emojiCountBefore = Number(getByTestId('emojiCount').textContent);
+
+      act(() => {
+        vonageVideoClient.emit('signal:emoji', {
+          type: 'signal:emoji',
+          data: JSON.stringify({ emoji: '👍', time: 1 }),
+          from: { connectionId: 'remote-connection' },
+        } as unknown as SignalEvent);
+      });
+
+      // The emoji is processed (added to the queue)...
+      await waitFor(() =>
+        expect(Number(getByTestId('emojiCount').textContent)).toBe(emojiCountBefore + 1)
+      );
+
+      // ...but the subscriberWrappers reference must be unchanged. Returning a fresh array copy
+      // would re-render the whole session context and every video tile on every emoji received.
+      expect(subscriberWrappersRefHistory.at(-1)).toBe(wrappersBeforeEmoji);
     });
 
     it('removing a subscriber should remove it from the subscriberWrappers', async () => {

--- a/frontend/src/Context/SessionProvider/session.tsx
+++ b/frontend/src/Context/SessionProvider/session.tsx
@@ -244,12 +244,18 @@ const SessionProvider = ({
     }
   };
 
+  // Mirror the latest subscriberWrappers into a ref so the emoji signal handler (registered once
+  // as a session listener) can read them without a stale closure. Previously handleEmoji abused
+  // setSubscriberWrappers to read current state and returned a fresh array copy, which re-rendered
+  // the whole session context and every video tile on every emoji received.
+  const subscriberWrappersRef = useRef(subscriberWrappers);
+  useEffect(() => {
+    subscriberWrappersRef.current = subscriberWrappers;
+  }, [subscriberWrappers]);
+
   const handleEmoji = useCallback(
     (emojiEvent: SignalEvent) => {
-      setSubscriberWrappers((currentSubscriberWrappers) => {
-        onEmoji(emojiEvent, currentSubscriberWrappers);
-        return [...currentSubscriberWrappers]; // Return unchanged state
-      });
+      onEmoji(emojiEvent, subscriberWrappersRef.current);
     },
     [onEmoji]
   );


### PR DESCRIPTION
## Summary

Fixes #565. `handleEmoji` abused `setSubscriberWrappers` purely to **read** the current `subscriberWrappers`, then returned `[...currentSubscriberWrappers]` — a fresh array with identical contents. That new reference made React treat the state as changed on **every emoji received**, re-rendering the whole `SessionProvider` context and every video tile. It also ran `onEmoji` (a side effect) inside the state updater, which React may re-invoke.

## Fix

Read the latest wrappers from a ref and call `onEmoji` directly — no `setSubscriberWrappers`, so no re-render and no side effect inside a reducer:

```diff
+  const subscriberWrappersRef = useRef(subscriberWrappers);
+  useEffect(() => {
+    subscriberWrappersRef.current = subscriberWrappers;
+  }, [subscriberWrappers]);
+
   const handleEmoji = useCallback(
     (emojiEvent: SignalEvent) => {
-      setSubscriberWrappers((currentSubscriberWrappers) => {
-        onEmoji(emojiEvent, currentSubscriberWrappers);
-        return [...currentSubscriberWrappers]; // Return unchanged state
-      });
+      onEmoji(emojiEvent, subscriberWrappersRef.current);
     },
     [onEmoji]
   );
```

The ref-mirror mirrors the file's existing `activeSpeakerIdRef` precedent (a listener registered once needs the latest state without a stale closure). No UI/visual change.

## Testing

Test-first: `session.spec` asserts that receiving an emoji signal is processed (the emoji queue grows) **without** changing the `subscriberWrappers` reference — **fails on develop** (`expected […] to be […] // Object.is` — same contents, new array) and passes with the fix.

- Full suite green (`yarn test`); `yarn quality-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)