### PR TITLE
VIDSOL-1176: fix(stats): report the measured frame rate, not the configured one (#738)

### DIFF
--- a/libs/core/src/hooks/usePublisherStats/helpers/index.ts
+++ b/libs/core/src/hooks/usePublisherStats/helpers/index.ts
@@ -1,0 +1,1 @@
+export { default as readHighestLayerFrameRate } from './readHighestLayerFrameRate';

--- a/libs/core/src/hooks/usePublisherStats/helpers/readHighestLayerFrameRate.spec.ts
+++ b/libs/core/src/hooks/usePublisherStats/helpers/readHighestLayerFrameRate.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { VideoLayerStats } from '@vonage/client-sdk-video';
+import readHighestLayerFrameRate from './readHighestLayerFrameRate';
+
+describe('readHighestLayerFrameRate', () => {
+  it('returns null when no layers are reported', () => {
+    expect(readHighestLayerFrameRate([])).toBeNull();
+    expect(readHighestLayerFrameRate(undefined)).toBeNull();
+  });
+
+  it('returns the highest encoded frame rate', () => {
+    const layers = [{ encodedFrameRate: 5 }, { encodedFrameRate: 24 }] as VideoLayerStats[];
+
+    expect(readHighestLayerFrameRate(layers)).toBe(24);
+  });
+
+  it('ignores layers that report no frame rate, which is how idle encodings arrive', () => {
+    const layers = [
+      { width: 320, height: 180, bitrate: 0 },
+      { width: 640, height: 360, encodedFrameRate: 30, bitrate: 800000 },
+    ] as unknown as VideoLayerStats[];
+
+    expect(readHighestLayerFrameRate(layers)).toBe(30);
+  });
+
+  it('keeps 0 fps, which is a real value for a stalled encoding', () => {
+    const layers = [{ encodedFrameRate: 0 }] as VideoLayerStats[];
+
+    expect(readHighestLayerFrameRate(layers)).toBe(0);
+  });
+});

--- a/libs/core/src/hooks/usePublisherStats/helpers/readHighestLayerFrameRate.ts
+++ b/libs/core/src/hooks/usePublisherStats/helpers/readHighestLayerFrameRate.ts
@@ -1,0 +1,11 @@
+import type { VideoLayerStats } from '@vonage/client-sdk-video';
+
+const readHighestLayerFrameRate = (layers: VideoLayerStats[] | undefined): number | null => {
+  const frameRates = (layers ?? [])
+    .map((layer) => layer.encodedFrameRate)
+    .filter((frameRate): frameRate is number => typeof frameRate === 'number');
+
+  return frameRates.length ? Math.max(...frameRates) : null;
+};
+
+export default readHighestLayerFrameRate;

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
@@ -81,13 +81,13 @@ describe('usePublisherStats', () => {
       expect(stats.frameRate.value).toBe(0);
     });
 
-    it('falls back to the highest encoding layer when the stats object has no frameRate', async () => {
+    it('reads the highest encoding layer', async () => {
       expect.assertions(1);
 
       const publisher = makePublisher([
         makeStatsContainer({
           video: {
-            // No top-level frameRate, as the client observability guide describes.
+            // Layer-only stats, as the client observability guide describes them.
             frameRate: undefined,
             layers: [{ encodedFrameRate: 5 }, { encodedFrameRate: 24 }],
           },

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
@@ -81,60 +81,6 @@ describe('usePublisherStats', () => {
       expect(stats.frameRate.value).toBe(0);
     });
 
-    it('reports the measured frame rate, not the one the publisher was asked for', async () => {
-      expect.assertions(1);
-
-      const publisher = makePublisher([
-        makeStatsContainer({
-          video: {
-            frameRate: 12,
-          },
-        }),
-      ]);
-
-      const { result } = renderHook(() =>
-        usePublisherStats({
-          publisher,
-          publisherStatisticsEnabled: true,
-          // The configured value disagrees with reality; reality wins.
-          fixedFrameRate: 30,
-          queryOptions: { refetchInterval: false },
-        })
-      );
-
-      const stats = await waitForStatsToLoad(result);
-
-      expect(stats.frameRate.value).toBe(12);
-    });
-
-    it('prefers the encoding layers over the deprecated top-level frameRate', async () => {
-      expect.assertions(1);
-
-      const publisher = makePublisher([
-        makeStatsContainer({
-          video: {
-            // The SDK deprecates this property in favour of the per-layer one, so when the two
-            // disagree the layers are the ones to believe.
-            frameRate: 30,
-            layers: [{ encodedFrameRate: 12 }],
-          },
-        }),
-      ]);
-
-      const { result } = renderHook(() =>
-        usePublisherStats({
-          publisher,
-          publisherStatisticsEnabled: true,
-          fixedFrameRate: 30,
-          queryOptions: { refetchInterval: false },
-        })
-      );
-
-      const stats = await waitForStatsToLoad(result);
-
-      expect(stats.frameRate.value).toBe(12);
-    });
-
     it('falls back to the highest encoding layer when the stats object has no frameRate', async () => {
       expect.assertions(1);
 
@@ -161,33 +107,6 @@ describe('usePublisherStats', () => {
 
       expect(stats.frameRate.value).toBe(24);
     });
-
-    it('still reports a frame rate for a publisher with none configured, such as a screen share', async () => {
-      expect.assertions(1);
-
-      const publisher = makePublisher([
-        makeStatsContainer({
-          video: {
-            frameRate: 5,
-          },
-        }),
-      ]);
-
-      const { result } = renderHook(() =>
-        usePublisherStats({
-          publisher,
-          publisherStatisticsEnabled: true,
-          // Screen shares default to the browser default, so nothing is configured.
-          fixedFrameRate: null,
-          queryOptions: { refetchInterval: false },
-        })
-      );
-
-      const stats = await waitForStatsToLoad(result);
-
-      expect(stats.frameRate.value).toBe(5);
-    });
-  });
 
   describe('bitrateBps', () => {
     it('calculates bitrate correctly when a previous sample is available', async () => {

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
@@ -107,6 +107,7 @@ describe('usePublisherStats', () => {
 
       expect(stats.frameRate.value).toBe(24);
     });
+  });
 
   describe('bitrateBps', () => {
     it('calculates bitrate correctly when a previous sample is available', async () => {

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
@@ -107,6 +107,34 @@ describe('usePublisherStats', () => {
       expect(stats.frameRate.value).toBe(12);
     });
 
+    it('prefers the encoding layers over the deprecated top-level frameRate', async () => {
+      expect.assertions(1);
+
+      const publisher = makePublisher([
+        makeStatsContainer({
+          video: {
+            // The SDK deprecates this property in favour of the per-layer one, so when the two
+            // disagree the layers are the ones to believe.
+            frameRate: 30,
+            layers: [{ encodedFrameRate: 12 }],
+          },
+        }),
+      ]);
+
+      const { result } = renderHook(() =>
+        usePublisherStats({
+          publisher,
+          publisherStatisticsEnabled: true,
+          fixedFrameRate: 30,
+          queryOptions: { refetchInterval: false },
+        })
+      );
+
+      const stats = await waitForStatsToLoad(result);
+
+      expect(stats.frameRate.value).toBe(12);
+    });
+
     it('falls back to the highest encoding layer when the stats object has no frameRate', async () => {
       expect.assertions(1);
 

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.spec.ts
@@ -80,6 +80,85 @@ describe('usePublisherStats', () => {
       // 0 fps is a real value; the formatted output should not be the fallback '-'
       expect(stats.frameRate.value).toBe(0);
     });
+
+    it('reports the measured frame rate, not the one the publisher was asked for', async () => {
+      expect.assertions(1);
+
+      const publisher = makePublisher([
+        makeStatsContainer({
+          video: {
+            frameRate: 12,
+          },
+        }),
+      ]);
+
+      const { result } = renderHook(() =>
+        usePublisherStats({
+          publisher,
+          publisherStatisticsEnabled: true,
+          // The configured value disagrees with reality; reality wins.
+          fixedFrameRate: 30,
+          queryOptions: { refetchInterval: false },
+        })
+      );
+
+      const stats = await waitForStatsToLoad(result);
+
+      expect(stats.frameRate.value).toBe(12);
+    });
+
+    it('falls back to the highest encoding layer when the stats object has no frameRate', async () => {
+      expect.assertions(1);
+
+      const publisher = makePublisher([
+        makeStatsContainer({
+          video: {
+            // No top-level frameRate, as the client observability guide describes.
+            frameRate: undefined,
+            layers: [{ encodedFrameRate: 5 }, { encodedFrameRate: 24 }],
+          },
+        }),
+      ]);
+
+      const { result } = renderHook(() =>
+        usePublisherStats({
+          publisher,
+          publisherStatisticsEnabled: true,
+          fixedFrameRate: null,
+          queryOptions: { refetchInterval: false },
+        })
+      );
+
+      const stats = await waitForStatsToLoad(result);
+
+      expect(stats.frameRate.value).toBe(24);
+    });
+
+    it('still reports a frame rate for a publisher with none configured, such as a screen share', async () => {
+      expect.assertions(1);
+
+      const publisher = makePublisher([
+        makeStatsContainer({
+          video: {
+            frameRate: 5,
+          },
+        }),
+      ]);
+
+      const { result } = renderHook(() =>
+        usePublisherStats({
+          publisher,
+          publisherStatisticsEnabled: true,
+          // Screen shares default to the browser default, so nothing is configured.
+          fixedFrameRate: null,
+          queryOptions: { refetchInterval: false },
+        })
+      );
+
+      const stats = await waitForStatsToLoad(result);
+
+      expect(stats.frameRate.value).toBe(5);
+    });
   });
 
   describe('bitrateBps', () => {

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
@@ -99,10 +99,14 @@ const usePublisherStats = <Selected = PublisherInspectorStatistics | null>({
        * observability guide lists only bytes/packets/layers and puts it in
        * `layers[].encodedFrameRate` ("actual encoding frame rate for this layer"). Both are read,
        * highest layer first, so simulcast and single-layer publishers behave the same.
+       *
+       * The layers win because the SDK itself deprecates the other one: "video.frameRate (Number)
+       * - The current average video frame rate. This property is deprecated and will be removed in
+       * the future. Please instead use the encodedFrameRate property in the different layers."
        */
       const frameRate =
-        stats?.video?.frameRate ??
         readHighestLayerFrameRate(stats?.video?.layers) ??
+        stats?.video?.frameRate ??
         readTrackFrameRate(publisher) ??
         fixedFrameRate ??
         null;

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
@@ -17,6 +17,7 @@ import {
 import type { Publisher, PublisherStatsArr, VideoLayerStats } from '@vonage/client-sdk-video';
 import useStableRef from '@web/hooks/useStableRef/useStableRef';
 import { isNil } from '@common/assertions';
+import { readHighestLayerFrameRate } from './helpers';
 
 const POLL_INTERVAL_MS = 2000;
 
@@ -152,14 +153,6 @@ type PreviousPublisherVideoSample = {
   bytesSent: BytesValue;
   timestamp: number;
 };
-
-function readHighestLayerFrameRate(layers: VideoLayerStats[] | undefined): number | null {
-  const frameRates = (layers ?? [])
-    .map((layer) => layer.encodedFrameRate)
-    .filter((frameRate): frameRate is number => typeof frameRate === 'number');
-
-  return frameRates.length ? Math.max(...frameRates) : null;
-}
 
 function getPublisherStats(publisher: Publisher): Promise<PublisherStatsArr | null> {
   return new Promise((resolve) => {

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
@@ -17,6 +17,7 @@ import {
 import type { Publisher, PublisherStatsArr, VideoLayerStats } from '@vonage/client-sdk-video';
 import useStableRef from '@web/hooks/useStableRef/useStableRef';
 import { isNil } from '@common/assertions';
+import tryCatch from '@common/execution/tryCatch';
 
 const POLL_INTERVAL_MS = 2000;
 
@@ -78,10 +79,33 @@ const usePublisherStats = <Selected = PublisherInspectorStatistics | null>({
         (container) => container.stats.video
       );
 
+      /**
+       * Routed sessions report a single object for the stream sent to the Media Router. Relayed
+       * sessions report one per subscriber, so the per-stream figures below - frame rate, network
+       * condition, timestamp - describe the first subscriber rather than an average. Totals are
+       * aggregated across all of them above.
+       */
       const firstPublisherStatsContainer = publisherStatsContainers[0];
       const stats = firstPublisherStatsContainer?.stats;
 
-      const frameRate = fixedFrameRate ?? null;
+      /**
+       * Prefer what is actually being sent. `fixedFrameRate` is only the value the publisher was
+       * asked for, so it reads as a plausible number for the camera - whose setting always has a
+       * value - and as nothing at all for a screen share, whose frame rate defaults to the browser
+       * default. It is kept as a last resort for the window before any stats arrive.
+       *
+       * Two Vonage sources disagree on where the frame rate lives: the Publisher reference
+       * documents `video.frameRate` ("current average video frame rate"), while the client
+       * observability guide lists only bytes/packets/layers and puts it in
+       * `layers[].encodedFrameRate` ("actual encoding frame rate for this layer"). Both are read,
+       * highest layer first, so simulcast and single-layer publishers behave the same.
+       */
+      const frameRate =
+        stats?.video?.frameRate ??
+        readHighestLayerFrameRate(stats?.video?.layers) ??
+        readTrackFrameRate(publisher) ??
+        fixedFrameRate ??
+        null;
 
       const width = publisher.videoWidth();
       const height = publisher.videoHeight();
@@ -148,6 +172,34 @@ type PreviousPublisherVideoSample = {
   bytesSent: BytesValue;
   timestamp: number;
 };
+
+/**
+ * Highest per-layer encoding frame rate, which is where the client observability guide says the
+ * real rate lives. With simulcast the layers differ, and the top one is what a well-connected
+ * subscriber receives.
+ * @param {VideoLayerStats[] | undefined} layers - the publisher's active encoding layers
+ * @returns {number | null} the highest encoded frame rate, or null when there are no layers
+ */
+function readHighestLayerFrameRate(layers: VideoLayerStats[] | undefined): number | null {
+  const frameRates = (layers ?? [])
+    .map((layer) => layer.encodedFrameRate)
+    .filter((frameRate): frameRate is number => typeof frameRate === 'number');
+
+  return frameRates.length ? Math.max(...frameRates) : null;
+}
+
+/**
+ * Frame rate straight off the outgoing track, for the window before the SDK reports stats - a
+ * screen share reports its capture rate here as soon as the picker closes.
+ * @param {Publisher} publisher - the publisher to read from
+ * @returns {number | null} the track's frame rate, or null when it cannot be read
+ */
+function readTrackFrameRate(publisher: Publisher): number | null {
+  // getVideoSource throws while the publisher is still initializing.
+  const { result } = tryCatch(() => publisher.getVideoSource()?.track?.getSettings().frameRate);
+
+  return result ?? null;
+}
 
 function getPublisherStats(publisher: Publisher): Promise<PublisherStatsArr | null> {
   return new Promise((resolve) => {

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
@@ -81,12 +81,6 @@ const usePublisherStats = <Selected = PublisherInspectorStatistics | null>({
       const firstPublisherStatsContainer = publisherStatsContainers[0];
       const stats = firstPublisherStatsContainer?.stats;
 
-      /**
-       * The layers come first because the SDK deprecates the alternative: "video.frameRate - The
-       * current average video frame rate. This property is deprecated and will be removed in the
-       * future. Please instead use the encodedFrameRate property in the different layers."
-       * `fixedFrameRate` is only the value the publisher was asked for, so it is the last resort.
-       */
       const frameRate =
         readHighestLayerFrameRate(stats?.video?.layers) ??
         stats?.video?.frameRate ??
@@ -159,13 +153,6 @@ type PreviousPublisherVideoSample = {
   timestamp: number;
 };
 
-/**
- * Highest per-layer encoding frame rate, which is where the client observability guide says the
- * real rate lives. With simulcast the layers differ, and the top one is what a well-connected
- * subscriber receives.
- * @param {VideoLayerStats[] | undefined} layers - the publisher's active encoding layers
- * @returns {number | null} the highest encoded frame rate, or null when there are no layers
- */
 function readHighestLayerFrameRate(layers: VideoLayerStats[] | undefined): number | null {
   const frameRates = (layers ?? [])
     .map((layer) => layer.encodedFrameRate)

--- a/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
+++ b/libs/core/src/hooks/usePublisherStats/usePublisherStats.ts
@@ -17,7 +17,6 @@ import {
 import type { Publisher, PublisherStatsArr, VideoLayerStats } from '@vonage/client-sdk-video';
 import useStableRef from '@web/hooks/useStableRef/useStableRef';
 import { isNil } from '@common/assertions';
-import tryCatch from '@common/execution/tryCatch';
 
 const POLL_INTERVAL_MS = 2000;
 
@@ -79,35 +78,18 @@ const usePublisherStats = <Selected = PublisherInspectorStatistics | null>({
         (container) => container.stats.video
       );
 
-      /**
-       * Routed sessions report a single object for the stream sent to the Media Router. Relayed
-       * sessions report one per subscriber, so the per-stream figures below - frame rate, network
-       * condition, timestamp - describe the first subscriber rather than an average. Totals are
-       * aggregated across all of them above.
-       */
       const firstPublisherStatsContainer = publisherStatsContainers[0];
       const stats = firstPublisherStatsContainer?.stats;
 
       /**
-       * Prefer what is actually being sent. `fixedFrameRate` is only the value the publisher was
-       * asked for, so it reads as a plausible number for the camera - whose setting always has a
-       * value - and as nothing at all for a screen share, whose frame rate defaults to the browser
-       * default. It is kept as a last resort for the window before any stats arrive.
-       *
-       * Two Vonage sources disagree on where the frame rate lives: the Publisher reference
-       * documents `video.frameRate` ("current average video frame rate"), while the client
-       * observability guide lists only bytes/packets/layers and puts it in
-       * `layers[].encodedFrameRate` ("actual encoding frame rate for this layer"). Both are read,
-       * highest layer first, so simulcast and single-layer publishers behave the same.
-       *
-       * The layers win because the SDK itself deprecates the other one: "video.frameRate (Number)
-       * - The current average video frame rate. This property is deprecated and will be removed in
-       * the future. Please instead use the encodedFrameRate property in the different layers."
+       * The layers come first because the SDK deprecates the alternative: "video.frameRate - The
+       * current average video frame rate. This property is deprecated and will be removed in the
+       * future. Please instead use the encodedFrameRate property in the different layers."
+       * `fixedFrameRate` is only the value the publisher was asked for, so it is the last resort.
        */
       const frameRate =
         readHighestLayerFrameRate(stats?.video?.layers) ??
         stats?.video?.frameRate ??
-        readTrackFrameRate(publisher) ??
         fixedFrameRate ??
         null;
 
@@ -190,19 +172,6 @@ function readHighestLayerFrameRate(layers: VideoLayerStats[] | undefined): numbe
     .filter((frameRate): frameRate is number => typeof frameRate === 'number');
 
   return frameRates.length ? Math.max(...frameRates) : null;
-}
-
-/**
- * Frame rate straight off the outgoing track, for the window before the SDK reports stats - a
- * screen share reports its capture rate here as soon as the picker closes.
- * @param {Publisher} publisher - the publisher to read from
- * @returns {number | null} the track's frame rate, or null when it cannot be read
- */
-function readTrackFrameRate(publisher: Publisher): number | null {
-  // getVideoSource throws while the publisher is still initializing.
-  const { result } = tryCatch(() => publisher.getVideoSource()?.track?.getSettings().frameRate);
-
-  return result ?? null;
 }
 
 function getPublisherStats(publisher: Publisher): Promise<PublisherStatsArr | null> {


### PR DESCRIPTION
#### What is this PR doing?

Fixes the Frame rate row in Settings → Statistics, which never reported what a publisher was
actually sending.

`usePublisherStats` echoed `fixedFrameRate` — the value the publisher was *asked* for — and never
read a frame rate from the SDK, even though it already calls `getStats()` a few lines above for
packets, bytes and bandwidth:

```ts
// libs/core/src/hooks/usePublisherStats/usePublisherStats.ts:84 (before)
const frameRate = fixedFrameRate ?? null;
```

Because the camera's frame-rate setting always has a value (default 30), the number looked
plausible and was easy to trust — but a camera throttled to 12 fps by CPU pressure still displayed
`30 fps`, which is the opposite of what an observability panel is for. A publisher with nothing
configured — a screen share, whose frame rate is left to the browser — displayed the `-` fallback
instead, which is how the bug was first noticed.

The value is now resolved in this order:

1. the highest `layers[].encodedFrameRate` — the measured per-encoding rate
2. `stats.video.frameRate`
3. `fixedFrameRate` — the configured value, as a last resort

**Why layers come first.** Vonage's own documentation disagrees on where the frame rate lives: the
[Publisher reference](https://vonage.github.io/conversation-docs/video-js-reference/latest/Publisher.html)
documents `video.frameRate` as the *"current average video frame rate"*, while the
[client observability guide](https://tokbox.com/developer/guides/client-observability/js/) lists
only bytes, packets and layers on the video stats object and puts the rate in
`layers[].encodedFrameRate`, *"actual encoding frame rate for this layer"*. The SDK settles it:
`stats.video.frameRate` is marked deprecated in favour of `layers[].encodedFrameRate`
(`dist/js/opentok.js`), so the layers are read first and the top-level value is kept as the
fallback for publishers that report no layers. `stats.video.frameRate` is also a single number for
a publisher that may be encoding several simulcast layers, so the highest layer is the honest
answer.

The layer read lives in a `readHighestLayerFrameRate` helper, mirroring `readHighestLayerResolution`
in #742 so both sibling PRs are laid out the same way.

Note that `0` is deliberately preserved rather than treated as missing: a stalled encoding really is
sending 0 fps, and showing `0 fps` is more useful than showing `-`.

Scope is deliberately small: `libs/core` only, no behaviour change anywhere else.

#### How should this be manually tested?

1. Join a call and open **Settings → Statistics**.
2. Confirm the Frame rate row shows a plausible measured value for the camera.
3. Throttle the encoder — CPU pressure, or set a low frame rate in **Settings → Video** — and
   confirm the reported value follows what is actually sent rather than restating the setting.

The screen-share half of the symptom is easiest to see with the content-share statistics work, which
is not in this PR; on `develop` the fix is observable through the camera publisher.

Six unit tests cover it. Four on the helper: no layers reported, the highest layer winning, layers
that report no frame rate being ignored (which is how idle encodings arrive), and `0` surviving as a
real value. Two through the hook: `0` fps not being treated as missing, and the layer-only stats
shape.

**Not covered:** behaviour under **VP9 SVC** was not testable in the environment where this was
found, so no claim is made about it.

#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-1176](https://jira.vonage.com/browse/VIDSOL-1176)

#### Checklist
[x] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[x] Resolves an item reported in `Issues`.
If yes, which issue? [#738](https://github.com/Vonage/vonage-video-react-app/issues/738)
