### PR TITLE
VIDSOL-1113: chore(deps): bump opentok-layout-js to 5.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "normalize-range": "0.1.2",
     "opentok": "2.22.0",
     "opentok-jwt": "0.1.5",
-    "opentok-layout-js": "5.5.0",
+    "opentok-layout-js": "5.5.1",
     "opentok-solutions-logging": "1.1.5",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11624,10 +11624,10 @@ opentok-jwt@0.1.5:
   dependencies:
     jsonwebtoken "^9.0.0"
 
-opentok-layout-js@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/opentok-layout-js/-/opentok-layout-js-5.5.0.tgz#20f6971fdd9a39c816b1c23182351836a61d25e2"
-  integrity sha512-ynUo+zRjp1iasLUT0UQXuWvFyPAQIxhrdLOjWdNrPkPtziTuZcxccgPhr2kGQm9TztdLLQVlFruJN48cmqQiYA==
+opentok-layout-js@5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/opentok-layout-js/-/opentok-layout-js-5.5.1.tgz#4d572269bec6d66539940688fb885e48dab7f142"
+  integrity sha512-7SDkQROSrVbAGcyfBzDcjZi6/P3pO/P9nermq28CH0/xYF7IrMZ8m89Qlq5j9EIW4WAsMfIIUqoKYGfJ7XOvyw==
 
 opentok-solutions-logging@1.1.5, opentok-solutions-logging@^1.1.1:
   version "1.1.5"


### PR DESCRIPTION
Bumps `opentok-layout-js` (the layout-management library) from `5.5.0` to `5.5.1`.

#### What is this PR doing?
Upgrades the `opentok-layout-js` dependency to `5.5.1`, which picks up the upstream fix that removes the stray `console.log('getLayout apply')` debug statement. That log fired on **every** layout computation and flooded the browser console during calls — the logging noise we tracked down in VERA.

Upstream fix: aullman/opentok-layout-js#144 (released in v5.5.1). The diff is limited to `package.json` and `yarn.lock`; there are no application code changes.

#### How should this be manually tested?
- Join a call with several participants so the layout manager runs repeatedly.
- Open the browser dev-tools console and confirm the repeated `getLayout apply` lines no longer appear.
- Confirm the tile layout still arranges and reflows correctly as participants join, leave, and start/stop screen-sharing.

#### What are the relevant tickets?
A maintainer will add this ticket number.

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`?
[ ] Resolves an item reported in `Issues`.
