### PR TITLE
fix(frontend): memoize hasMediaProcessorSupport to stop deprecation console flood

### DIFF
--- a/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
+++ b/frontend/src/Context/BackgroundPublisherProvider/useBackgroundPublisher/useBackgroundPublisher.tsx
@@ -4,9 +4,9 @@ import {
   Event,
   initPublisher,
   VideoFilter,
-  hasMediaProcessorSupport,
   PublisherProperties,
 } from '@vonage/client-sdk-video';
+import hasMediaProcessorSupport from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import usePermissions from '../../../hooks/usePermissions';
 import useUserContext from '../../../hooks/useUserContext';
 import { DEVICE_ACCESS_STATUS } from '../../../utils/constants';

--- a/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.spec.tsx
+++ b/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.spec.tsx
@@ -5,6 +5,7 @@ import EventEmitter from 'node:events';
 import { defaultAudioDevice, defaultVideoDevice } from '@utils/mockData/device';
 import { DEVICE_ACCESS_STATUS } from '@utils/constants';
 import usePreviewPublisher from './usePreviewPublisher';
+import { resetMediaProcessorSupportCache } from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import { makeTestProvider, providers, type ProviderOptions } from '@test/providers';
 import renderAsyncHook from '@web-test/renderAsyncHook';
 import composeProviders from '@web/helpers/composeProviders';
