### PR TITLE
VIDSOL-1112: fix(publisher): surface publishing errors after a sustained transient state, not just once

### DIFF
--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.spec.tsx
@@ -1,6 +1,6 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { act, renderHook as renderHookBase, waitFor } from '@testing-library/react';
-import {
+import OT, {
   initPublisher,
   Publisher,
   Stream,
@@ -389,6 +389,59 @@ describe('usePublisher', () => {
       });
 
       expect(mockedSessionPublish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('OT exception handling (sustained network/session failures)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('surfaces a blocking error after repeated 1500 failures even while the session never fully reconnects', () => {
+      vi.useFakeTimers();
+      mockedInitPublisher.mockReturnValue(mockPublisher);
+
+      // The session stays disconnected throughout, exactly like the real incident where the
+      // signaling connection dropped and never recovered ("connected" never becomes true again).
+      const { result } = renderHook(() => usePublisher(), {
+        sessionContext: {
+          __interceptor: (ctx) => {
+            if (ctx) {
+              ctx.connected = false;
+            }
+          },
+        },
+      });
+
+      act(() => {
+        result.current.initializeLocalPublisher({});
+      });
+
+      const exceptionHandler = vi
+        .mocked(OT.on)
+        .mock.calls.find(([event]) => event === 'exception')?.[1] as (event: {
+        code: number;
+      }) => void;
+      expect(exceptionHandler).toBeDefined();
+
+      expect(result.current.publishingError).toBeNull();
+
+      // 3 failures spanning past the grace period, mirroring the real incident's ~76s span.
+      act(() => {
+        exceptionHandler({ code: 1500 });
+      });
+      act(() => {
+        vi.advanceTimersByTime(51_000);
+        exceptionHandler({ code: 1500 });
+      });
+      act(() => {
+        vi.advanceTimersByTime(25_000);
+        exceptionHandler({ code: 1500 });
+      });
+
+      // Even though the session never stopped looking "transient" (still disconnected), the
+      // user must eventually be told rather than left stuck silently and indefinitely.
+      expect(result.current.publishingError).not.toBeNull();
     });
   });
 

--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
@@ -31,6 +31,14 @@ type DeviceAccessStatus = {
   camera: boolean | undefined;
 };
 
+/**
+ * How long (in ms) a sustained streak of publish failures is tolerated while the session appears
+ * "transient" (reconnecting/disconnected/offline) before surfacing a blocking error to the user
+ * regardless. A real incident showed 3 consecutive `Unable to Publish (1500)` failures spanning
+ * ~76s while the session never fully reconnected — see #usePublisher exceptionHandler.
+ */
+const PUBLISHING_TRANSIENT_FAILURE_GRACE_PERIOD_MS = 45_000;
+
 export type PublishingErrorType = {
   header: string;
   caption: string;
@@ -128,6 +136,7 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
   const isInitializingPublisherRef = useRef<boolean>(false);
   const reconnectingRef = useRef<boolean>(false);
   const consecutivePublishingFailureCountRef = useRef<number>(0);
+  const firstPublishingFailureAtRef = useRef<number | null>(null);
 
   const {
     publish: sessionPublish,
@@ -202,6 +211,7 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
 
     // Successful publish resets transient failure tracking
     consecutivePublishingFailureCountRef.current = 0;
+    firstPublishingFailureAtRef.current = null;
     setPublishingError(null);
   }, []);
 
@@ -440,6 +450,10 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
         frontendLogger.log('usePublisher: exception 1500', { code: exceptionEvent.code });
         consecutivePublishingFailureCountRef.current += 1;
 
