### PR TITLE
VIDSOL-958: well known update

### DIFF
--- a/backend/routes/wellKnown.ts
+++ b/backend/routes/wellKnown.ts
@@ -57,7 +57,7 @@ wellKnownRouter.get('/apple-app-site-association', (_req: Request, res: Response
               comment: 'Matches any room URL',
             },
             {
-              '/': '/auth/callback',
+              '/': '/api/auth/callback*',
               comment: 'Auth callback',
             },
           ],

--- a/backend/routes/wellKnown.ts
+++ b/backend/routes/wellKnown.ts
@@ -56,6 +56,10 @@ wellKnownRouter.get('/apple-app-site-association', (_req: Request, res: Response
               '/': '/room/*',
               comment: 'Matches any room URL',
             },
+            {
+              '/': '/auth/callback*',
+              comment: 'Okta auth callback',
+            },
           ],
         },
       ],

--- a/backend/routes/wellKnown.ts
+++ b/backend/routes/wellKnown.ts
@@ -57,8 +57,8 @@ wellKnownRouter.get('/apple-app-site-association', (_req: Request, res: Response
               comment: 'Matches any room URL',
             },
             {
-              '/': '/auth/callback*',
-              comment: 'Okta auth callback',
+              '/': '/auth/callback',
+              comment: 'Auth callback',
             },
           ],
         },

--- a/backend/tests/apple-app-site-association.test.ts
+++ b/backend/tests/apple-app-site-association.test.ts
@@ -51,7 +51,7 @@ describe('GET /.well-known/apple-app-site-association', () => {
                   comment: 'Matches any room URL',
                 }),
                 expect.objectContaining({
-                  '/': '/auth/callback',
+                  '/': '/api/auth/callback*',
                   comment: 'Auth callback',
                 }),
               ]),

--- a/backend/tests/apple-app-site-association.test.ts
+++ b/backend/tests/apple-app-site-association.test.ts
@@ -50,6 +50,10 @@ describe('GET /.well-known/apple-app-site-association', () => {
                   '/': '/room/*',
                   comment: 'Matches any room URL',
                 }),
+                expect.objectContaining({
+                  '/': '/auth/callback*',
+                  comment: 'Okta auth callback',
+                }),
               ]),
             }),
           ]),

--- a/backend/tests/apple-app-site-association.test.ts
+++ b/backend/tests/apple-app-site-association.test.ts
@@ -51,8 +51,8 @@ describe('GET /.well-known/apple-app-site-association', () => {
                   comment: 'Matches any room URL',
                 }),
                 expect.objectContaining({
-                  '/': '/auth/callback*',
-                  comment: 'Okta auth callback',
+                  '/': '/auth/callback',
+                  comment: 'Auth callback',
                 }),
               ]),
             }),


### PR DESCRIPTION
#### What is this PR doing?
Adds the Okta auth callback path (`/api/auth/callback*`) to the Apple App 
Site Association (AASA) well-known endpoint, enabling Universal Links 
for iOS native authentication flow.

#### How should this be manually tested?
1. Hit `GET /.well-known/apple-app-site-association` on the deployed PR preview
2. Verify the response includes a component with `"/": "/api/auth/callback*"`
3. Run `npm test` — all AASA tests should pass

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-958](https://jira.vonage.com/browse/VIDSOL-958)

#### Checklist
[ ] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