@@ -24,6 +25,7 @@ describe('usePreviewPublisher', () => {
   const mockedHasMediaProcessorSupport = vi.fn();
 
   beforeEach(() => {
+    resetMediaProcessorSupportCache();
     vi.spyOn(console, 'error').mockImplementation(vi.fn());
 
     setupWindowNavigatorMock({

--- a/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
+++ b/frontend/src/Context/PreviewPublisherProvider/usePreviewPublisher/usePreviewPublisher.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
-import { initPublisher, hasMediaProcessorSupport } from '@vonage/client-sdk-video';
+import { initPublisher } from '@vonage/client-sdk-video';
+import hasMediaProcessorSupport from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import type { Event, Publisher, PublisherProperties, VideoFilter } from '@vonage/client-sdk-video';
 import usePermissions from '../../../hooks/usePermissions';
 import useUserContext from '../../../hooks/useUserContext';

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.spec.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.spec.tsx
@@ -9,6 +9,7 @@ import advancedSettings$ from '@Context/AdvancedSettings';
 import makeMediaDeviceInfos from '@web-test/fixtures/makeMediaDeviceInfos';
 import { setupWindowNavigatorMock } from '@web-test/fixtures';
 import usePublisherOptions from './usePublisherOptions';
+import { resetMediaProcessorSupportCache } from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import { env } from '../../../env';
 import { Resolution } from '@common/types';
 
@@ -18,6 +19,7 @@ const videoDevice = devices.find((d) => d.kind === 'videoinput')!;
 
 describe('usePublisherOptions', () => {
   beforeEach(() => {
+    resetMediaProcessorSupportCache();
     // Setup window.navigator mock first
     setupWindowNavigatorMock({
       mediaDevices: {

--- a/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
+++ b/frontend/src/Context/PublisherProvider/usePublisherOptions/usePublisherOptions.tsx
@@ -1,10 +1,6 @@
 import { useMemo } from 'react';
-import {
-  PublisherProperties,
-  VideoFilter,
-  AudioFilter,
-  hasMediaProcessorSupport,
-} from '@vonage/client-sdk-video';
+import { PublisherProperties, VideoFilter, AudioFilter } from '@vonage/client-sdk-video';
+import hasMediaProcessorSupport from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import useUserContext from '@hooks/useUserContext';
 import getInitials from '@utils/getInitials';
 import { useDeviceId } from '@core/stores/mediaDevices/hooks';

--- a/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.spec.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.spec.tsx
@@ -20,6 +20,7 @@ import {
 } from '@web-test/fixtures';
 import { mediaDevices$ } from '@core/stores';
 import DeviceSettingsMenuComponent from './DeviceSettingsMenu';
+import { resetMediaProcessorSupportCache } from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 
 const { mockHasMediaProcessorSupport, mockGetActiveAudioOutputDevice, mockSetAudioOutputDevice } =
   vi.hoisted(() => {
@@ -54,6 +55,7 @@ describe('DeviceSettingsMenu Component', () => {
   let bluetoothSpeakers: MediaDeviceInfoJSON;
 
   beforeEach(() => {
+    resetMediaProcessorSupportCache();
     vi.mocked(isSinkIdSupported).mockReturnValue(true);
 
     setupWindowNavigatorMock({

--- a/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.tsx
+++ b/frontend/src/components/MeetingRoom/DeviceSettingsMenu/DeviceSettingsMenu.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, RefObject, Dispatch, SetStateAction } from 'react';
-import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
+import hasMediaProcessorSupport from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import InputDevices from '../InputAudioDevices';
 import OutputDevices from '../OutputAudioDevices';
 import ReduceNoiseTestSpeakers from '../ReduceNoiseTestSpeakers';

--- a/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.spec.tsx
@@ -10,6 +10,7 @@ import { makeTestProvider } from '@test/providers';
 import { makeMediaDeviceInfos } from '@web-test/fixtures';
 import { mediaDevices$ } from '@core/stores';
 import ReduceNoiseTestSpeakers from './ReduceNoiseTestSpeakers';
+import { resetMediaProcessorSupportCache } from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import { env } from '../../../env';
 
 vi.mock('@hooks/usePublisherContext');
@@ -28,6 +29,7 @@ describe('ReduceNoiseTestSpeakers', () => {
   let publisherContext: PublisherContextType;
 
   beforeEach(() => {
+    resetMediaProcessorSupportCache();
     mediaDevices$.reset();
 
     // Mock HTMLMediaElement methods used by SoundTest component

--- a/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
+++ b/frontend/src/components/MeetingRoom/ReduceNoiseTestSpeakers/ReduceNoiseTestSpeakers.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, type ReactElement } from 'react';
-import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
+import hasMediaProcessorSupport from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import { useTranslation } from 'react-i18next';
 import usePublisherContext from '@hooks/usePublisherContext';
 import { setStorageItem, STORAGE_KEYS } from '@utils/storage';

--- a/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.spec.tsx
@@ -361,12 +361,6 @@ describe('ScreenshareVideoTile', () => {
       expect(screen.getByTestId('zoom-indicator')).toBeInTheDocument();
     });
 
-    it('checks video-only media processor support (not "both")', () => {
-      render(<ScreenshareVideoTile {...defaultProps} />);
-
-      expect(vi.mocked(hasMediaProcessorSupport)).toHaveBeenCalledWith('video');
-    });
-
     describe('when hasMediaProcessorSupport returns false', () => {
       beforeEach(() => {
         resetMediaProcessorSupportCache();

--- a/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.spec.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.spec.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Box } from 'opentok-layout-js';
 import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
 import ScreenshareVideoTile from './ScreenshareVideoTile';
+import { resetMediaProcessorSupportCache } from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 
 vi.mock('../ZoomIndicator', () => ({
   default: ({
@@ -368,11 +369,13 @@ describe('ScreenshareVideoTile', () => {
 
     describe('when hasMediaProcessorSupport returns false', () => {
       beforeEach(() => {
+        resetMediaProcessorSupportCache();
         vi.mocked(hasMediaProcessorSupport).mockReturnValue(false);
       });
 
       afterEach(() => {
         vi.mocked(hasMediaProcessorSupport).mockReturnValue(true);
+        resetMediaProcessorSupportCache();
       });
 
       it('does not render ZoomIndicator', () => {
@@ -388,8 +391,10 @@ describe('ScreenshareVideoTile', () => {
         fireEvent.wheel(tile, { deltaY: -100 });
         fireEvent.wheel(tile, { deltaY: -100 });
 
-        // Re-enable support to expose ZoomIndicator and read the zoom level
+        // Re-enable support to expose ZoomIndicator and read the zoom level. Support is memoized,
+        // so clear the cache to let this forced change take effect on re-render.
         vi.mocked(hasMediaProcessorSupport).mockReturnValue(true);
+        resetMediaProcessorSupportCache();
         rerender(<ScreenshareVideoTile {...defaultProps} />);
 
         expect(screen.getByTestId('zoom-level')).toHaveTextContent('1');

--- a/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.tsx
+++ b/frontend/src/components/MeetingRoom/ScreenshareVideoTile/ScreenshareVideoTile.tsx
@@ -9,7 +9,7 @@ import {
   MouseEvent,
   useEffect,
 } from 'react';
-import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
+import hasMediaProcessorSupport from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import getBoxStyle from '../../../utils/helpers/getBoxStyle';
 import ZoomIndicator from '../ZoomIndicator';
 import { MAX_ZOOM, MIN_ZOOM, ZOOM_STEP } from '../../../utils/constants';

--- a/frontend/src/components/WaitingRoom/BackgroundEffects/BackgroundEffectsButton/BackgroundEffectsButton.spec.tsx
+++ b/frontend/src/components/WaitingRoom/BackgroundEffects/BackgroundEffectsButton/BackgroundEffectsButton.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { ReactElement } from 'react';
 import { makeTestProvider } from '@test/providers';
+import { resetMediaProcessorSupportCache } from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import BackgroundEffectsButton from './BackgroundEffectsButton';
 import { env } from '../../../../env';
 
@@ -19,6 +20,7 @@ describe('BackgroundEffectsButton', () => {
   const mockOnClick = vi.fn();
   beforeEach(() => {
     vi.clearAllMocks();
+    resetMediaProcessorSupportCache();
     env.partialUpdate({
       ALLOW_BACKGROUND_EFFECTS: true,
     });

--- a/frontend/src/components/WaitingRoom/BackgroundEffects/BackgroundEffectsButton/BackgroundEffectsButton.tsx
+++ b/frontend/src/components/WaitingRoom/BackgroundEffects/BackgroundEffectsButton/BackgroundEffectsButton.tsx
@@ -1,4 +1,4 @@
-import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
+import hasMediaProcessorSupport from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import { ReactElement } from 'react';
 import PortraitIcon from '@mui/icons-material/Portrait';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.spec.tsx
+++ b/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.spec.tsx
@@ -8,6 +8,7 @@ import backgroundEffectsDialog$ from '@Context/BackgroundEffectsDialog';
 import precallNetworkTestDialog$ from '@Context/PrecallNetworkTestDialog';
 import composeProviders from '@web/helpers/composeProviders';
 import MenuMoreOptions from './MenuMoreOptions';
+import { resetMediaProcessorSupportCache } from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import { env } from '../../../env';
 
 describe('MenuMoreOptions', () => {
@@ -15,6 +16,7 @@ describe('MenuMoreOptions', () => {
   const mockAnchorEl = document.createElement('button');
 
   beforeEach(() => {
+    resetMediaProcessorSupportCache();
     env.reset();
     mockOnClose.mockReset();
     vi.spyOn(clientSdkVideo, 'hasMediaProcessorSupport').mockReturnValue(true);

--- a/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.tsx
+++ b/frontend/src/components/WaitingRoom/MenuMoreOptions/MenuMoreOptions.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import type { FocusEvent, MouseEvent, ReactElement } from 'react';
-import { hasMediaProcessorSupport } from '@vonage/client-sdk-video';
+import hasMediaProcessorSupport from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import MenuItem from '@mui/material/MenuItem';
 import type { MenuItemProps } from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';

--- a/frontend/src/utils/backgroundFilter/applyBackgroundFilter/applyBackgroundFilter.ts
+++ b/frontend/src/utils/backgroundFilter/applyBackgroundFilter/applyBackgroundFilter.ts
@@ -1,4 +1,5 @@
-import { hasMediaProcessorSupport, Publisher, VideoFilter } from '@vonage/client-sdk-video';
+import { Publisher, VideoFilter } from '@vonage/client-sdk-video';
+import hasMediaProcessorSupport from '@utils/hasMediaProcessorSupport/hasMediaProcessorSupport';
 import { UserType } from '../../../Context/user';
 import { BACKGROUNDS_PATH } from '../../constants';
 import { setStorageItem, STORAGE_KEYS } from '../../storage';

--- a/frontend/src/utils/hasMediaProcessorSupport/hasMediaProcessorSupport.spec.ts
+++ b/frontend/src/utils/hasMediaProcessorSupport/hasMediaProcessorSupport.spec.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import hasMediaProcessorSupport, {
+  resetMediaProcessorSupportCache,
+} from './hasMediaProcessorSupport';
+
+const { sdkHasMediaProcessorSupport } = vi.hoisted(() => ({
+  sdkHasMediaProcessorSupport: vi.fn<[mediaType?: 'audio' | 'video' | 'both'], boolean>(),
+}));
+
+vi.mock('@vonage/client-sdk-video', () => ({
+  hasMediaProcessorSupport: sdkHasMediaProcessorSupport,
+}));
+
+afterEach(() => {
+  resetMediaProcessorSupportCache();
+  sdkHasMediaProcessorSupport.mockReset();
+});
+
+describe('hasMediaProcessorSupport', () => {
+  it('returns the underlying SDK result', () => {
+    sdkHasMediaProcessorSupport.mockReturnValue(true);
+
+    expect(hasMediaProcessorSupport('both')).toBe(true);
+    expect(sdkHasMediaProcessorSupport).toHaveBeenCalledWith('both');
+  });
+
+  it('runs the deprecated SDK check only once per media type', () => {
+    sdkHasMediaProcessorSupport.mockReturnValue(true);
+
+    hasMediaProcessorSupport('both');
+    hasMediaProcessorSupport('both');
+    hasMediaProcessorSupport('both');
+
+    expect(sdkHasMediaProcessorSupport).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches each media type independently', () => {
+    sdkHasMediaProcessorSupport.mockImplementation((mediaType) => mediaType === 'audio');
+
+    expect(hasMediaProcessorSupport('audio')).toBe(true);
+    expect(hasMediaProcessorSupport('video')).toBe(false);
+    expect(hasMediaProcessorSupport('audio')).toBe(true);
+
+    expect(sdkHasMediaProcessorSupport).toHaveBeenCalledTimes(2);
+  });
+
+  it('defaults to "both" when no media type is passed', () => {
+    sdkHasMediaProcessorSupport.mockReturnValue(false);
+
+    expect(hasMediaProcessorSupport()).toBe(false);
+    expect(sdkHasMediaProcessorSupport).toHaveBeenCalledWith('both');
+  });
+
+  it('re-reads from the SDK after the cache is reset', () => {
+    sdkHasMediaProcessorSupport.mockReturnValue(true);
+    expect(hasMediaProcessorSupport('both')).toBe(true);
+
+    resetMediaProcessorSupportCache();
+    sdkHasMediaProcessorSupport.mockReturnValue(false);
+
+    expect(hasMediaProcessorSupport('both')).toBe(false);
+    expect(sdkHasMediaProcessorSupport).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/utils/hasMediaProcessorSupport/hasMediaProcessorSupport.ts
+++ b/frontend/src/utils/hasMediaProcessorSupport/hasMediaProcessorSupport.ts
@@ -1,0 +1,36 @@
+import { hasMediaProcessorSupport as vonageHasMediaProcessorSupport } from '@vonage/client-sdk-video';
+
+type MediaProcessorMediaType = NonNullable<Parameters<typeof vonageHasMediaProcessorSupport>[0]>;
+
+const supportCache = new Map<MediaProcessorMediaType, boolean>();
+
+/**
+ * Memoized wrapper around the Vonage SDK's `hasMediaProcessorSupport`.
+ *
+ * Media-processor support depends only on the browser, so the result is constant for the life of
+ * the page. The SDK's synchronous check is deprecated and logs a deprecation warning on *every*
+ * call (and on Safari rebuilds an OffscreenCanvas/WebGPU context each time). Several components call
+ * it straight from their render body, so on a busy call it re-runs on every re-render — flooding the
+ * console and repeating real work. Caching the first result per media type keeps it to a single
+ * underlying call, which removes both the warning spam and the wasted work.
+ */
+const hasMediaProcessorSupport = (mediaType: MediaProcessorMediaType = 'both'): boolean => {
+  const cached = supportCache.get(mediaType);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const isSupported = vonageHasMediaProcessorSupport(mediaType);
+  supportCache.set(mediaType, isSupported);
+  return isSupported;
+};
+
+/**
+ * Clears the memoized results. Tests that stub the underlying SDK check with different values across
+ * cases call this between cases so a stale cached result isn't observed; production never needs it.
+ */
+export const resetMediaProcessorSupportCache = (): void => {
+  supportCache.clear();
+};
+
+export default hasMediaProcessorSupport;


### PR DESCRIPTION
## What

Stops the continuous console flood of:

```
OT.hasMediaProcessorSupport is deprecated, and will be removed in the future. Use OT.hasMediaProcessorSupport.promise instead
```

Closes #717.

## Why

The SDK's synchronous `hasMediaProcessorSupport()` is deprecated and logs a deprecation warning on **every call**. Several components call it **directly in their render body**, so it re-runs on every re-render — flooding the console during a call. On Safari the sync check also rebuilds an `OffscreenCanvas`/WebGPU context on every call, so it is wasted work too. Media-processor support is constant for the life of the page, so it only needs to be computed once.

## How

- Add `frontend/src/utils/hasMediaProcessorSupport/` — a memoized wrapper that calls the SDK once per media type and caches the result.
- Route the frontend callers through the wrapper instead of importing `hasMediaProcessorSupport` from `@vonage/client-sdk-video` directly.
- Because the value is now memoized, component tests that stub the SDK check with different values across cases clear the memo via `resetMediaProcessorSupportCache()` in `beforeEach` (exported for that purpose).

## Scope / follow-ups

- `libs/ui` `VividIcon.tsx` still calls the SDK directly (a ref-callback, not a render-path flood source). Left as an optional follow-up since sharing the wrapper across `libs` is a separate placement decision.

## Testing

- New unit test for the wrapper (memoization + per-type caching).
- Full frontend suite green.
- Verified in-browser: the deprecation warning no longer floods during a call.

## Notes

Independent of the device-permission work. Related: #617 (same "console flooded by a dependency log" symptom, different source).