+        if (firstPublishingFailureAtRef.current === null) {
+          firstPublishingFailureAtRef.current = Date.now();
+        }
+
         const isBrowserOnline = (() => {
           if (typeof navigator === 'undefined') return true;
           return navigator.onLine;
@@ -448,6 +462,16 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
         // During network changes, code 1500 is often transient.
         // Try to recover by recreating the publisher; only surface a blocking error after repeated failures.
         const shouldTreatAsTransient = reconnectingRef.current || !connected || !isBrowserOnline;
+
+        // A "transient" state (reconnecting/disconnected/offline) that never resolves is not
+        // actually transient. Without this, a sustained network/session outage can keep
+        // shouldTreatAsTransient true forever, permanently suppressing handlePublishingError and
+        // leaving the user stuck: publishing silently, indefinitely, with no error and no redirect
+        // to the goodbye page. If failures have kept occurring past the grace period, surface the
+        // error regardless of the transient state.
+        const failureDurationMs = Date.now() - firstPublishingFailureAtRef.current;
+        const hasExceededTransientGracePeriod =
+          failureDurationMs >= PUBLISHING_TRANSIENT_FAILURE_GRACE_PERIOD_MS;
 
         const publisherToCleanup = publisherRef.current;
         publisherRef.current = null;
@@ -464,7 +488,8 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
         setStream(null);
 
         const shouldSurfaceBlockingError =
-          shouldTreatAsTransient === false && consecutivePublishingFailureCountRef.current >= 3;
+          consecutivePublishingFailureCountRef.current >= 3 &&
+          (shouldTreatAsTransient === false || hasExceededTransientGracePeriod);
 
         if (shouldSurfaceBlockingError) {
           handlePublishingError();

--- a/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisher/usePublisher.tsx
@@ -450,9 +450,7 @@ const usePublisher = (initialValue: PublisherContextInitialValue = {}): Publishe
         frontendLogger.log('usePublisher: exception 1500', { code: exceptionEvent.code });
         consecutivePublishingFailureCountRef.current += 1;
 
-        if (firstPublishingFailureAtRef.current === null) {
-          firstPublishingFailureAtRef.current = Date.now();
-        }
+        firstPublishingFailureAtRef.current ??= Date.now();
 
         const isBrowserOnline = (() => {
           if (typeof navigator === 'undefined') return true;


### PR DESCRIPTION
## Summary

Fixes #713 — filed from a real production incident. A user reported joining a meeting and being unable to be seen or heard, while he could see and hear everyone else. Client console/network logs from the incident show:

```
OT.exception :: title: Unable to Publish (1500) msg: ICEWorkflow   (×3, at +0ms / +51s / +25s)
OpenTok:RaptorSocket:error cannot publish until the socket is connected.
Subscriber with stream ID ... destroyed   (×6, in a burst)
```

The root network cause (his network blocked the WebRTC publish path while subscribe worked) isn't fixable in application code. But the app already has a safety net designed for exactly this — after 3 consecutive non-transient `1500` failures, `usePublisher` sets `publishingError`, which redirects the user to `/goodbye` rather than leaving them stuck. The incident exposed a gap in it.

## Root cause

```ts
const shouldTreatAsTransient = reconnectingRef.current || !connected || !isBrowserOnline;
...
const shouldSurfaceBlockingError =
  shouldTreatAsTransient === false && consecutivePublishingFailureCountRef.current >= 3;
```

`shouldTreatAsTransient` treats **any** reconnecting/disconnected/offline state as an indefinite free pass, assuming it will self-heal. The incident's log shows a burst of 6 subscribers destroyed right around the 3rd failure — evidence the signaling connection (`connected`) dropped at that exact moment. If `connected` is `false` when the 3rd exception lands, the redirect is suppressed — and since no further `1500` exception fires once retries stop, **the safety net never re-evaluates**. The user is left stuck indefinitely: publishing silently broken, no error, no redirect.

## Fix

Track how long a failure streak has persisted (`firstPublishingFailureAtRef`, reset on a successful publish). If failures keep occurring past a 45s grace period even while nominally "transient," surface the error anyway — a transient outage that never resolves is not actually transient:

```diff
+ const failureDurationMs = Date.now() - firstPublishingFailureAtRef.current;
+ const hasExceededTransientGracePeriod =
+   failureDurationMs >= PUBLISHING_TRANSIENT_FAILURE_GRACE_PERIOD_MS;

  const shouldSurfaceBlockingError =
-   shouldTreatAsTransient === false && consecutivePublishingFailureCountRef.current >= 3;
+   consecutivePublishingFailureCountRef.current >= 3 &&
+   (shouldTreatAsTransient === false || hasExceededTransientGracePeriod);
```

## Testing

Test-first: reproduces the incident's **exact timing** (3 `1500` failures at 0s/+51s/+25s while `connected` stays `false` throughout) — `publishingError` stays `null` forever on unpatched `develop`, is set once the grace period is exceeded with the fix.

- Full suite green (`yarn test`, 193 files / 972 tests); `yarn quality-check` clean.
- Rebased onto latest `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)