### PR TITLE
VIDSOL-1196: test to prove the v1 session routes  are protected

### DIFF
--- a/backend/tests/helpers/index.ts
+++ b/backend/tests/helpers/index.ts
@@ -1,1 +1,2 @@
 export { default as doPartialMock } from './doPartialMock';
+export { default as mockVonageVideoSdk } from './mockVonageVideoSdk';

--- a/backend/tests/helpers/mockVonageVideoSdk.ts
+++ b/backend/tests/helpers/mockVonageVideoSdk.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/await-thenable */
+import { jest } from '@jest/globals';
+
+type ArchiveResponse = { id: string; status: string };
+type CaptionsResponse = { captionsId: string };
+
+// base64('2~vonageAppId~0.0.0.0~2024-01-01') — valid format for decodeSessionId
+export const DEFAULT_VALID_SESSION_ID = '1_Mn52b25hZ2VBcHBJZH4wLjAuMC4wfjIwMjQtMDEtMDE=';
+export const DEFAULT_CAPTIONS_ID = '123e4567-a12b-41a2-a123-123456789012';
+
+type VideoSdkOverrides = Partial<{
+  createSession: () => Promise<{ sessionId: string }>;
+  generateClientToken: () => string;
+  startArchive: (sessionId: string) => Promise<ArchiveResponse>;
+  stopArchive: (archiveId: string) => Promise<ArchiveResponse>;
+  searchArchives: () => Promise<{ items: unknown[]; count: number }>;
+  enableCaptions: () => Promise<CaptionsResponse>;
+  disableCaptions: (captionsId: string) => Promise<void>;
+}>;
+
+/**
+ * Registers the same third-party SDK mocks (`@vonage/auth`, `@vonage/video`, and the legacy
+ * `opentokVideoService`) that any test importing `../server` needs, since `makeVideoClient$()`
+ * constructs a real SDK client at module load time. Must be awaited before `../server` is
+ * imported — jest.unstable_mockModule only takes effect on modules imported afterwards.
+ *
+ * Uses `jest.unstable_mockModule` directly rather than `doPartialMock`: these SDKs export
+ * classes, and a jest mock function isn't structurally assignable to a class's constructor
+ * type, which `doPartialMock`'s generic (built for plain function/object modules like
+ * `config.ts`) can't accommodate.
+ *
+ * `videoOverrides` lets a suite override specific SDK methods (e.g. to reject for a
+ * particular id) while keeping the rest of the happy-path defaults below.
+ *
+ * jest.unstable_mockModule resolves relative specifiers against the calling *test* file, not
+ * this file — hence `../videoService/...` below, not `../../videoService/...`. That means this
+ * helper only works from test files directly under `backend/tests/`.
+ */
+async function mockVonageVideoSdk({
+  validSessionId = DEFAULT_VALID_SESSION_ID,
+  videoOverrides = {},
+}: {
+  validSessionId?: string;
+  videoOverrides?: VideoSdkOverrides;
+} = {}): Promise<void> {
+  const actualAuth = await import('@vonage/auth');
+  const actualVideo = await import('@vonage/video');
+
+  await jest.unstable_mockModule('@vonage/auth', () => ({
+    ...actualAuth,
+    Auth: jest.fn().mockImplementation(() => ({ applicationId: 'vonageAppId' })),
+  }));
+
+  await jest.unstable_mockModule('@vonage/video', () => ({
+    ...actualVideo,
+    Video: jest.fn().mockImplementation(() => ({
+      createSession: jest
+        .fn<() => Promise<{ sessionId: string }>>()
+        .mockResolvedValue({ sessionId: validSessionId }),
+      generateClientToken: jest.fn().mockReturnValue('someToken'),
+      startArchive: jest
+        .fn<(sessionId: string) => Promise<ArchiveResponse>>()
+        .mockResolvedValue({ id: 'archiveId', status: 'started' }),
+      stopArchive: jest
+        .fn<(archiveId: string) => Promise<ArchiveResponse>>()
+        .mockImplementation((archiveId: string) =>
+          Promise.resolve({ id: archiveId, status: 'stopped' })
+        ),
+      searchArchives: jest
+        .fn<() => Promise<{ items: unknown[]; count: number }>>()
+        .mockResolvedValue({ items: [], count: 0 }),
+      enableCaptions: jest
+        .fn<() => Promise<CaptionsResponse>>()
+        .mockResolvedValue({ captionsId: DEFAULT_CAPTIONS_ID }),
+      disableCaptions: jest
+        .fn<(captionsId: string) => Promise<void>>()
+        .mockResolvedValue(undefined),
+      ...videoOverrides,
+    })),
+  }));
+
+  await jest.unstable_mockModule('../videoService/opentokVideoService.ts', () => ({
+    default: jest.fn().mockImplementation(() => ({
+      startArchive: jest.fn<() => Promise<string>>().mockResolvedValue('archiveId'),
+      stopArchive: jest.fn<() => Promise<string>>().mockResolvedValue('archiveId'),
+      enableCaptions: jest.fn<() => Promise<string>>().mockResolvedValue('captionsId'),
+      disableCaptions: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      generateToken: jest
+        .fn<() => Promise<{ token: string; apiKey: string }>>()
+        .mockResolvedValue({ token: 'someToken', apiKey: 'someApiKey' }),
+      createSession: jest.fn<() => Promise<string>>().mockResolvedValue(validSessionId),
+      searchArchives: jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]),
+    })),
+  }));
+}
+
+export default mockVonageVideoSdk;

--- a/backend/tests/session.auth.test.ts
+++ b/backend/tests/session.auth.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import axios from 'axios';
+import request from 'supertest';
+import { Server } from 'http';
+import getSessionStorageService from '../sessionStorageService';
+import { SESSION_COOKIE_NAME } from '../routes/auth/constants';
+import mockVonageVideoSdk, { DEFAULT_CAPTIONS_ID } from './helpers/mockVonageVideoSdk';
+
+const OIDC_CLIENT_ID = 'test-client-id';
+const introspectionResponse = { data: { active: true, sub: 'user-1', client_id: OIDC_CLIENT_ID } };
+
+const originalEnv = process.env;
+process.env = {
+  ...originalEnv,
+  AUTH_ENABLED: 'true',
+  OIDC_ISSUER_URL: 'https://example.com',
+  OIDC_CLIENT_ID: OIDC_CLIENT_ID,
+  OIDC_WEB_REDIRECT_URI: 'http://localhost:3000/api/auth/callback/okta',
+};
+
+jest.mock('axios');
+const mockPost = jest.spyOn(axios, 'post');
+
+await mockVonageVideoSdk();
+
+const startServer = (await import('../server')).default;
+const sessionService = getSessionStorageService();
+
+/**
+ * Proves the 5 v1 `session.ts` routes are actually wired into the app-wide `authMiddleware`
+ * gate from server.ts — introspection logic itself (inactive token, client_id mismatch, etc.)
+ * is already covered by authMiddleware.test.ts and is not re-tested here.
+ */
+describe('v1 session routes are protected by authMiddleware when AUTH_ENABLED=true', () => {
+  let server: Server;
+  const roomName = 'auth-wired-room';
+  const captionsId = DEFAULT_CAPTIONS_ID;
+  const archiveId = 'archive-1';
+
+  const routes: Array<{ name: string; method: 'get' | 'post'; path: string }> = [
+    {
+      name: 'POST /session/:room/startArchive',
+      method: 'post',
+      path: `/session/${roomName}/startArchive`,
+    },
+    {
+      name: 'POST /session/:room/:archiveId/stopArchive',
+      method: 'post',
+      path: `/session/${roomName}/${archiveId}/stopArchive`,
+    },
+    { name: 'GET /session/:room/archives', method: 'get', path: `/session/${roomName}/archives` },
+    {
+      name: 'POST /session/:room/enableCaptions',
+      method: 'post',
+      path: `/session/${roomName}/enableCaptions`,
+    },
+    {
+      name: 'POST /session/:room/:captionsId/disableCaptions',
+      method: 'post',
+      path: `/session/${roomName}/${captionsId}/disableCaptions`,
+    },
+  ];
+
+  beforeAll(async () => {
+    server = await startServer(0);
+
+    // Primes the room the same way the app would — a real join creates the session and
+    // registers the sessionId → sessionKey mapping (via videoHandler's onSettled$ hook) — rather
+    // than hand-crafting storage state that could drift out of sync with what decodeSessionKey
+    // actually returns.
+    mockPost.mockResolvedValueOnce(introspectionResponse);
+    await request(server).get(`/session/${roomName}`).set('Authorization', 'Bearer valid-token');
+    mockPost.mockReset();
+  });
+
+  afterAll((done) => {
+    process.env = originalEnv;
+    server.close(done);
+  });
+
+  afterEach(() => {
+    mockPost.mockReset();
+  });
+
+  it.each(routes)('$name returns 401 with no token and no cookie', async ({ method, path }) => {
+    const res = await request(server)[method](path).set('Content-Type', 'application/json');
+
+    expect(res.statusCode).toEqual(401);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it.each(routes)(
+    '$name returns 200 with a valid Bearer token (mobile path)',
+    async ({ method, path }) => {
+      mockPost.mockResolvedValue(introspectionResponse);
+
+      const res = await request(server)
+        [method](path)
+        .set('Content-Type', 'application/json')
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(res.statusCode).toEqual(200);
+    }
+  );
+
+  it('GET /session/:room/archives returns 200 with a valid session cookie (web path)', async () => {
+    mockPost.mockResolvedValue(introspectionResponse);
+    await sessionService.setAccessToken({
+      sessionId: 'v1-cookie-session',
+      accessToken: 'session-token',
+    });
+
+    const res = await request(server)
+      .get(`/session/${roomName}/archives`)
+      .set('Cookie', `${SESSION_COOKIE_NAME}=v1-cookie-session`);
+
+    expect(res.statusCode).toEqual(200);
+  });
+});

--- a/backend/tests/session.test.ts
+++ b/backend/tests/session.test.ts
@@ -6,84 +6,39 @@ import { Archive } from 'opentok';
 import InMemorySessionStorage from '../storage/inMemorySessionStorage';
 import mockOpentokConfig from '../helpers/__mocks__/config';
 import getSessionStorageService from '../sessionStorageService';
+import mockVonageVideoSdk, {
+  DEFAULT_CAPTIONS_ID as validCaptionsId,
+  DEFAULT_VALID_SESSION_ID as validSessionId,
+} from './helpers/mockVonageVideoSdk';
 
-// base64('2~vonageAppId~0.0.0.0~2024-01-01') — valid format for decodeSessionId
-const validSessionId = '1_Mn52b25hZ2VBcHBJZH4wLjAuMC4wfjIwMjQtMDEtMDE=';
 const validSessionKey =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uSWQiOiIxX01YNWtNVEkxWWpGbU1DMWtZMkl5TFRRM05EY3RZamxrWVMxa09ESTVOMkk0WkdFME9UZC1makUzTnpVM09UWXhOVGd3TWpkLWFqaElOU3RYZEV4VU5sYzBZbE5vZGs5UVNYVllVRmRDZm41LSIsInJvb21OYW1lIjoiYXdlc29tZS1yb29tLW5hbWUiLCJpYXQiOjE3NzU5NjMzMjh9.QcNVXp6gatPTV82IJa8VgDG6rOLBkFjU3r7j_BcxM-c';
 
 await jest.unstable_mockModule('../helpers/config', mockOpentokConfig);
 
-// Mock third-party Vonage SDKs only
-const actualAuth = await import('@vonage/auth');
-const actualVideo = await import('@vonage/video');
+await mockVonageVideoSdk({
+  validSessionId,
+  videoOverrides: {
+    stopArchive: (archiveId: string) => {
+      if (archiveId === 'b8-c9-d10') {
+        return Promise.reject(new Error('invalid archive'));
+      }
 
-await jest.unstable_mockModule('@vonage/auth', () => ({
-  ...actualAuth,
-  Auth: jest.fn().mockImplementation(() => ({ applicationId: 'vonageAppId' })),
-}));
-
-await jest.unstable_mockModule('@vonage/video', () => ({
-  ...actualVideo,
-  Video: jest.fn().mockImplementation(() => ({
-    createSession: jest
-      .fn<() => Promise<{ sessionId: string }>>()
-      .mockResolvedValue({ sessionId: validSessionId }),
-    generateClientToken: jest.fn().mockReturnValue('someToken'),
-    startArchive: jest
-      .fn<(sessionId: string) => Promise<{ id: string; status: string }>>()
-      .mockResolvedValue({ id: 'archiveId', status: 'started' }),
-    stopArchive: jest
-      .fn<(archiveId: string) => Promise<{ id: string; status: string }>>()
-      .mockImplementation((archiveId: string) => {
-        if (archiveId === 'b8-c9-d10') {
-          return Promise.reject(new Error('invalid archive'));
-        }
-
-        return Promise.resolve({ id: archiveId, status: 'stopped' });
-      }),
-    searchArchives: jest
-      .fn<(filters: { sessionId: string }) => Promise<{ items: Archive[]; count: number }>>()
-      .mockResolvedValue({
+      return Promise.resolve({ id: archiveId, status: 'stopped' });
+    },
+    searchArchives: () =>
+      Promise.resolve({
         items: [{ id: 'archive1' }, { id: 'archive2' }] as unknown as Archive[],
         count: 2,
       }),
-    enableCaptions: jest
-      .fn<() => Promise<{ captionsId: string }>>()
-      .mockResolvedValue({ captionsId: '123e4567-a12b-41a2-a123-123456789012' }),
-    disableCaptions: jest
-      .fn<(captionsId: string) => Promise<void>>()
-      .mockImplementation((captionsId: string) => {
-        if (captionsId === 'wrongCaptionId') {
-          return Promise.reject(new Error('Invalid caption ID'));
-        }
+    disableCaptions: (captionsId: string) => {
+      if (captionsId === 'wrongCaptionId') {
+        return Promise.reject(new Error('Invalid caption ID'));
+      }
 
-        return Promise.resolve(undefined);
-      }),
-  })),
-}));
-
-await jest.unstable_mockModule('../videoService/opentokVideoService.ts', () => {
-  return {
-    default: jest.fn().mockImplementation(() => {
-      return {
-        startArchive: jest.fn<() => Promise<string>>().mockResolvedValue('archiveId'),
-        stopArchive: jest.fn<() => Promise<string>>().mockRejectedValue('invalid archive'),
-        enableCaptions: jest.fn<() => Promise<string>>().mockResolvedValue('captionsId'),
-        disableCaptions: jest.fn<() => Promise<string>>().mockResolvedValue('invalid caption'),
-        generateToken: jest
-          .fn<() => Promise<{ token: string; apiKey: string }>>()
-          .mockResolvedValue({
-            token: 'someToken',
-            apiKey: 'someApiKey',
-          }),
-        createSession: jest.fn<() => Promise<string>>().mockResolvedValue(validSessionId),
-        searchArchives: jest
-          .fn<() => Promise<Archive[]>>()
-          .mockResolvedValue([{ id: 'archive1' }, { id: 'archive2' }] as unknown as Archive[]),
-      };
-    }),
-  };
+      return Promise.resolve(undefined);
+    },
+  },
 });
 
 const startServer = (await import('../server')).default;
@@ -162,7 +117,7 @@ describe.each([['InMemorySessionStorage', new InMemorySessionStorage()]])(
         });
 
         it('returns a 200 when disabling captions in a room', async () => {
-          const captionsId = '123e4567-a12b-41a2-a123-123456789012';
+          const captionsId = validCaptionsId;
           const res = await request(server)
             .post(`/session/${roomName}/${captionsId}/disableCaptions`)
             .set('Content-Type', 'application/json');
@@ -189,7 +144,7 @@ describe.each([['InMemorySessionStorage', new InMemorySessionStorage()]])(
 
         it('returns a 404 when stopping captions in a non-existent room', async () => {
           const invalidRoomName = 'nonExistingRoomName';
-          const captionsId = '123e4567-a12b-41a2-a123-123456789012';
+          const captionsId = validCaptionsId;
           const res = await request(server)
             .post(`/session/${invalidRoomName}/${captionsId}/disableCaptions`)
             .set('Content-Type', 'application/json');
@@ -310,7 +265,7 @@ describe.each([['InMemorySessionStorage', new InMemorySessionStorage()]])(
         it('ignores non-destroyed session events and cleans up on sessionDestroyed', async () => {
           await sessionService.setCaptionsId({
             sessionId: validSessionId,
-            captionsId: '123e4567-a12b-41a2-a123-123456789012',
+            captionsId: validCaptionsId,
           });
 
           await sessionService.setArchiveIds({
@@ -343,7 +298,7 @@ describe.each([['InMemorySessionStorage', new InMemorySessionStorage()]])(
           });
 
           expect(ignoredResponse.statusCode).toEqual(200);
-          expect(captionsIdAfterIgnored).toEqual('123e4567-a12b-41a2-a123-123456789012');
+          expect(captionsIdAfterIgnored).toEqual(validCaptionsId);
           expect(archiveIdsAfterIgnored).toEqual(['archive-id-1']);
           expect(destroyedResponse.statusCode).toEqual(200);
           expect(captionsIdAfterDestroyed).toBeNull();


### PR DESCRIPTION
#### What is this PR doing?
the 5 v1 `session.ts` routes were already covered by the app wide `authMiddleware` gate from [VIDSOL-1153](https://jira.vonage.com/browse/VIDSOL-1153) and [VIDSOL-860](https://jira.vonage.com/browse/VIDSOL-1153); adds integration tests confirming the wiring (401 without a token, 200 with Bearer or session cookie) for each route. Extracts the shared Vonage SDK mock setup into `tests/helpers/mockVonageVideoSdk.ts` to remove duplication between `session.test.ts` and the new suite.

#### How should this be manually tested?


#### What are the relevant tickets?
A maintainer will add this ticket number.

Resolves [VIDSOL-1196](https://jira.vonage.com/browse/VIDSOL-1196)

#### Checklist
[X] Branch is based on `develop` (not `main`).
[ ] Resolves a `Known Issue`.
[ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`? 
[ ] Resolves an item reported in `Issues`.
If yes, which issue? [Issue Number](https://github.com/Vonage/vonage-video-react-app/issues/)?
